### PR TITLE
chore(release): bump version to v0.27.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Works identically over direct and MASQUE-relayed connections; PQC identity is
   inherited from the connection. See `docs/design/node-app-bidi-streams.md`.
 
+## [0.27.31] - 2026-07-13
+
+### Fixed
+- NAT-traversal sessions that failed terminally were never removed from
+  `active_sessions` and kept holding their `Connection` handle — megabytes of
+  per-connection state (streams tables sized by the configured
+  concurrent-stream limits) retained per failed dial to an unreachable peer
+  (#210, #211). Terminal failures now mark the session `Closed`, drop the
+  connection handle, and clear candidates/attempt records; establishment
+  timeouts release the handle immediately instead of one cache-TTL later.
+
+### Maintenance
+- Fixed six new stable-clippy lints (`manual_filter`, `for_kv_map`,
+  `unneeded_wildcard_pattern`) that were failing CI for every PR (#212).
+
 ## [0.27.25] - 2026-05-29
 
 ACK-v2 empty-response duplicate-safe retry. Fixes an intermittent

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.30"
+version = "0.27.31"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.30"
+version = "0.27.31"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release for #210/#211 (failed NAT-traversal sessions retained Connection state) + #212 lint fixes. Changelog included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.27.31` release. The main changes are:

- Bumps the crate version in `Cargo.toml`.
- Updates the matching package entry in `Cargo.lock`.
- Adds changelog notes for the NAT traversal cleanup and lint fixes.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Updates the main crate version to `0.27.31`. |
| Cargo.lock | Updates the locked `ant-quic` package version to match the manifest. |
| CHANGELOG.md | Adds the `0.27.31` release entry with fix and maintenance notes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump version to v0.27.31..."](https://github.com/saorsa-labs/ant-quic/commit/7c62c97af1032c850430d51127e6d2d1e20fa2be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43920638)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=aa5b0a72-43fc-4512-856d-2b1369850c99))
- Context used - .cursorrules ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=08a064d6-4d62-436c-b6c5-725c2d6871b8))
- Context used - AGENTS.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=0fcbf7d8-485f-4997-9d42-680f49b36e91))
</details>

<!-- /greptile_comment -->