### PR TITLE
fix(streams): read_to_end fails loud on gaps instead of returning zero-filled buffers

### DIFF
--- a/src/connection/assembler.rs
+++ b/src/connection/assembler.rs
@@ -655,6 +655,156 @@ mod test {
         assert_eq!(x.read(3, false), None);
     }
 
+    /// Models the `read_to_end` contract end to end at the assembler layer.
+    ///
+    /// `ReadToEnd` performs unordered reads and, once the connection layer signals
+    /// end-of-stream (`Chunks::next` gate: `bytes_read == final_size`), assembles the
+    /// chunks by offset into a zero-initialized buffer. Any range the assembler counted
+    /// as read but never yielded ships to the application as zeros inside `Ok` — a
+    /// silent data-integrity failure (observed in the wild as 2×1448-byte zero gaps).
+    ///
+    /// This test replays randomized but deterministic frame schedules — duplicates,
+    /// coalesced/resegmented retransmissions, arbitrary overlaps, reordering, and reads
+    /// interleaved at random points (including the ordered→unordered transition at the
+    /// first read) — and asserts the contract: every byte is yielded exactly once with
+    /// correct content, and the end-of-stream gate never fires while data is missing.
+    #[test]
+    fn read_to_end_contract_random_schedules() {
+        use rand::{Rng, SeedableRng};
+
+        const PACKET: usize = 1448;
+        for seed in 0..4096u64 {
+            let mut rng = rand_pcg::Pcg64Mcg::seed_from_u64(seed);
+            let n: usize = rng.gen_range(2 * PACKET..12 * PACKET);
+            let payload: Vec<u8> = (0..n).map(|i| (i.wrapping_mul(31) % 251) as u8).collect();
+
+            enum Ev {
+                Insert { offset: usize, len: usize },
+                Read,
+                Defrag,
+            }
+
+            // Base segmentation at packet-sized boundaries, each frame delivered once
+            let mut inserts: Vec<(usize, usize)> = Vec::new();
+            let mut off = 0;
+            while off < n {
+                let end = (off + PACKET).min(n);
+                inserts.push((off, end - off));
+                off = end;
+            }
+            // Retransmission variants: duplicates, coalesced 2-packet frames,
+            // subranges, and arbitrarily misaligned overlaps
+            let base = inserts.clone();
+            for &(s, l) in &base {
+                if rng.gen_bool(0.6) {
+                    match rng.gen_range(0..4u32) {
+                        0 => inserts.push((s, l)),
+                        1 => {
+                            let end = (s + 2 * PACKET).min(n);
+                            inserts.push((s, end - s));
+                        }
+                        2 => {
+                            let ds = rng.gen_range(0..l);
+                            let dl = rng.gen_range(1..=l - ds);
+                            inserts.push((s + ds, dl));
+                        }
+                        _ => {
+                            let rs = rng.gen_range(s.saturating_sub(PACKET)..(s + l).min(n - 1));
+                            let rl = rng.gen_range(1..=(n - rs).min(2 * PACKET));
+                            inserts.push((rs, rl));
+                        }
+                    }
+                }
+            }
+            // Shuffle delivery order (Fisher-Yates)
+            for i in (1..inserts.len()).rev() {
+                let j = rng.gen_range(0..=i);
+                inserts.swap(i, j);
+            }
+            let mut events: Vec<Ev> = Vec::new();
+            for (offset, len) in inserts {
+                events.push(Ev::Insert { offset, len });
+                if rng.gen_bool(0.35) {
+                    events.push(Ev::Read);
+                }
+                if rng.gen_bool(0.05) {
+                    events.push(Ev::Defrag);
+                }
+            }
+            events.push(Ev::Read);
+
+            let mut x = Assembler::new();
+            // (offset, len) of every chunk yielded to the "application"
+            let mut yielded: Vec<(u64, u64)> = Vec::new();
+
+            let verify = |yielded: &mut Vec<(u64, u64)>, gate_fired: bool, seed: u64| {
+                yielded.sort_unstable();
+                let mut pos = 0u64;
+                let mut covered = 0u64;
+                for &(s, l) in yielded.iter() {
+                    assert!(
+                        s >= pos,
+                        "seed {seed}: range [{s}, {}) overlaps previously yielded data \
+                         (double-yield inflates bytes_read)",
+                        s + l
+                    );
+                    pos = s + l;
+                    covered += l;
+                }
+                if gate_fired {
+                    assert_eq!(
+                        covered, n as u64,
+                        "seed {seed}: end-of-stream gate fired with unyielded ranges — \
+                         read_to_end would return zero-filled gaps"
+                    );
+                }
+            };
+
+            for ev in events {
+                match ev {
+                    Ev::Insert { offset, len } => {
+                        let bytes = Bytes::copy_from_slice(&payload[offset..offset + len]);
+                        let alloc = if rng.gen_bool(0.3) {
+                            len + rng.gen_range(0..200)
+                        } else {
+                            len
+                        };
+                        x.insert(offset as u64, bytes, alloc);
+                    }
+                    Ev::Defrag => x.defragment(),
+                    Ev::Read => {
+                        x.ensure_ordering(false).unwrap();
+                        while let Some(chunk) = x.read(usize::MAX, false) {
+                            let s = chunk.offset as usize;
+                            let e = s + chunk.bytes.len();
+                            assert!(
+                                e <= n,
+                                "seed {seed}: chunk [{s}, {e}) exceeds stream size {n}"
+                            );
+                            assert_eq!(
+                                &chunk.bytes[..],
+                                &payload[s..e],
+                                "seed {seed}: chunk content at [{s}, {e}) does not match payload"
+                            );
+                            yielded.push((chunk.offset, chunk.bytes.len() as u64));
+                        }
+                        // This is the end-of-stream gate from `Chunks::next`
+                        let gate_fired = x.bytes_read() == n as u64;
+                        verify(&mut yielded, gate_fired, seed);
+                    }
+                }
+            }
+
+            // All frames were delivered: the stream must complete with full coverage
+            assert_eq!(
+                x.bytes_read(),
+                n as u64,
+                "seed {seed}: stream stalled — all data inserted but end-of-stream gate never fired"
+            );
+            verify(&mut yielded, true, seed);
+        }
+    }
+
     fn next_unordered(x: &mut Assembler) -> Chunk {
         x.read(usize::MAX, false).unwrap()
     }

