### PR TITLE
fix(nat): release failed sessions' connection state promptly (#210)

### DIFF
--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -3513,6 +3513,13 @@ impl NatTraversalEndpoint {
                             if let Some(mut session) = sessions.get_mut(&peer_id) {
                                 session.session_state.state = ConnectionState::Closed;
                                 session.session_state.last_transition = std::time::Instant::now();
+                                // Release the connection handle now, not at
+                                // session removal one cache-TTL later — a
+                                // timed-out establishment attempt otherwise
+                                // pins megabytes of per-connection state for
+                                // the whole Closed grace window (#210).
+                                session.session_state.connection = None;
+                                session.session_state.active_attempts.clear();
                                 tracing::warn!("Connection to {:?} timed out", peer_id);
                             }
                         }
@@ -9205,6 +9212,19 @@ impl NatTraversalEndpoint {
                 session.retry_at = None;
                 session.next_deadline = None;
                 session.phase = TraversalPhase::Failed;
+                // Terminal failure must also release everything the session
+                // pins and hand it to the session reaper. A Failed session
+                // that stays `Connecting`/`Idle` is never matched by the
+                // reaper's `Closed` arm, so it sits in `active_sessions`
+                // forever holding its `Connection` handle — megabytes of
+                // per-connection state (streams tables sized by the
+                // configured concurrent-stream limits) retained per failed
+                // dial to an unreachable peer (#210).
+                session.session_state.state = ConnectionState::Closed;
+                session.session_state.last_transition = now;
+                session.session_state.connection = None;
+                session.session_state.active_attempts.clear();
+                session.candidates.clear();
                 self.emit_event(
                     events,
                     NatTraversalEvent::TraversalTerminated {
@@ -11971,7 +11991,12 @@ mod tests {
             started_at: now,
             phase_started_at: now,
             phase: TraversalPhase::Synchronization,
-            candidates: Vec::new(),
+            candidates: vec![CandidateAddress {
+                address: "192.0.2.7:4433".parse().unwrap(),
+                priority: 100,
+                source: CandidateSource::Local,
+                state: CandidateState::New,
+            }],
             last_progress_at: now,
             next_deadline: Some(SessionDeadline {
                 kind: TraversalDeadlineKind::RetryBackoff,
@@ -11983,7 +12008,7 @@ mod tests {
                 state: ConnectionState::Connecting,
                 last_transition: now,
                 connection: None,
-                active_attempts: Vec::new(),
+                active_attempts: vec![("192.0.2.7:4433".parse().unwrap(), now)],
                 metrics: ConnectionMetrics::default(),
             },
         };
@@ -12009,6 +12034,26 @@ mod tests {
             "terminal failures clear next_deadline"
         );
         assert!(matches!(session.phase, TraversalPhase::Failed));
+        // #210: a terminal failure must hand the session to the reaper and
+        // release everything it pins. If the state is not `Closed` the reaper
+        // never removes the entry, and a retained `connection` handle keeps
+        // megabytes of per-connection state alive per failed dial.
+        assert!(
+            matches!(session.session_state.state, ConnectionState::Closed),
+            "terminal failure must mark the session Closed for the reaper"
+        );
+        assert!(
+            session.session_state.connection.is_none(),
+            "terminal failure must release the held connection handle"
+        );
+        assert!(
+            session.session_state.active_attempts.is_empty(),
+            "terminal failure must clear in-flight attempt records"
+        );
+        assert!(
+            session.candidates.is_empty(),
+            "terminal failure must clear discovered candidates"
+        );
         assert!(matches!(
             events.as_slice(),
             [


### PR DESCRIPTION
Partial fix for #210 (the session-lifecycle holder; the eager `StreamsState` prealloc is a separate work item, see below).

## What

- A terminal traversal failure (`RetryDisposition::Never`) set `phase = Failed` but left `session_state.state` at `Connecting`/`Idle`. The session reaper only removes `Closed` sessions, so a Failed session sat in `active_sessions` **forever**, holding its `Connection` handle — megabytes of per-connection state (streams tables sized by the configured concurrent-stream limits) retained per failed dial to an unreachable peer. Now: mark `Closed`, drop the connection handle, clear `candidates`/`active_attempts`, and let the existing reaper remove it.
- The establishment-`Timeout` handler set `Closed` but kept the `connection` handle until removal one cache-TTL later; it now drops the handle (and clears attempt records) immediately, like `Disconnected` does.

## Validation

- Extended `test_handle_phase_failure_emits_terminal_event_and_clears_retry_state` to pin the release invariant (Closed + no handle + cleared vectors), with a populated candidate/attempt fixture so the clears actually bite.
- fmt, clippy `-D warnings`, full `cargo nextest run --all-features` green.
- x0x-side dead-peer profile (MallocStackLogging before/after a peer kill): tracked live-heap delta dropped 7.6 → 4.3 MB and `leaks` unreferenced delta 6.3 → 3.2 MB with this patch; the remaining growth is the time-bounded in-flight/draining attempts, each carrying the eager streams-table prealloc.

## Remaining for #210

1. `StreamsState::new` materializes a slot for every advertised remote stream at construction (`for i in 0..max_remote { insert }`); with a large configured uni-stream limit this is the dominant per-connection cost (50k slots ≈ 1.58 MB measured). Newer quinn-lineage code moved to lazy stream-state allocation — porting that is the structural fix. Callers can meanwhile keep advertised limits sane (x0x is dropping 50_000 → 4_096).
2. A smaller truly-unreferenced residual (~1 connection-sized blob per failure burst) still shows in `leaks` and deserves a hunt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR releases NAT traversal session resources sooner after failed connection setup. The main changes are:

- Closed state is set on terminal traversal failure.
- Held connection handles and active attempts are cleared on timeout and terminal failure.
- Terminal failure tests now cover populated candidates and active attempts.

<h3>Confidence Score: 4/5</h3>

The changed flow looks mergeable after a small cleanup to timeout resource release.

- Terminal traversal failures now transition to closed state and release the heavy connection handle.
- Establishment timeout cleanup still keeps candidate entries until the closed-session reaper removes the session.
- The remaining issue is bounded by the cache grace window and affects retained memory, not connection correctness.

src/nat_traversal_api.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nat_traversal_api.rs | Updates timeout and terminal-failure cleanup for NAT traversal sessions, with one remaining timeout cleanup asymmetry around retained candidates. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/nat_traversal_api.rs:3521-3522
**Timeout Candidates Stay Retained**

When establishment timeout closes a session, this branch drops the connection handle and active attempts but leaves `session.candidates` allocated until the closed-session reaper runs after `interface_cache_ttl`. The terminal failure cleanup below clears candidates immediately for the same release invariant, so peers that timed out after collecting many candidates still retain avoidable per-session state during the grace window.

```suggestion
                                session.session_state.connection = None;
                                session.session_state.active_attempts.clear();
                                session.candidates.clear();
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(nat): release failed sessions&#39; conne..."](https://github.com/saorsa-labs/ant-quic/commit/fe975b69c7ae32b9eeb5e6f3dfac545d0e3a64e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43886666)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=aa5b0a72-43fc-4512-856d-2b1369850c99))
- Context used - .cursorrules ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=08a064d6-4d62-436c-b6c5-725c2d6871b8))
- Context used - AGENTS.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=0fcbf7d8-485f-4997-9d42-680f49b36e91))
</details>

<!-- /greptile_comment -->
