### PR TITLE
chore(release): v0.27.32 — reassembly gap cap (GHSA-4w2j-m93h-cj5j) + lazy stream-state alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.32] - 2026-07-14
+
+### Security
+- **Reassembly-buffer memory exhaustion (GHSA-4w2j-m93h-cj5j, CVSS 7.5,
+  CWE-770).** A peer sending stream fragments with many gaps while withholding
+  the early part of the stream could grow the receiver's out-of-order
+  reassembly buffer without bound. `Assembler::insert` now yields a
+  `TooManyChunks` error once more than 1024 chunks remain buffered after a
+  defragmentation pass; both call sites (crypto-stream and stream-data) convert
+  this to a connection-fatal `TransportError::INTERNAL_ERROR`, tearing the
+  connection down instead of buffering indefinitely. Ports the quinn project's
+  fix `fed0321a` / PR #2694. (#214)
+
+### Changed
+- Remote stream state is now allocated lazily. `StreamsState::new` previously
+  eagerly inserted a send/recv map entry for every remote stream the advertised
+  `MAX_STREAMS` permits — up to ~1.58 MB of hashbrown allocation per
+  connection at a 50,000-stream advertisement, paid up front on every
+  connection whether or not it ever opened a stream. Maps now start empty and
+  streams are materialized on first reference via `ensure_remote()`, bounded by
+  the advertised limit (RFC 9000 §21.8). This removes the unconditional
+  per-connection cost that dominated failed-dial memory retention. Ports the
+  quinn project's PR #2601. (#210)
+
 ### Added
 - `Node::open_bi(peer) -> Result<(HighLevelSendStream, HighLevelRecvStream)>`
   and `Node::accept_bi() -> Result<(PeerId, HighLevelSendStream,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.31"
+version = "0.27.32"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.31"
+version = "0.27.32"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Release v0.27.32. Two per-connection memory fixes, both ported from the quinn project, reviewed and CI-green on their feature PRs (#217, #216) before merge to master.

## Security — GHSA-4w2j-m93h-cj5j (CVSS 7.5, CWE-770)
Out-of-order reassembly buffers could grow without bound when a peer sends gapped fragments while withholding the stream prefix. `Assembler::insert` now caps at 1024 post-defragment chunks and tears the connection down with `INTERNAL_ERROR`. Ports quinn `fed0321a` / PR #2694. Closes #214.

## Structural — lazy remote stream-state allocation
`StreamsState::new` no longer eagerly preallocates a map entry per advertised remote stream (~1.58 MB/connection at 50k streams). Maps start empty; streams materialize on first reference, bounded by the advertised limit. Ports quinn PR #2601. Structural half of #210.

## Also rolled in
- `Node::open_bi` / `accept_bi` application byte-streams (previously under Unreleased; code shipped with 0.27.31, now formally versioned).

## Verification
- Both fixes independently reviewed (faithful ports, no correctness/security-boundary defects).
- Feature PRs green across the full CI matrix; master green post-merge (CI, Platforms, Tests, Coverage, Quick Checks).
- Adversarial regression tests added for both (gap-cap flood; lazy-alloc starts-empty), each proven to fail if the fix is reverted.

Tag `v0.27.32` after merge triggers release.yml (GitHub + crates.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the `0.27.32` release metadata. The main changes are:

- Added changelog notes for the reassembly gap cap security fix.
- Added changelog notes for lazy remote stream-state allocation.
- Bumped the crate version in `Cargo.toml` and `Cargo.lock`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the `0.27.32` release entry with security and allocation notes. |
| Cargo.toml | Bumps the root `ant-quic` package version to `0.27.32`. |
| Cargo.lock | Updates the locked `ant-quic` package version to match `Cargo.toml`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): v0.27.32 — reassembly ga..."](https://github.com/saorsa-labs/ant-quic/commit/bba9acfe894ccd0b55be1cf33c8c3b9692b2b656) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44113149)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=aa5b0a72-43fc-4512-856d-2b1369850c99))
- Context used - .cursorrules ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=08a064d6-4d62-436c-b6c5-725c2d6871b8))
- Context used - AGENTS.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=0fcbf7d8-485f-4997-9d42-680f49b36e91))
</details>

<!-- /greptile_comment -->