### PR TITLE
fix(streams): lazily allocate remote stream state (#210)

### DIFF
--- a/src/connection/streams/mod.rs
+++ b/src/connection/streams/mod.rs
@@ -59,7 +59,7 @@ impl<'a> Streams<'a> {
 
         self.state.next[dir as usize] += 1;
         let id = StreamId::new(self.state.side, dir, self.state.next[dir as usize] - 1);
-        self.state.insert(false, id);
+        self.state.insert_local(id);
         self.state.send_streams += 1;
         Some(id)
     }

--- a/src/connection/streams/state.rs
+++ b/src/connection/streams/state.rs
@@ -152,7 +152,7 @@ impl StreamsState {
         receive_window: VarInt,
         stream_receive_window: VarInt,
     ) -> Self {
-        let mut this = Self {
+        Self {
             side,
             send: FxHashMap::default(),
             recv: FxHashMap::default(),
@@ -184,15 +184,7 @@ impl StreamsState {
             initial_max_stream_data_bidi_local: 0u32.into(),
             initial_max_stream_data_bidi_remote: 0u32.into(),
             receive_window_shrink_debt: 0,
-        };
-
-        for dir in Dir::iter() {
-            for i in 0..this.max_remote[dir as usize] {
-                this.insert(true, StreamId::new(!side, dir, i));
-            }
         }
-
-        this
     }
 
     pub(crate) fn set_params(&mut self, params: &TransportParameters) {
@@ -202,10 +194,11 @@ impl StreamsState {
         self.max[Dir::Bi as usize] = params.initial_max_streams_bidi.into();
         self.max[Dir::Uni as usize] = params.initial_max_streams_uni.into();
         self.received_max_data(params.initial_max_data);
-        for i in 0..self.max_remote[Dir::Bi as usize] {
-            let id = StreamId::new(!self.side, Dir::Bi, i);
-            if let Some(s) = self.send.get_mut(&id).and_then(|s| s.as_mut()) {
-                s.max_data = params.initial_max_stream_data_bidi_local.into();
+        for (&id, slot) in self.send.iter_mut() {
+            if id.initiator() != self.side && id.dir() == Dir::Bi {
+                if let Some(s) = slot.as_mut() {
+                    s.max_data = params.initial_max_stream_data_bidi_local.into();
+                }
             }
         }
     }
@@ -215,10 +208,6 @@ impl StreamsState {
     fn ensure_remote_streams(&mut self, dir: Dir) {
         let new_count = self.max_concurrent_remote_count[dir as usize]
             .saturating_sub(self.allocated_remote_count[dir as usize]);
-        for i in 0..new_count {
-            let id = StreamId::new(!self.side, dir, self.max_remote[dir as usize] + i);
-            self.insert(true, id);
-        }
         self.allocated_remote_count[dir as usize] += new_count;
         self.max_remote[dir as usize] += new_count;
     }
@@ -263,6 +252,9 @@ impl StreamsState {
             debug!("received illegal STREAM frame");
         })?;
 
+        // Create state for this stream if the remote peer created it.
+        let newly_created = self.ensure_remote(id);
+
         let rs = match self
             .recv
             .get_mut(&id)
@@ -285,7 +277,11 @@ impl StreamsState {
         self.data_recvd = self.data_recvd.saturating_add(new_bytes);
 
         if !rs.stopped {
-            self.on_stream_frame(true, id);
+            // Newly opened streams are inherently readable; the app discovers them via
+            // `StreamEvent::Opened` and a separate `Readable` would be redundant.
+            if !newly_created {
+                self.events.push_back(StreamEvent::Readable { id });
+            }
             return Ok(ShouldTransmit(false));
         }
 
@@ -314,6 +310,9 @@ impl StreamsState {
         self.validate_receive_id(id).inspect_err(|_e| {
             debug!("received illegal RESET_STREAM frame");
         })?;
+
+        // Create state for this stream if the remote peer created it.
+        let newly_created = self.ensure_remote(id);
 
         let rs = match self
             .recv
@@ -344,8 +343,11 @@ impl StreamsState {
             // Stopped streams should be disposed immediately on reset
             let rs = self.recv.remove(&id).flatten().unwrap();
             self.stream_recv_freed(id, rs);
+        } else if !newly_created {
+            // Newly opened streams are inherently readable; the app discovers them via
+            // `StreamEvent::Opened` and a separate `Readable` would be redundant.
+            self.events.push_back(StreamEvent::Readable { id });
         }
-        self.on_stream_frame(!stopped, id);
 
         // Update connection-level flow control
         Ok(if bytes_read != final_offset.into_inner() {
@@ -361,6 +363,9 @@ impl StreamsState {
 
     /// Process incoming `STOP_SENDING` frame
     pub fn received_stop_sending(&mut self, id: StreamId, error_code: VarInt) {
+        // Create state for this stream if the remote peer created it.
+        self.ensure_remote(id);
+
         let max_send_data = self.max_send_data(id);
         let stream = match self
             .send
@@ -374,7 +379,6 @@ impl StreamsState {
         if stream.try_stop(error_code) {
             self.events
                 .push_back(StreamEvent::Stopped { id, error_code });
-            self.on_stream_frame(false, id);
         }
     }
 
@@ -619,24 +623,6 @@ impl StreamsState {
         stream_frames
     }
 
-    /// Notify the application that new streams were opened or a stream became readable.
-    fn on_stream_frame(&mut self, notify_readable: bool, stream: StreamId) {
-        if stream.initiator() == self.side {
-            // Notifying about the opening of locally-initiated streams would be redundant.
-            if notify_readable {
-                self.events.push_back(StreamEvent::Readable { id: stream });
-            }
-            return;
-        }
-        let next = &mut self.next_remote[stream.dir() as usize];
-        if stream.index() >= *next {
-            *next = stream.index() + 1;
-            self.opened[stream.dir() as usize] = true;
-        } else if notify_readable {
-            self.events.push_back(StreamEvent::Readable { id: stream });
-        }
-    }
-
     pub(crate) fn received_ack_of(&mut self, frame: frame::StreamMeta) {
         let mut entry = match self.send.entry(frame.id) {
             hash_map::Entry::Vacant(_) => return,
@@ -741,6 +727,9 @@ impl StreamsState {
             ));
         }
 
+        // Create state for this stream if the remote peer created it.
+        self.ensure_remote(id);
+
         let write_limit = self.write_limit();
         let max_send_data = self.max_send_data(id);
         if let Some(ss) = self
@@ -766,7 +755,6 @@ impl StreamsState {
             ));
         }
 
-        self.on_stream_frame(false, id);
         Ok(())
     }
 
@@ -878,17 +866,53 @@ impl StreamsState {
         expanded
     }
 
-    pub(super) fn insert(&mut self, remote: bool, id: StreamId) {
-        let bi = id.dir() == Dir::Bi;
-        // bidirectional OR (unidirectional AND NOT remote)
-        if bi || !remote {
-            assert!(self.send.insert(id, None).is_none());
-        }
-        // bidirectional OR (unidirectional AND remote)
-        if bi || remote {
+    /// Insert `(id, None)` placeholders for a locally-initiated stream into `send` (and `recv`
+    /// for bidi). Called from `Streams::open`; the caller guarantees the id is fresh.
+    pub(super) fn insert_local(&mut self, id: StreamId) {
+        debug_assert_eq!(id.initiator(), self.side);
+        assert!(self.send.insert(id, None).is_none());
+        if id.dir() == Dir::Bi {
             let recv = self.free_recv.pop();
             assert!(self.recv.insert(id, recv).is_none());
         }
+    }
+
+    /// Allocate any new remote streams when a packet arrives for a stream id.
+    ///
+    /// Any streams above `next_remote` are considered to be in the default state, avoiding
+    /// allocations. Once we receive a packet for a new remote stream, we advance `next_remote`
+    /// and allocate actual state. If there's a gap, we insert `None` placeholders for the missing
+    /// streams (RFC 9000 §3.2: opening stream N implicitly opens all lower same-type streams).
+    ///
+    /// Returns `true` if `id` was a newly allocated remote stream.
+    fn ensure_remote(&mut self, id: StreamId) -> bool {
+        let dir = id.dir();
+        let dir_idx = dir as usize;
+
+        // If we initiated this stream, nothing to do
+        if id.initiator() == self.side
+            // If this stream is larger than the max allowed, return.
+            // NOTE: STREAM/RESET_STREAM already enforce this via `validate_receive_id`; however
+            // STOP_SENDING/MAX_STREAM_DATA do not.
+            || id.index() >= self.max_remote[dir_idx]
+            // If this stream has already been opened, nothing to do
+            || id.index() < self.next_remote[dir_idx]
+        {
+            return false;
+        }
+
+        // Create all of the streams between the largest opened and this stream.
+        for i in self.next_remote[dir_idx]..=id.index() {
+            let id = StreamId::new(!self.side, dir, i);
+            let recv = self.free_recv.pop();
+            assert!(self.recv.insert(id, recv).is_none());
+            if dir == Dir::Bi {
+                assert!(self.send.insert(id, None).is_none());
+            }
+        }
+        self.next_remote[dir_idx] = id.index() + 1;
+        self.opened[dir_idx] = true;
+        true
     }
 
     /// Adds credits to the connection flow control window
@@ -1873,10 +1897,173 @@ mod tests {
         for _ in 0..2 {
             client.set_max_concurrent(Dir::Uni, 200u32.into());
             client.set_max_concurrent(Dir::Bi, 201u32.into());
-            assert_eq!(client.recv.len(), 200 + 201);
             assert_eq!(client.max_remote[Dir::Uni as usize], 200);
             assert_eq!(client.max_remote[Dir::Bi as usize], 201);
+            assert_eq!(client.allocated_remote_count[Dir::Uni as usize], 200);
+            assert_eq!(client.allocated_remote_count[Dir::Bi as usize], 201);
+            // Slots are materialized lazily: no remote stream has been touched yet.
+            assert!(client.recv.is_empty());
+            assert!(client.send.is_empty());
         }
+    }
+
+    #[test]
+    fn lazy_remote_allocation_starts_empty() {
+        // Regression guard for ant-quic #210: `StreamsState::new` must not pre-populate
+        // `send`/`recv` with placeholder slots. Per-connection cost must track actual stream
+        // usage, not the advertised MAX_STREAMS limit — otherwise a large advertisement (x0x
+        // once advertised 50k uni streams) allocates a ~1.5MB hashbrown table on every
+        // connection whether or not any stream is ever opened. If someone reinstates eager
+        // allocation in `new()`, the capacity assertions below will fail.
+        let client = StreamsState::new(
+            Side::Client,
+            10_000u32.into(),
+            10_000u32.into(),
+            1024 * 1024,
+            (1024 * 1024u32).into(),
+            (1024 * 1024u32).into(),
+        );
+        // No slots allocated until a stream is actually received.
+        assert!(client.recv.is_empty());
+        assert!(client.send.is_empty());
+        assert_eq!(client.recv.capacity(), 0);
+        assert_eq!(client.send.capacity(), 0);
+    }
+
+    #[test]
+    fn out_of_order_implicit_open() {
+        // Receiving idx=5 implicitly opens idx 0..=4 (RFC 9000 §3.2). A later frame for idx=3
+        // must be processed normally, not dropped as "closed" — absence below the frontier only
+        // means Closed for ids that were actually opened and freed.
+        const STREAM_5_PAYLOAD: &[u8] = &[0xAA; 8];
+        const STREAM_3_PAYLOAD: &[u8] = &[0xBB; 4];
+
+        let mut client = make(Side::Client);
+        assert_eq!(
+            client.received(
+                frame::Stream {
+                    id: StreamId::new(Side::Server, Dir::Uni, 5),
+                    offset: 0,
+                    fin: true,
+                    data: Bytes::from_static(STREAM_5_PAYLOAD),
+                },
+                STREAM_5_PAYLOAD.len(),
+            ),
+            Ok(ShouldTransmit(false))
+        );
+        assert_eq!(client.next_remote[Dir::Uni as usize], 6);
+        assert_eq!(
+            client.received(
+                frame::Stream {
+                    id: StreamId::new(Side::Server, Dir::Uni, 3),
+                    offset: 0,
+                    fin: true,
+                    data: Bytes::from_static(STREAM_3_PAYLOAD),
+                },
+                STREAM_3_PAYLOAD.len(),
+            ),
+            Ok(ShouldTransmit(false))
+        );
+
+        let id = StreamId::new(Side::Server, Dir::Uni, 3);
+        let mut pending = Retransmits::default();
+        let mut recv = RecvStream {
+            id,
+            state: &mut client,
+            pending: &mut pending,
+        };
+        let mut chunks = recv.read(true).unwrap();
+        assert_eq!(
+            chunks.next(STREAM_3_PAYLOAD.len()).unwrap().unwrap().bytes,
+            STREAM_3_PAYLOAD
+        );
+        let _ = chunks.finalize();
+    }
+
+    #[test]
+    fn frame_for_closed_stream_is_dropped() {
+        // After a remote stream is fully freed, a subsequent frame for the same id must be
+        // dropped — absence from the map unambiguously means "closed" for ids below the
+        // frontier. This is the crux of the Closed-vs-Allowed distinction.
+        const PAYLOAD: &[u8] = &[0; 4];
+
+        let mut client = make(Side::Client);
+        let id = StreamId::new(Side::Server, Dir::Uni, 0);
+        assert_eq!(
+            client.received(
+                frame::Stream {
+                    id,
+                    offset: 0,
+                    fin: true,
+                    data: Bytes::from_static(PAYLOAD),
+                },
+                PAYLOAD.len(),
+            ),
+            Ok(ShouldTransmit(false))
+        );
+        // Stop the stream so it's fully freed.
+        let mut pending = Retransmits::default();
+        RecvStream {
+            id,
+            state: &mut client,
+            pending: &mut pending,
+        }
+        .stop(0u32.into())
+        .unwrap();
+        assert!(!client.recv.contains_key(&id));
+
+        // A stray retransmit for the freed stream must be dropped without resurrecting state.
+        assert_eq!(
+            client.received(
+                frame::Stream {
+                    id,
+                    offset: 0,
+                    fin: true,
+                    data: Bytes::from_static(PAYLOAD),
+                },
+                PAYLOAD.len(),
+            ),
+            Ok(ShouldTransmit(false))
+        );
+        assert!(!client.recv.contains_key(&id));
+    }
+
+    #[test]
+    fn churn_keeps_maps_bounded() {
+        // Rapidly open + fully close a long sequence of remote streams. The maps must stay
+        // bounded (only active streams are materialized) even though thousands of ids have been
+        // used over the connection's lifetime — the memory-intent behind lazy allocation.
+        const N: u64 = 5_000;
+
+        let mut client = make(Side::Client);
+        for i in 0..N {
+            let id = StreamId::new(Side::Server, Dir::Uni, i);
+            assert_eq!(
+                client.received(
+                    frame::Stream {
+                        id,
+                        offset: 0,
+                        fin: true,
+                        data: Bytes::from_static(&[0; 1]),
+                    },
+                    1,
+                ),
+                Ok(ShouldTransmit(false))
+            );
+            let mut pending = Retransmits::default();
+            let mut recv = RecvStream {
+                id,
+                state: &mut client,
+                pending: &mut pending,
+            };
+            let mut chunks = recv.read(true).unwrap();
+            let _ = chunks.next(1).unwrap();
+            assert!(chunks.next(1).unwrap().is_none());
+            let _ = chunks.finalize();
+        }
+        // Every stream was fully drained; the map must be empty.
+        assert_eq!(client.recv.len(), 0);
+        assert_eq!(client.send.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #210. `StreamsState::new` eagerly inserted a send/recv `HashMap` entry for **every** remote stream the advertised MAX_STREAMS permitted. At a large advertisement this is a multi-megabyte hashbrown allocation paid up front on **every** connection, whether or not any stream is ever opened — x0x once advertised 50,000 uni streams, measured at ~1.58 MB per connection.

This ports the reviewed diff from the quinn project's PR #2601 (which fixes their issue #2600), adapted by hand to ant-quic's `match`-based receive paths.

## What changed

- **`StreamsState::new`** constructs with empty `send`/`recv` maps — no eager loop.
- **`ensure_remote(id)`** materializes remote stream slots lazily on the first frame that references them, filling intervening ids (RFC 9000 §3.2 implicit-open: opening stream N implicitly opens all lower same-type streams). It **rejects over-limit ids before allocating**, so STOP_SENDING / MAX_STREAM_DATA cannot force allocation of a vector (STREAM / RESET_STREAM already reject via `validate_receive_id`).
- **Closed-vs-Allowed distinction:** absence from the map *below* `next_remote` means Closed (frame dropped); absence *above* `next_remote` means merely Allowed (lazily created on receipt).
- `insert` split into `insert_local` (locally-opened streams) and `ensure_remote`; `on_stream_frame` removed, its `next_remote`/`opened` bookkeeping folded into `ensure_remote`, its Readable-event logic inlined at each call site.
- `set_max_concurrent` / `ensure_remote_streams` now only advance the flow-control counters (`allocated_remote_count`, `max_remote`); they no longer pre-insert slots.
- `set_params` iterates existing `send` entries instead of scanning `0..max_remote`.

Per-connection cost now tracks actual stream usage rather than the advertised limit. The advertised MAX_STREAMS remains the worst-case bound (RFC 9000 §21.8 stream-commitment attack); this patch removes only the *unconditional* cost.

## Tests

- `lazy_remote_allocation_starts_empty` — memory-intent regression: a fresh connection advertising 10k streams holds zero map entries and zero capacity. Verified it **fails** if eager allocation is reinstated.
- `out_of_order_implicit_open` — receiving idx 5 then idx 3 processes both (3 is not mis-dropped as closed).
- `frame_for_closed_stream_is_dropped` — a retransmit for a fully-freed stream is dropped without resurrecting state.
- `churn_keeps_maps_bounded` — 5,000 open+close cycles leave the maps empty.
- `remote_stream_capacity` updated to assert lazy semantics (counters advance, maps stay empty).

## Gates

- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets --all-features -- -D warnings`: pass
- `cargo nextest run --all-features`: all stream tests pass; the only failures are pre-existing and unrelated (missing `docker/nat-emulation` assets, and the known `test_tiebreaker_deterministic` simultaneous-connect timing flake).

No `unwrap`/`expect`/`panic!` added to production paths; the `assert!` calls in `ensure_remote`/`insert_local` mirror the original `insert`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes remote stream state allocation lazy. The main changes are:

- Empty `send` and `recv` maps at connection creation.
- Lazy materialization of remote stream slots through `ensure_remote`.
- Updated stream event handling after removing `on_stream_frame`.
- Tests for lazy allocation, implicit opens, closed-stream drops, and churn.

<h3>Confidence Score: 4/5</h3>

The changed stream allocation path has one contained state-machine issue before merging.

- `MAX_STREAM_DATA` can now create remote stream state before a stream-opening frame arrives.
- The rest of the lazy allocation changes align with the inspected counter and event paths.

src/connection/streams/state.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/connection/streams/mod.rs | Updates local stream opening to use the new `insert_local` helper. |
| src/connection/streams/state.rs | Moves remote stream maps to lazy allocation and updates receive paths, counters, and tests around that model. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Remote frame references stream id] --> B{Frame type}
  B -->|STREAM or RESET_STREAM| C[Validate id]
  C --> D[ensure_remote allocates implicit-open range]
  D --> E[Process receive state]
  B -->|STOP_SENDING| F[ensure_remote allocates send side if allowed]
  F --> G[Deliver stop event]
  B -->|MAX_STREAM_DATA| H[ensure_remote allocates stream state]
  H --> I[Update send credit]
  H --> J[Opened flag may be set without STREAM or RESET]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Remote frame references stream id] --> B{Frame type}
  B -->|STREAM or RESET_STREAM| C[Validate id]
  C --> D[ensure_remote allocates implicit-open range]
  D --> E[Process receive state]
  B -->|STOP_SENDING| F[ensure_remote allocates send side if allowed]
  F --> G[Deliver stop event]
  B -->|MAX_STREAM_DATA| H[ensure_remote allocates stream state]
  H --> I[Update send credit]
  H --> J[Opened flag may be set without STREAM or RESET]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/connection/streams/state.rs:727-728
**Flow-Control Frame Opens Streams**

When a peer sends `MAX_STREAM_DATA` for an unopened remote bidirectional stream below `max_remote`, this new `ensure_remote(id)` call materializes that stream and every lower missing stream, advances `next_remote`, and sets the opened flag. A flow-control update can now make the application observe peer-opened streams without any STREAM or RESET_STREAM frame, and it can force the lazy allocation this change is meant to avoid.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(streams): lazily allocate remote str..."](https://github.com/saorsa-labs/ant-quic/commit/5d516115142953102ae2ff7a57d1930be8f765dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44107460)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=aa5b0a72-43fc-4512-856d-2b1369850c99))
- Context used - .cursorrules ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=08a064d6-4d62-436c-b6c5-725c2d6871b8))
- Context used - AGENTS.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=0fcbf7d8-485f-4997-9d42-680f49b36e91))
</details>

<!-- /greptile_comment -->