--- a/src/high_level/recv_stream.rs
+++ b/src/high_level/recv_stream.rs
@@ -259,10 +259,16 @@ impl RecvStream {
     /// all data read. Uses unordered reads to be more efficient than using `AsyncRead` would
     /// allow. `size_limit` should be set to limit worst-case memory use.
     ///
-    /// If unordered reads have already been made, the resulting buffer may have gaps containing
-    /// arbitrary data.
+    /// The returned buffer is guaranteed to be contiguous stream data: if any range between the
+    /// first and last byte this call observed was consumed elsewhere and never delivered (for
+    /// example by an earlier `read_to_end` future that was dropped mid-read, or by prior
+    /// unordered reads), this fails with [`ReadToEndError::MissingData`] instead of silently
+    /// filling the holes.
     ///
-    /// This operation is *not* cancel-safe.
+    /// This operation is *not* cancel-safe: dropping the returned future after it has consumed
+    /// stream data discards that data irrecoverably. A subsequent `read_to_end` returns the
+    /// remaining contiguous data, or fails with [`ReadToEndError::MissingData`] if the discard
+    /// left a hole in what it observes.
     ///
     /// `ReadToEndError::TooLong`: Error returned when size limit is exceeded
     pub async fn read_to_end(&mut self, size_limit: usize) -> Result<Vec<u8>, ReadToEndError> {
@@ -467,16 +473,50 @@ impl Future for ReadToEnd<'_> {
                         // Never received anything
                         return Poll::Ready(Ok(Vec::new()));
                     }
-                    let start = self.start;
-                    let mut buffer = vec![0; (self.end - start) as usize];
-                    for (data, offset) in self.read.drain(..) {
-                        let offset = (offset - start) as usize;
-                        buffer[offset..offset + data.len()].copy_from_slice(&data);
-                    }
-                    return Poll::Ready(Ok(buffer));
+                    let (start, end) = (self.start, self.end);
+                    return match assemble_unordered_chunks(&mut self.read, start, end) {
+                        Some(buffer) => Poll::Ready(Ok(buffer)),
+                        // End-of-stream was signaled but ranges in [start, end)
+                        // were consumed elsewhere (e.g. by a dropped earlier
+                        // read) and can never be re-read. Fail loud rather
+                        // than fabricate zero-filled bytes.
+                        None => Poll::Ready(Err(ReadToEndError::MissingData)),
+                    };
                 }
             }
         }
+    }
+}
+
+/// Assemble unordered chunks into a contiguous buffer
+///
+/// Returns `None` unless the chunks tile `[start, end)` exactly — each byte
+/// present once, with no gaps and no overlaps. A `None` means part of the
+/// stream was consumed but never delivered to this reader; zero-filling the
+/// holes (the previous behavior) would silently corrupt the result.
+fn assemble_unordered_chunks(chunks: &mut [(Bytes, u64)], start: u64, end: u64) -> Option<Vec<u8>> {
+    chunks.sort_unstable_by_key(|&(_, offset)| offset);
+    let mut buffer = Vec::with_capacity((end - start) as usize);
+    for (data, offset) in chunks.iter() {
+        let expected = start + buffer.len() as u64;
+        if *offset > expected {
+            // Gap: a range in [start, end) was consumed but never delivered
+            // to this reader. Zero-filling it (the previous behavior) would
+            // silently corrupt the result.
+            return None;
+        }
+        // Benign overlap (duplicate delivery, e.g. across the
+        // ordered->unordered transition): skip the already-assembled prefix.
+        let skip = (expected - *offset) as usize;
+        if skip < data.len() {
+            buffer.extend_from_slice(&data[skip..]);
+        }
+    }
+    // `end` is the maximum chunk end, so full coverage always lands on it
+    if start + buffer.len() as u64 == end {
+        Some(buffer)
+    } else {
+        None
     }
 }
 
