### PR TITLE
chore(lint): fix six new stable-clippy lints blocking CI

### DIFF
--- a/src/candidate_discovery.rs
+++ b/src/candidate_discovery.rs
@@ -876,13 +876,10 @@ impl CandidateDiscoveryManager {
                     continue;
                 }
 
-                let bound_candidate = self.config.bound_address.and_then(|addr| {
-                    if self.is_valid_local_address(&addr) || addr.ip().is_loopback() {
-                        Some(addr)
-                    } else {
-                        None
-                    }
-                });
+                let bound_candidate = self
+                    .config
+                    .bound_address
+                    .filter(|addr| self.is_valid_local_address(addr) || addr.ip().is_loopback());
 
                 if let Some(bound_addr) = bound_candidate {
                     if let Some(session) = self.active_sessions.get_mut(&peer_id) {
@@ -1075,12 +1072,8 @@ impl CandidateDiscoveryManager {
                         peer_id
                     );
 
-                    let bound_candidate = self.config.bound_address.and_then(|addr| {
-                        if self.is_valid_local_address(&addr) || addr.ip().is_loopback() {
-                            Some(addr)
-                        } else {
-                            None
-                        }
+                    let bound_candidate = self.config.bound_address.filter(|addr| {
+                        self.is_valid_local_address(addr) || addr.ip().is_loopback()
                     });
 
                     if let Some(session) = self.active_sessions.get_mut(&peer_id) {

--- a/src/connection/packet_crypto.rs
+++ b/src/connection/packet_crypto.rs
@@ -95,16 +95,11 @@ pub(super) fn decrypt_packet_body(
         &zero_rtt_crypto.unwrap().packet
     } else if packet_key_phase == conn_key_phase || space != SpaceId::Data {
         &spaces[space].crypto.as_ref().unwrap().packet.remote
-    } else if let Some(prev) = prev_crypto.and_then(|crypto| {
-        // If this packet comes prior to acknowledgment of the key update by the peer,
-        if crypto.end_packet.is_none_or(|(pn, _)| number < pn) {
-            // use the previous keys.
-            Some(crypto)
-        } else {
-            // Otherwise, this must be a remotely-initiated key update, so fall through to the
-            // final case.
-            None
-        }
+    } else if let Some(prev) = prev_crypto.filter(|crypto| {
+        // If this packet comes prior to acknowledgment of the key update by the
+        // peer, use the previous keys. Otherwise, this must be a
+        // remotely-initiated key update, so fall through to the final case.
+        crypto.end_packet.is_none_or(|(pn, _)| number < pn)
     }) {
         &prev.crypto.remote
     } else {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -3361,7 +3361,7 @@ impl P2pEndpoint {
         // multiple times to the same target (e.g. during reconnect loops).
         {
             let peers = self.connected_peers.read().await;
-            for (_, existing) in peers.iter() {
+            for existing in peers.values() {
                 if existing.remote_addr == TransportAddr::Udp(addr) {
                     // Verify the underlying QUIC connection is still alive
                     if let Some(peer_id) = peers

--- a/src/stats_dashboard.rs
+++ b/src/stats_dashboard.rs
@@ -187,7 +187,8 @@ impl StatsDashboard {
             NatTraversalEvent::ConnectionEstablished {
                 peer_id,
                 remote_address,
-                side: _, // Direction not tracked in dashboard stats yet
+                // `..` also covers `side` — direction not tracked in
+                // dashboard stats yet.
                 ..
             } => {
                 let mut connections = self.connections.write().await;

--- a/src/transport/ble.rs
+++ b/src/transport/ble.rs
@@ -2967,7 +2967,7 @@ impl BleTransport {
         let mut disconnecting = 0;
         let mut oldest_activity = None;
 
-        for (_id, conn) in connections.iter() {
+        for conn in connections.values() {
             let conn = conn.read().await;
             match conn.state().await {
                 BleConnectionState::Connected => active += 1,


### PR DESCRIPTION
CI's updated stable clippy denies six pre-existing lints across master (`manual_filter` ×3, `for_kv_map` ×2, `unneeded_wildcard_pattern` ×1), failing the Quick Checks gate on every PR — #211 hit this. All rewrites are behavior-preserving; local clippy `-D warnings` (all targets, all features) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several stable clippy warnings with narrow Rust refactors. The main changes are:

- Manual `Option` predicate filtering was replaced with `Option::filter`.
- Map loops now use `values()` when keys are unused.
- A redundant ignored event field was removed from a dashboard match pattern.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/candidate_discovery.rs | Replaced two manual `Option::and_then` filters over `bound_address` with `Option::filter`. |
| src/connection/packet_crypto.rs | Replaced a manual previous-crypto option filter with `Option::filter`. |
| src/p2p_endpoint.rs | Changed an unused-key map iteration to iterate over values directly. |
| src/stats_dashboard.rs | Removed an explicit ignored `side` field from a dashboard event pattern. |
| src/transport/ble.rs | Changed a BLE connection map loop to iterate over values directly. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(lint): fix six new stable-clippy l..."](https://github.com/saorsa-labs/ant-quic/commit/168b0ee3fcd0cbd366155a6477f099d2b03501a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43896521)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=aa5b0a72-43fc-4512-856d-2b1369850c99))
- Context used - .cursorrules ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=08a064d6-4d62-436c-b6c5-725c2d6871b8))
- Context used - AGENTS.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=0fcbf7d8-485f-4997-9d42-680f49b36e91))
</details>

<!-- /greptile_comment -->