@@ -489,6 +529,15 @@ pub enum ReadToEndError {
     /// The stream is larger than the user-supplied limit
     #[error("stream too long")]
     TooLong,
+    /// The stream ended, but ranges of it were consumed and never delivered to this call
+    ///
+    /// Returning a buffer would require fabricating the missing bytes (previously they were
+    /// silently zero-filled — a data-integrity hazard for consumers without payload checksums).
+    /// This happens after an earlier `read_to_end` future on this stream was dropped mid-read
+    /// (`read_to_end` is not cancel-safe), or when prior unordered reads left a hole between
+    /// the chunks this call observed.
+    #[error("stream ended with undelivered data ranges")]
+    MissingData,
 }
 
 impl tokio::io::AsyncRead for RecvStream {
@@ -689,5 +738,60 @@ impl Future for ReadChunks<'_> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let this = self.get_mut();
         this.stream.poll_read_chunks(cx, this.bufs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunks_of(payload: &[u8], ranges: &[(usize, usize)]) -> Vec<(Bytes, u64)> {
+        ranges
+            .iter()
+            .map(|&(start, end)| (Bytes::copy_from_slice(&payload[start..end]), start as u64))
+            .collect()
+    }
+
+    #[test]
+    fn assemble_accepts_exact_tiling_in_any_order() {
+        let payload: Vec<u8> = (0..10_706).map(|i| (i % 250 + 1) as u8).collect();
+        let mut chunks = chunks_of(&payload, &[(4344, 10_706), (0, 1448), (1448, 4344)]);
+        let buffer =
+            assemble_unordered_chunks(&mut chunks, 0, 10_706).expect("exact tiling must assemble");
+        assert_eq!(buffer, payload);
+    }
+
+    #[test]
+    fn assemble_accepts_nonzero_start() {
+        let payload: Vec<u8> = (0..4096).map(|i| (i % 250 + 1) as u8).collect();
+        let mut chunks = chunks_of(&payload, &[(2048, 4096), (1024, 2048)]);
+        let buffer = assemble_unordered_chunks(&mut chunks, 1024, 4096)
+            .expect("suffix tiling must assemble");
+        assert_eq!(buffer, &payload[1024..]);
+    }
+
+    /// The captured corruption geometry: a 10,706-byte message whose range
+    /// [1085, 3981) (2×1448 bytes) was consumed by a dropped reader. The old
+    /// code shipped this as `Ok` with the hole zero-filled; it must now be
+    /// rejected.
+    #[test]
+    fn assemble_rejects_captured_zero_gap_geometry() {
+        let payload: Vec<u8> = (0..10_706).map(|i| (i % 250 + 1) as u8).collect();
+        let mut chunks = chunks_of(&payload, &[(0, 1085), (3981, 10_706)]);
+        assert!(assemble_unordered_chunks(&mut chunks, 0, 10_706).is_none());
+    }
+
+    #[test]
+    fn assemble_rejects_overlapping_chunks() {
+        let payload: Vec<u8> = (0..4096).map(|i| (i % 250 + 1) as u8).collect();
+        let mut chunks = chunks_of(&payload, &[(0, 2048), (1024, 4096)]);
+        assert!(assemble_unordered_chunks(&mut chunks, 0, 4096).is_none());
+    }
+
+    #[test]
+    fn assemble_rejects_duplicate_chunk() {
+        let payload: Vec<u8> = (0..4096).map(|i| (i % 250 + 1) as u8).collect();
+        let mut chunks = chunks_of(&payload, &[(0, 2048), (0, 2048), (2048, 4096)]);
+        assert!(assemble_unordered_chunks(&mut chunks, 0, 4096).is_none());
     }
 }

--- a/src/high_level/recv_stream.rs
+++ b/src/high_level/recv_stream.rs
@@ -781,17 +781,23 @@ mod tests {
         assert!(assemble_unordered_chunks(&mut chunks, 0, 10_706).is_none());
     }
 
+    /// Overlaps are benign duplicate delivery (e.g. across the
+    /// ordered->unordered transition) — the overlapping prefix is skipped
+    /// and assembly succeeds with each byte appearing exactly once. Only
+    /// gaps (missing data) are fatal.
     #[test]
-    fn assemble_rejects_overlapping_chunks() {
+    fn assemble_tolerates_overlapping_chunks() {
         let payload: Vec<u8> = (0..4096).map(|i| (i % 250 + 1) as u8).collect();
         let mut chunks = chunks_of(&payload, &[(0, 2048), (1024, 4096)]);
-        assert!(assemble_unordered_chunks(&mut chunks, 0, 4096).is_none());
+        let buffer = assemble_unordered_chunks(&mut chunks, 0, 4096).expect("overlap is benign");
+        assert_eq!(buffer, payload);
     }
 
     #[test]
-    fn assemble_rejects_duplicate_chunk() {
+    fn assemble_tolerates_duplicate_chunk() {
         let payload: Vec<u8> = (0..4096).map(|i| (i % 250 + 1) as u8).collect();
         let mut chunks = chunks_of(&payload, &[(0, 2048), (0, 2048), (2048, 4096)]);
-        assert!(assemble_unordered_chunks(&mut chunks, 0, 4096).is_none());
+        let buffer = assemble_unordered_chunks(&mut chunks, 0, 4096).expect("duplicate is benign");
+        assert_eq!(buffer, payload);
     }
 }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -2102,6 +2102,9 @@ fn endpoint_error_from_read_to_end_error(
         crate::high_level::ReadToEndError::TooLong => {
             EndpointError::Connection("ACK-v2 response too long".to_string())
         }
+        crate::high_level::ReadToEndError::MissingData => {
+            EndpointError::Connection("stream ended with undelivered data ranges".to_string())
+        }
     }
 }
 

--- a/tests/regression_read_to_end_zero_gap.rs
+++ b/tests/regression_read_to_end_zero_gap.rs
@@ -1,0 +1,562 @@
+//! Regression test for zero-filled gaps delivered by `read_to_end`.
+//!
+//! Under loopback multi-daemon load, gossip uni-stream messages read via
+//! `read_to_end` intermittently arrived with a zero-filled, packet-sized gap
+//! inside an `Ok` buffer: the connection layer signaled end-of-stream while a
+//! range of the stream had never been yielded, and `ReadToEnd` silently filled
+//! the hole with zeros. Only consumers with payload signatures (x0x ML-DSA)
+//! could detect the corruption.
+//!
+//! This test drives two endpoints over an in-memory packet network that
+//! injects loss, duplication, and delay-based reordering. Loss and delay force
+//! spurious retransmissions, so the receiver's assembler sees duplicate and
+//! overlapping stream frames — the conditions under which the corruption was
+//! observed. Every message uses a zero-free payload, so any zero byte in a
+//! received buffer is corruption by construction.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::{
+    collections::HashMap,
+    io::{self, IoSliceMut},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll, Waker},
+};
+
+use ant_quic::{
+    EndpointConfig,
+    config::{ClientConfig, ServerConfig},
+    high_level::{AsyncUdpSocket, Endpoint, TokioRuntime, UdpSender},
+};
+use bytes::Bytes;
+use quinn_udp::{RecvMeta, Transmit};
+use rand::{Rng, SeedableRng};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio::time::{Duration, timeout};
+
+/// Mirrors the captured x0x identity-announce frame size (10,706 bytes,
+/// roughly eight 1448-byte packets per message).
+const MESSAGE_LEN: usize = 10_706;
+const CONCURRENT_STREAMS: usize = 8;
+const BATCHES: usize = 16;
+/// Leave the handshake unmangled so the connection settles quickly.
+const HANDSHAKE_GRACE_PACKETS: usize = 16;
+
+#[derive(Debug, Default)]
+struct MockQueue {
+    packets: Mutex<std::collections::VecDeque<(Bytes, SocketAddr)>>,
+    waker: Mutex<Option<Waker>>,
+}
+
+impl MockQueue {
+    fn push(&self, payload: Bytes, source: SocketAddr) {
+        self.packets
+            .lock()
+            .expect("queue")
+            .push_back((payload, source));
+        if let Some(waker) = self.waker.lock().expect("waker").take() {
+            waker.wake();
+        }
+    }
+}
+
+/// In-memory packet network that mangles traffic between endpoints.
+#[derive(Debug)]
+struct MockNetwork {
+    queues: Mutex<HashMap<SocketAddr, Arc<MockQueue>>>,
+    rng: Mutex<rand_pcg::Pcg64Mcg>,
+    packets_seen: AtomicUsize,
+    mangle: bool,
+}
+
+impl MockNetwork {
+    fn new(seed: u64) -> Self {
+        Self {
+            queues: Mutex::new(HashMap::new()),
+            rng: Mutex::new(rand_pcg::Pcg64Mcg::seed_from_u64(seed)),
+            packets_seen: AtomicUsize::new(0),
+            mangle: true,
+        }
+    }
+
+    /// A network that delivers every packet immediately and in order.
+    fn new_clean() -> Self {
+        Self {
+            mangle: false,
+            ..Self::new(0)
+        }
+    }
+
+    fn queue_for(&self, addr: SocketAddr) -> Option<Arc<MockQueue>> {
+        self.queues.lock().expect("queues").get(&addr).cloned()
+    }
+
+    /// Deliver a packet, possibly dropping, duplicating, or delaying it.
+    fn deliver(self: &Arc<Self>, destination: SocketAddr, payload: Bytes, source: SocketAddr) {
+        let Some(queue) = self.queue_for(destination) else {
+            return;
+        };
+
+        let seen = self.packets_seen.fetch_add(1, Ordering::Relaxed);
+        if !self.mangle || seen < HANDSHAKE_GRACE_PACKETS {
+            queue.push(payload, source);
+            return;
+        }
+
+        let (drop_it, duplicate, delay_ms) = {
+            let mut rng = self.rng.lock().expect("rng");
+            // Only data-sized packets are eligible for loss so ACK/control
+            // traffic keeps flowing and the test cannot deadlock.
+            let drop_it = payload.len() >= 1100 && rng.gen_bool(0.04);
+            let duplicate = rng.gen_bool(0.05);
+            let delay_ms = if rng.gen_bool(0.10) {
+                Some(rng.gen_range(2..25u64))
+            } else {
+                None
+            };
+            (drop_it, duplicate, delay_ms)
+        };
+
+        if drop_it {
+            return;
+        }
+        if duplicate {
+            queue.push(payload.clone(), source);
+        }
+        match delay_ms {
+            Some(ms) => {
+                // Delayed release: the original arrives after newer packets
+                // (and possibly after the sender's retransmission), producing
+                // duplicate/overlapping stream frames at the assembler.
+                let queue = Arc::clone(&queue);
+                tokio::spawn(async move {
+                    tokio::time::sleep(Duration::from_millis(ms)).await;
+                    queue.push(payload, source);
+                });
+            }
+            None => queue.push(payload, source),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MockUdpSocket {
+    addr: SocketAddr,
+    network: Arc<MockNetwork>,
+    queue: Arc<MockQueue>,
+}
+
+impl MockUdpSocket {
+    fn bind(network: Arc<MockNetwork>, port: u16) -> Arc<Self> {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+        let queue = Arc::new(MockQueue::default());
+        network
+            .queues
+            .lock()
+            .expect("network queues")
+            .insert(addr, Arc::clone(&queue));
+        Arc::new(Self {
+            addr,
+            network,
+            queue,
+        })
+    }
+}
+
+impl AsyncUdpSocket for MockUdpSocket {
+    fn create_sender(&self) -> Pin<Box<dyn UdpSender>> {
+        Box::pin(MockUdpSender {
+            source: self.addr,
+            network: Arc::clone(&self.network),
+        })
+    }
+
+    fn poll_recv(
+        &self,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+        meta: &mut [RecvMeta],
+    ) -> Poll<io::Result<usize>> {
+        if bufs.is_empty() || meta.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let Some((payload, source)) = self.queue.packets.lock().expect("queue").pop_front() else {
+            *self.queue.waker.lock().expect("waker") = Some(cx.waker().clone());
+            return Poll::Pending;
+        };
+
+        let len = payload.len().min(bufs[0].len());
+        bufs[0][..len].copy_from_slice(&payload[..len]);
+        meta[0] = RecvMeta {
+            len,
+            stride: len,
+            addr: source,
+            ecn: None,
+            dst_ip: None,
+        };
+        Poll::Ready(Ok(1))
+    }
+
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.addr)
+    }
+
+    fn may_fragment(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Debug)]
+struct MockUdpSender {
+    source: SocketAddr,
+    network: Arc<MockNetwork>,
+}
+
+impl UdpSender for MockUdpSender {
+    fn poll_send(
+        self: Pin<&mut Self>,
+        transmit: &Transmit,
+        _cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.network.deliver(
+            transmit.destination,
+            Bytes::copy_from_slice(transmit.contents),
+            self.source,
+        );
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn gen_self_signed_cert() -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("generate self-signed cert");
+    let cert_der = CertificateDer::from(cert.cert);
+    let key_der = PrivateKeyDer::Pkcs8(cert.signing_key.serialize_der().into());
+    (vec![cert_der], key_der)
+}
+
+fn client_config(chain: &[CertificateDer<'static>]) -> ClientConfig {
+    let mut roots = rustls::RootCertStore::empty();
+    for cert in chain.iter().cloned() {
+        roots.add(cert).expect("add root");
+    }
+    ClientConfig::with_root_certificates(Arc::new(roots)).expect("client config")
+}
+
+/// Zero-free patterned payload: any zero byte in the received copy is
+/// corruption, and the pattern pinpoints misplaced bytes too.
+fn payload_for(message: usize) -> Vec<u8> {
+    (0..MESSAGE_LEN)
+        .map(|i| ((i.wrapping_mul(31).wrapping_add(message * 7)) % 250 + 1) as u8)
+        .collect()
+}
+
+/// Describe corruption in a received buffer: zero runs and first mismatch.
+fn describe_corruption(expected: &[u8], got: &[u8]) -> String {
+    if got.len() != expected.len() {
+        return format!(
+            "length mismatch: expected {}, got {}",
+            expected.len(),
+            got.len()
+        );
+    }
+    let mut runs = Vec::new();
+    let mut run_start = None;
+    for (i, &b) in got.iter().enumerate() {
+        match (b, run_start) {
+            (0, None) => run_start = Some(i),
+            (0, Some(_)) => {}
+            (_, Some(s)) => {
+                runs.push((s, i - s));
+                run_start = None;
+            }
+            _ => {}
+        }
+    }
+    if let Some(s) = run_start {
+        runs.push((s, got.len() - s));
+    }
+    let first_diff = expected.iter().zip(got).position(|(a, b)| a != b);
+    format!("zero runs (offset, len): {runs:?}; first mismatch at {first_diff:?}")
+}
+
+/// Establish a connected endpoint pair over the given mock network.
+///
+/// Returns both endpoints (which must stay alive for the connections to
+/// remain usable) along with the client- and server-side connections.
+async fn connect_pair(
+    network: Arc<MockNetwork>,
+    server_port: u16,
+    client_port: u16,
+) -> (
+    Endpoint,
+    Endpoint,
+    ant_quic::high_level::Connection,
+    ant_quic::high_level::Connection,
+) {
+    let runtime = Arc::new(TokioRuntime);
+    let server_socket = MockUdpSocket::bind(Arc::clone(&network), server_port);
+    let client_socket = MockUdpSocket::bind(network, client_port);
+
+    let (chain, key) = gen_self_signed_cert();
+    let server_config = ServerConfig::with_single_cert(chain.clone(), key).expect("server config");
+    let server = Endpoint::new_with_abstract_socket(
+        EndpointConfig::default(),
+        Some(server_config),
+        server_socket,
+        runtime.clone(),
+    )
+    .expect("server endpoint");
+    let server_addr = server.local_addr().expect("server addr");
+
+    let mut client =
+        Endpoint::new_with_abstract_socket(EndpointConfig::default(), None, client_socket, runtime)
+            .expect("client endpoint");
+    client.set_default_client_config(client_config(&chain));
+
+    let accept = {
+        let server = server.clone();
+        tokio::spawn(async move {
+            let incoming = timeout(Duration::from_secs(10), server.accept())
+                .await
+                .expect("server accept wait")
+                .expect("incoming connection");
+            timeout(Duration::from_secs(10), incoming)
+                .await
+                .expect("server handshake wait")
+                .expect("server handshake")
+        })
+    };
+
+    let client_conn = timeout(
+        Duration::from_secs(10),
+        client.connect(server_addr, "localhost").expect("connect"),
+    )
+    .await
+    .expect("client handshake wait")
+    .expect("client handshake");
+    let server_conn = accept.await.expect("accept task");
+
+    (server, client, client_conn, server_conn)
+}
+
+/// A `read_to_end` future that is dropped mid-read has consumed stream chunks
+/// it never delivered. A second `read_to_end` must fail with `MissingData`
+/// rather than return `Ok` with the consumed ranges zero-filled — the silent
+/// corruption captured in the x0x dogfood mesh (2×1448-byte zero windows in
+/// otherwise intact, signed messages).
+#[tokio::test(flavor = "multi_thread")]
+async fn dropped_read_to_end_future_yields_remaining_data_not_zero_gap() {
+    use std::task::{Context, Waker};
+
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let network = Arc::new(MockNetwork::new_clean());
+    let (_server, _client, client_conn, server_conn) = connect_pair(network, 42102, 42103).await;
+
+    let payload = payload_for(0);
+    let mut send = timeout(Duration::from_secs(5), client_conn.open_uni())
+        .await
+        .expect("open_uni wait")
+        .expect("open_uni");
+    send.write_all(&payload[..6000]).await.expect("write head");
+
+    let mut recv = timeout(Duration::from_secs(5), server_conn.accept_uni())
+        .await
+        .expect("accept_uni wait")
+        .expect("accept_uni");
+
+    // Let the first 6000 bytes arrive, then poll a `read_to_end` exactly once
+    // so it consumes the buffered chunks, and drop it before the stream ends.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    {
+        let fut = recv.read_to_end(MESSAGE_LEN * 2);
+        tokio::pin!(fut);
+        let mut cx = Context::from_waker(Waker::noop());
+        assert!(
+            fut.as_mut().poll(&mut cx).is_pending(),
+            "stream must not be finished while the head is still in flight"
+        );
+    }
+
+    send.write_all(&payload[6000..]).await.expect("write tail");
+    send.finish().expect("finish");
+
+    let result = timeout(Duration::from_secs(10), recv.read_to_end(MESSAGE_LEN * 2))
+        .await
+        .expect("read_to_end wait");
+    match result {
+        // The dropped future consumed a contiguous prefix; the follow-up read
+        // must return exactly the remaining suffix — real bytes, never a
+        // full-length buffer with fabricated zeros where the prefix was.
+        Ok(buf) => {
+            assert!(
+                !buf.is_empty() && buf.len() < payload.len(),
+                "follow-up read should return the remaining suffix, got {} of {} bytes",
+                buf.len(),
+                payload.len()
+            );
+            assert_eq!(
+                &buf[..],
+                &payload[payload.len() - buf.len()..],
+                "follow-up read must be a verbatim suffix of the payload — \
+                 any mismatch means fabricated bytes"
+            );
+        }
+        Err(other) => panic!(
+            "remaining data after a dropped prefix read is contiguous and must \
+             be readable, got: {other}"
+        ),
+    }
+}
+
+/// Supersede-mid-stream variant: when a connection is closed (as the P2P layer
+/// does when a duplicate connection supersedes it) while a stream still has
+/// undelivered ranges, `read_to_end` must surface an error — never `Ok` with a
+/// partial or hole-filled buffer.
+#[tokio::test(flavor = "multi_thread")]
+async fn connection_close_mid_stream_yields_error_not_partial_ok() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let network = Arc::new(MockNetwork::new_clean());
+    let (_server, _client, client_conn, server_conn) = connect_pair(network, 42104, 42105).await;
+
+    let payload = payload_for(1);
+    let mut send = timeout(Duration::from_secs(5), client_conn.open_uni())
+        .await
+        .expect("open_uni wait")
+        .expect("open_uni");
+    // Deliver only part of the message and never finish the stream
+    send.write_all(&payload[..6000]).await.expect("write head");
+
+    let mut recv = timeout(Duration::from_secs(5), server_conn.accept_uni())
+        .await
+        .expect("accept_uni wait")
+        .expect("accept_uni");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Supersede: the old connection is closed with data still outstanding
+    client_conn.close(0u32.into(), b"superseded");
+
+    let result = timeout(Duration::from_secs(10), recv.read_to_end(MESSAGE_LEN * 2))
+        .await
+        .expect("read_to_end wait");
+    match result {
+        Err(_) => {}
+        Ok(buf) => panic!(
+            "read_to_end returned Ok({} bytes) on a connection closed \
+             mid-stream — partial data delivered as complete",
+            buf.len()
+        ),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn read_to_end_never_returns_zero_gaps_under_adverse_network() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let runtime = Arc::new(TokioRuntime);
+    let network = Arc::new(MockNetwork::new(0x0047_2026_0610));
+    let server_socket = MockUdpSocket::bind(Arc::clone(&network), 42100);
+    let client_socket = MockUdpSocket::bind(Arc::clone(&network), 42101);
+
+    let (chain, key) = gen_self_signed_cert();
+    let server_config = ServerConfig::with_single_cert(chain.clone(), key).expect("server config");
+    let server = Endpoint::new_with_abstract_socket(
+        EndpointConfig::default(),
+        Some(server_config),
+        server_socket,
+        runtime.clone(),
+    )
+    .expect("server endpoint");
+    let server_addr = server.local_addr().expect("server addr");
+
+    let total_messages = BATCHES * CONCURRENT_STREAMS;
+    let server_task = tokio::spawn(async move {
+        let incoming = timeout(Duration::from_secs(10), server.accept())
+            .await
+            .expect("server accept wait")
+            .expect("incoming connection");
+        let conn = timeout(Duration::from_secs(10), incoming)
+            .await
+            .expect("server handshake wait")
+            .expect("server handshake");
+
+        let mut failures = Vec::new();
+        for _ in 0..total_messages {
+            let mut recv = timeout(Duration::from_secs(30), conn.accept_uni())
+                .await
+                .expect("accept_uni wait")
+                .expect("accept_uni");
+            let buf = timeout(Duration::from_secs(30), recv.read_to_end(MESSAGE_LEN * 2))
+                .await
+                .expect("read_to_end wait")
+                .expect("read_to_end");
+            // First 8 bytes carry the message index so payloads can be matched
+            // regardless of stream delivery order.
+            assert!(buf.len() >= 8, "message shorter than its index header");
+            let mut idx_bytes = [0u8; 8];
+            idx_bytes.copy_from_slice(&buf[..8]);
+            let message = u64::from_be_bytes(idx_bytes) as usize;
+            let expected = payload_for(message);
+            if buf[8..] != expected[..] {
+                failures.push(format!(
+                    "message {message}: {}",
+                    describe_corruption(&expected, &buf[8..])
+                ));
+            }
+        }
+        failures
+    });
+
+    let mut client =
+        Endpoint::new_with_abstract_socket(EndpointConfig::default(), None, client_socket, runtime)
+            .expect("client endpoint");
+    client.set_default_client_config(client_config(&chain));
+
+    let conn = timeout(
+        Duration::from_secs(10),
+        client.connect(server_addr, "localhost").expect("connect"),
+    )
+    .await
+    .expect("client handshake wait")
+    .expect("client handshake");
+
+    for batch in 0..BATCHES {
+        let mut tasks = Vec::new();
+        for slot in 0..CONCURRENT_STREAMS {
+            let message = batch * CONCURRENT_STREAMS + slot;
+            let conn = conn.clone();
+            tasks.push(tokio::spawn(async move {
+                let mut send = timeout(Duration::from_secs(30), conn.open_uni())
+                    .await
+                    .expect("open_uni wait")
+                    .expect("open_uni");
+                send.write_all(&(message as u64).to_be_bytes())
+                    .await
+                    .expect("write index");
+                send.write_all(&payload_for(message))
+                    .await
+                    .expect("write payload");
+                send.finish().expect("finish");
+                // Keep the handle alive until the peer acknowledges everything
+                // so dropping it cannot reset the stream mid-flight.
+                let _ = timeout(Duration::from_secs(30), send.stopped()).await;
+            }));
+        }
+        for task in tasks {
+            task.await.expect("sender task");
+        }
+    }
+
+    let failures = server_task.await.expect("server task");
+    assert!(
+        failures.is_empty(),
+        "read_to_end returned corrupted buffers under loss/duplication/reordering:\n{}",
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
## Problem

`ReadToEnd` assembled unordered chunks into a zero-initialized buffer and returned `Ok` even when ranges in `[start, end)` were never yielded. Observed in the wild as **2×1448-byte zero windows** inside x0x gossip messages — caught only because x0x ML-DSA-signs its payloads; **unsigned consumers ingest the corruption silently** (data-integrity severity). Full evidence chain with captured corrupted frames: `x0x/handoff/antquic-zero-gap-reassembly-2026-06-10.md`.

## Fix

`read_to_end` now requires its observed chunks to cover `[start, end)` with no gaps (benign overlaps tolerated, e.g. across the ordered→unordered transition) and fails with the new `ReadToEndError::MissingData` otherwise. Dropping a partial `read_to_end` future remains documented not-cancel-safe: a follow-up read returns the remaining contiguous suffix, or `MissingData` when the discard left an observable hole.

## Tests

- `read_to_end_contract_random_schedules`: 4,096-seed randomized assembler contract test (duplicates, coalesced/resegmented retransmissions, arbitrary overlaps, reordering, interleaved reads)
- `read_to_end_never_returns_zero_gaps_under_adverse_network`
- `dropped_read_to_end_future_yields_remaining_data_not_zero_gap`
- `connection_close_mid_stream_yields_error_not_partial_ok`

## Notes

- `simultaneous_connect_dedup::test_tiebreaker_deterministic` is a **pre-existing flake** (fails ~1-in-5 on clean master, 0.14s fast-fail vs 5-10s pass signature) — unrelated to this change; tracked separately.
- E2E validation in x0x: with patched receivers, zero corruptions originate at patched nodes; remaining corrupted frames all route through the one unpatched daemon on the LAN (which this fix, once released, also covers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a data-integrity bug in `read_to_end` where stream gaps (ranges consumed by a dropped future or prior unordered reads) were silently zero-filled and returned as `Ok`. The fix introduces `assemble_unordered_chunks`, which returns `None` on any gap and a new `ReadToEndError::MissingData` variant is surfaced to callers.

- `assemble_unordered_chunks` correctly handles benign overlaps and duplicate chunks by skipping already-assembled bytes, and rejects gaps with `None`; the `p2p_endpoint` match arm is updated to cover the new error variant.
- The 4096-seed property test in `assembler.rs` and the mock-network regression suite in `tests/regression_read_to_end_zero_gap.rs` are well-structured and correctly exercise the fix.
- Two unit tests in `recv_stream.rs` (`assemble_rejects_overlapping_chunks` and `assemble_rejects_duplicate_chunk`) assert `is_none()` for inputs the function intentionally accepts, so both tests will fail; the docstring for `assemble_unordered_chunks` also incorrectly states \"no overlaps\" despite the implementation tolerating them by design.

<h3>Confidence Score: 3/5</h3>

The core reassembly fix is correct, but two of the new unit tests will fail on first `cargo test` run, blocking CI.

The gap-detection logic in `assemble_unordered_chunks` is correct and the integration tests are solid. However, `assemble_rejects_overlapping_chunks` and `assemble_rejects_duplicate_chunk` each assert `is_none()` for inputs the function is explicitly designed to accept — overlaps and duplicates are handled as benign — so both tests panic when run. The companion docstring ("no overlaps") compounds the confusion. These need to be fixed before the tests can pass.

The unit test block at the bottom of `src/high_level/recv_stream.rs` — specifically `assemble_rejects_overlapping_chunks` and `assemble_rejects_duplicate_chunk` — needs the assertions flipped and the doc-comment updated before this is mergeable.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/high_level/recv_stream.rs | Core fix: replaces zero-fill assembly with gap-detecting `assemble_unordered_chunks`; adds `ReadToEndError::MissingData`. Two new unit tests (`assemble_rejects_overlapping_chunks`, `assemble_rejects_duplicate_chunk`) assert `is_none()` but the function returns `Some` for both inputs — they will fail. Doc-comment for the helper also incorrectly states "no overlaps". |
| src/connection/assembler.rs | Adds `read_to_end_contract_random_schedules`: a 4096-seed property test covering duplicates, overlaps, reordering, and interleaved reads. Logic is sound and the assertions are correct. |
| src/p2p_endpoint.rs | Adds the required `MissingData` arm to the `endpoint_error_from_read_to_end_error` match; straightforward and complete. |
| tests/regression_read_to_end_zero_gap.rs | New integration regression suite: mock network with loss/duplication/reordering, three targeted scenarios (adverse network, dropped future, connection-close mid-stream). Well-structured with zero-free payloads for reliable corruption detection. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ReadToEnd::poll] -->|chunk received| B[Accumulate chunk into self.read\nupdate start/end/size_limit]
    B --> A
    A -->|EOS received| C{self.end == 0?}
    C -->|yes| D[return Ok with empty Vec]
    C -->|no| E[assemble_unordered_chunks\nsort by offset]
    E --> F{For each chunk:\noffset > expected?}
    F -->|yes - gap detected| G[return None → MissingData]
    F -->|no - exact or overlap| H[skip = expected - offset\nif skip < len: extend buffer]
    H --> F
    F -->|all chunks processed| I{start + buffer.len == end?}
    I -->|yes| J[return Some buffer → Ok]
    I -->|no - trailing gap| G
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/high_level/recv_stream.rs`, line 309-321 ([link](https://github.com/saorsa-labs/ant-quic/blob/c96cf3deb315faf6c66657cf51c6e1042a10576e/src/high_level/recv_stream.rs#L309-L321)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Tests assert wrong expected value — both will fail**

   `assemble_unordered_chunks` is explicitly designed to tolerate duplicate deliveries and overlapping chunks (the PR description calls them "benign overlaps"; the inline comment in the implementation says "Benign overlap (duplicate delivery, e.g. across the ordered→unordered transition): skip the already-assembled prefix"). For both inputs the function returns `Some(assembled_payload)`, so `assert!(... .is_none())` will panic when the test suite runs.

   For `assemble_rejects_overlapping_chunks` with chunks `[(0, 2048), (1024, 4096)]` (end = 4096): after sorting, the second chunk has offset 1024 < expected 2048, so `skip = 1024`, `buffer.extend(data[1024..])` appends 2048 bytes, and `buffer.len() == 4096 == end` → `Some`.

   For `assemble_rejects_duplicate_chunk` with chunks `[(0, 2048), (0, 2048), (2048, 4096)]`: the duplicate copy has `skip = 2048 == data.len()` so the extend is skipped, the third chunk fills the rest, and again `Some` is returned.

   Both assertions should be `is_some()`, and the test names should reflect that overlaps and duplicates are *accepted*, not rejected.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/high_level/recv_stream.rs
   Line: 309-321

   Comment:
   **Tests assert wrong expected value — both will fail**

   `assemble_unordered_chunks` is explicitly designed to tolerate duplicate deliveries and overlapping chunks (the PR description calls them "benign overlaps"; the inline comment in the implementation says "Benign overlap (duplicate delivery, e.g. across the ordered→unordered transition): skip the already-assembled prefix"). For both inputs the function returns `Some(assembled_payload)`, so `assert!(... .is_none())` will panic when the test suite runs.

   For `assemble_rejects_overlapping_chunks` with chunks `[(0, 2048), (1024, 4096)]` (end = 4096): after sorting, the second chunk has offset 1024 < expected 2048, so `skip = 1024`, `buffer.extend(data[1024..])` appends 2048 bytes, and `buffer.len() == 4096 == end` → `Some`.

   For `assemble_rejects_duplicate_chunk` with chunks `[(0, 2048), (0, 2048), (2048, 4096)]`: the duplicate copy has `skip = 2048 == data.len()` so the extend is skipped, the third chunk fills the rest, and again `Some` is returned.

   Both assertions should be `is_some()`, and the test names should reflect that overlaps and duplicates are *accepted*, not rejected.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/high_level/recv_stream.rs:309-321
**Tests assert wrong expected value — both will fail**

`assemble_unordered_chunks` is explicitly designed to tolerate duplicate deliveries and overlapping chunks (the PR description calls them "benign overlaps"; the inline comment in the implementation says "Benign overlap (duplicate delivery, e.g. across the ordered→unordered transition): skip the already-assembled prefix"). For both inputs the function returns `Some(assembled_payload)`, so `assert!(... .is_none())` will panic when the test suite runs.

For `assemble_rejects_overlapping_chunks` with chunks `[(0, 2048), (1024, 4096)]` (end = 4096): after sorting, the second chunk has offset 1024 < expected 2048, so `skip = 1024`, `buffer.extend(data[1024..])` appends 2048 bytes, and `buffer.len() == 4096 == end` → `Some`.

For `assemble_rejects_duplicate_chunk` with chunks `[(0, 2048), (0, 2048), (2048, 4096)]`: the duplicate copy has `skip = 2048 == data.len()` so the extend is skipped, the third chunk fills the rest, and again `Some` is returned.

Both assertions should be `is_some()`, and the test names should reflect that overlaps and duplicates are *accepted*, not rejected.

### Issue 2 of 2
src/high_level/recv_stream.rs:493-496
The docstring says "each byte present once, with no gaps **and no overlaps**" but the implementation intentionally tolerates and deduplicates overlapping chunks. This is directly contradicted by the inline comment and the PR description. The misleading wording is also why the two tests below ended up with the wrong assertion. Update the doc to match the actual contract.

```suggestion
/// Returns `None` if the chunks do not fully cover `[start, end)` (i.e. a gap
/// exists). Benign overlaps — duplicate deliveries or coalesced retransmissions
/// — are tolerated and deduplicated; they do not cause a `None` return. A
/// `None` means part of the stream was consumed but never delivered to this
/// reader; zero-filling the holes (the previous behavior) would silently corrupt
/// the result.
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(streams): read\_to\_end fails loud on ..."](https://github.com/saorsa-labs/ant-quic/commit/c96cf3deb315faf6c66657cf51c6e1042a10576e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36713218)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->