### PR TITLE
feat(cache): endpoint-owned bootstrap cache — NodeConfig plumbing, in-memory mode, maintenance + shutdown flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.33] - 2026-07-15
+
+### Added
+- `BootstrapCacheConfig::persist` (default `true`): `persist(false)` gives a purely in-memory cache — nothing loaded, nothing written, no cache directory or lock file created.
+- `NodeConfig::bootstrap_cache` + builder method: plumb a per-instance `BootstrapCacheConfig` through the high-level `Node` API into the endpoint (previously only reachable via low-level `P2pConfig`, so every `Node` embedder silently got the host-shared default cache dir).
+- `Node::bootstrap_cache()` accessor: expose the endpoint's single shared `Arc<BootstrapCache>` so embedders enrich/query one instance instead of opening a second cache on the same directory.
+
+### Fixed
+- `P2pEndpoint` now starts bootstrap-cache maintenance itself (periodic save, stale cleanup, quality recalculation) — previously no ant-quic code path ever called `start_maintenance`, so the endpoint's cache never persisted or cleaned up unless the embedder wired it manually.
+- `P2pEndpoint::shutdown` aborts the maintenance task and flushes the cache so learned peers survive restart without waiting for the next save tick.
+- Endpoint creation no longer hard-fails when the bootstrap cache cannot be opened (corrupt file, unwritable dir): it degrades to an in-memory cache with a warning.
+
 ## [0.27.32] - 2026-07-14
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.32"
+version = "0.27.33"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.32"
+version = "0.27.33"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/src/bootstrap_cache/cache.rs
+++ b/src/bootstrap_cache/cache.rs
@@ -66,7 +66,8 @@ pub struct CacheStats {
 pub struct BootstrapCache {
     config: BootstrapCacheConfig,
     data: Arc<RwLock<CacheData>>,
-    persistence: CachePersistence,
+    /// `None` when the cache is in-memory only (`config.persist == false`).
+    persistence: Option<CachePersistence>,
     event_tx: broadcast::Sender<CacheEvent>,
     last_save: Arc<RwLock<Instant>>,
     last_cleanup: Arc<RwLock<Instant>>,
@@ -77,13 +78,29 @@ impl BootstrapCache {
     /// Open or create a bootstrap cache.
     ///
     /// Loads existing cache data from disk if available, otherwise starts fresh.
+    /// With `config.persist == false` the cache is in-memory only: nothing is
+    /// loaded, nothing is ever written, and no cache directory is created.
     pub async fn open(config: BootstrapCacheConfig) -> std::io::Result<Self> {
-        let persistence = CachePersistence::new(&config.cache_dir, config.enable_file_locking)?;
-        let data = persistence.load()?;
+        let persistence = if config.persist {
+            Some(CachePersistence::new(
+                &config.cache_dir,
+                config.enable_file_locking,
+            )?)
+        } else {
+            None
+        };
+        let data = match &persistence {
+            Some(p) => p.load()?,
+            None => CacheData::new(super::persistence::generate_instance_id()),
+        };
         let (event_tx, _) = broadcast::channel(256);
         let now = Instant::now();
 
-        info!("Opened bootstrap cache with {} peers", data.peers.len());
+        info!(
+            "Opened bootstrap cache with {} peers (persist: {})",
+            data.peers.len(),
+            config.persist
+        );
 
         Ok(Self {
             config,
@@ -392,8 +409,11 @@ impl BootstrapCache {
         self.data.write().await.peers.remove(&peer_id.0)
     }
 
-    /// Save cache to disk.
+    /// Save cache to disk. No-op for in-memory caches (`persist: false`).
     pub async fn save(&self) -> std::io::Result<()> {
+        let Some(persistence) = &self.persistence else {
+            return Ok(());
+        };
         let mut data = self.data.write().await;
 
         if data.peers.len() < self.config.min_peers_to_save {
@@ -405,7 +425,7 @@ impl BootstrapCache {
             return Ok(());
         }
 
-        self.persistence.save(&mut data)?;
+        persistence.save(&mut data)?;
 
         drop(data);
         *self.last_save.write().await = Instant::now();
@@ -499,11 +519,15 @@ impl BootstrapCache {
     /// Start background maintenance tasks.
     ///
     /// Spawns a task that periodically:
-    /// - Saves the cache to disk
+    /// - Saves the cache to disk (no-op for in-memory caches)
     /// - Cleans up stale peers
     /// - Recalculates quality scores
     ///
     /// Returns a handle that can be used to cancel the task.
+    ///
+    /// Note: [`crate::p2p_endpoint::P2pEndpoint`] starts maintenance
+    /// automatically for its own cache — embedders sharing the endpoint's
+    /// cache (via [`crate::Node::bootstrap_cache`]) must not call this again.
     pub fn start_maintenance(self: Arc<Self>) -> tokio::task::JoinHandle<()> {
         let cache = self;
 
@@ -583,6 +607,35 @@ mod tests {
             .build();
 
         BootstrapCache::open(config).await.unwrap()
+    }
+
+    /// `persist: false` must make the cache purely in-memory: opening in a
+    /// directory that does not exist succeeds, and adding peers + saving
+    /// never creates the directory, cache file, or lock file. This is what
+    /// lets multiple node instances on one host opt out of the shared
+    /// default cache dir without cross-instance pollution.
+    #[tokio::test]
+    async fn in_memory_cache_never_touches_disk() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("does-not-exist");
+        let config = BootstrapCacheConfig::builder()
+            .cache_dir(&cache_dir)
+            .min_peers_to_save(1)
+            .persist(false)
+            .build();
+
+        let cache = BootstrapCache::open(config).await.unwrap();
+        cache
+            .add_seed(PeerId([7u8; 32]), vec!["127.0.0.1:9000".parse().unwrap()])
+            .await;
+        cache.save().await.unwrap();
+
+        assert!(
+            !cache_dir.exists(),
+            "in-memory cache must not create its cache directory"
+        );
+        // Runtime behaviour is unchanged: the peer is still selectable.
+        assert_eq!(cache.peer_count().await, 1);
     }
 
     #[tokio::test]

--- a/src/bootstrap_cache/config.rs
+++ b/src/bootstrap_cache/config.rs
@@ -44,6 +44,14 @@ pub struct BootstrapCacheConfig {
     /// Enable file locking for multi-process safety
     pub enable_file_locking: bool,
 
+    /// Persist the cache to disk (default: true).
+    ///
+    /// When `false` the cache is purely in-memory: nothing is loaded on
+    /// open, nothing is written on save, and no cache directory or lock
+    /// file is created. Runtime behaviour (quality scoring, peer
+    /// selection, maintenance) is unchanged.
+    pub persist: bool,
+
     /// Quality score weights
     pub weights: QualityWeights,
 }
@@ -74,6 +82,7 @@ impl Default for BootstrapCacheConfig {
             cleanup_interval: Duration::from_secs(6 * 3600), // 6 hours
             min_peers_to_save: 10,
             enable_file_locking: true,
+            persist: true,
             weights: QualityWeights::default(),
         }
     }
@@ -164,6 +173,12 @@ impl BootstrapCacheConfigBuilder {
         self
     }
 
+    /// Enable or disable disk persistence (see [`BootstrapCacheConfig::persist`])
+    pub fn persist(mut self, persist: bool) -> Self {
+        self.config.persist = persist;
+        self
+    }
+
     /// Set quality weights
     pub fn weights(mut self, weights: QualityWeights) -> Self {
         self.config.weights = weights;
@@ -238,6 +253,7 @@ mod tests {
         assert_eq!(config.cleanup_interval, Duration::from_secs(6 * 3600));
         assert_eq!(config.min_peers_to_save, 10);
         assert!(config.enable_file_locking);
+        assert!(config.persist);
         assert!(
             config.cache_dir.ends_with("ant-quic-cache") || config.cache_dir.ends_with("ant-quic")
         );

--- a/src/bootstrap_cache/persistence.rs
+++ b/src/bootstrap_cache/persistence.rs
@@ -545,7 +545,7 @@ impl Drop for EncryptedCachePersistence {
     }
 }
 
-fn generate_instance_id() -> String {
+pub(super) fn generate_instance_id() -> String {
     format!(
         "{}_{:x}",
         std::process::id(),

--- a/src/node.rs
+++ b/src/node.rs
@@ -171,6 +171,10 @@ fn node_config_to_p2p_config(config: NodeConfig) -> Result<P2pConfig, NodeError>
         p2p_config.nat.port_mapping.enabled = enabled;
     }
 
+    if let Some(cache_config) = config.bootstrap_cache {
+        p2p_config.bootstrap_cache = cache_config;
+    }
+
     Ok(p2p_config)
 }
 
@@ -513,6 +517,19 @@ impl Node {
     /// Get access to the underlying P2pEndpoint for advanced operations.
     pub fn inner_endpoint(&self) -> &Arc<P2pEndpoint> {
         &self.inner
+    }
+
+    /// The node's bootstrap peer cache.
+    ///
+    /// This is the single cache instance the endpoint uses for
+    /// quality-scored reconnection, coordinator selection and bootstrap
+    /// tokens (configured via [`NodeConfig::bootstrap_cache`]). Embedders
+    /// should enrich and
+    /// query this shared instance rather than opening a second cache on
+    /// the same directory. The endpoint runs cache maintenance itself —
+    /// do not call `start_maintenance` on this handle.
+    pub fn bootstrap_cache(&self) -> Arc<crate::BootstrapCache> {
+        Arc::clone(&self.inner.bootstrap_cache)
     }
 
     /// Get the transport registry for this node

--- a/src/node_config.rs
+++ b/src/node_config.rs
@@ -35,6 +35,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::bootstrap_cache::BootstrapCacheConfig;
 use crate::crypto::pqc::types::{MlDsaPublicKey, MlDsaSecretKey};
 use crate::host_identity::HostIdentity;
 use crate::transport::{TransportAddr, TransportProvider, TransportRegistry};
@@ -107,6 +108,18 @@ pub struct NodeConfig {
     /// discovery + port-mapping task is skipped. When `None`, the ant-quic
     /// default applies (currently enabled).
     pub port_mapping_enabled: Option<bool>,
+
+    /// Bootstrap peer cache configuration for the node's endpoint.
+    ///
+    /// The endpoint always owns exactly one [`BootstrapCacheConfig`]-backed
+    /// cache used for quality-scored reconnection, coordinator selection and
+    /// bootstrap tokens. When `None`, the ant-quic default applies — a
+    /// **host-shared** directory (`$TMPDIR/ant-quic-cache` or the platform
+    /// cache dir). Embedders running multiple nodes per host (or wanting
+    /// per-instance persistence) should set an explicit per-instance
+    /// `cache_dir`, or `persist(false)` for an in-memory-only cache.
+    /// Access the resulting shared cache via [`crate::Node::bootstrap_cache`].
+    pub bootstrap_cache: Option<BootstrapCacheConfig>,
 }
 
 impl std::fmt::Debug for NodeConfig {
@@ -167,6 +180,7 @@ pub struct NodeConfigBuilder {
     max_concurrent_uni_streams: Option<u32>,
     max_message_size: Option<usize>,
     port_mapping_enabled: Option<bool>,
+    bootstrap_cache: Option<BootstrapCacheConfig>,
 }
 
 impl NodeConfigBuilder {
@@ -371,6 +385,13 @@ impl NodeConfigBuilder {
         self
     }
 
+    /// Configure the endpoint's bootstrap peer cache (see
+    /// [`NodeConfig::bootstrap_cache`])
+    pub fn bootstrap_cache(mut self, config: BootstrapCacheConfig) -> Self {
+        self.bootstrap_cache = Some(config);
+        self
+    }
+
     /// Build the configuration
     pub fn build(self) -> NodeConfig {
         NodeConfig {
@@ -382,6 +403,7 @@ impl NodeConfigBuilder {
             max_concurrent_uni_streams: self.max_concurrent_uni_streams,
             max_message_size: self.max_message_size,
             port_mapping_enabled: self.port_mapping_enabled,
+            bootstrap_cache: self.bootstrap_cache,
         }
     }
 }
@@ -422,6 +444,28 @@ mod tests {
         assert!(config.keypair.is_none());
         assert!(config.transport_providers.is_empty());
         assert!(config.max_message_size.is_none());
+    }
+
+    /// The endpoint always opens exactly one bootstrap cache from
+    /// `NodeConfig::bootstrap_cache`; without this plumbing embedders were
+    /// forced to open a *second* cache instance (host-shared default dir)
+    /// that diverged from the endpoint's own.
+    #[test]
+    fn builder_plumbs_bootstrap_cache_config() {
+        let cache_config = BootstrapCacheConfig::builder()
+            .cache_dir("/tmp/per-instance-peers")
+            .persist(false)
+            .build();
+        let config = NodeConfig::builder().bootstrap_cache(cache_config).build();
+
+        let plumbed = config.bootstrap_cache.expect("bootstrap cache config set");
+        assert_eq!(
+            plumbed.cache_dir,
+            std::path::PathBuf::from("/tmp/per-instance-peers")
+        );
+        assert!(!plumbed.persist);
+        // Default stays None so existing embedders keep ant-quic's default.
+        assert!(NodeConfig::default().bootstrap_cache.is_none());
     }
 
     #[test]

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -747,6 +747,11 @@ pub struct P2pEndpoint {
     /// Bootstrap cache for peer persistence
     pub bootstrap_cache: Arc<BootstrapCache>,
 
+    /// Background maintenance task for `bootstrap_cache` (periodic save,
+    /// stale cleanup, quality recalculation). Shared across endpoint clones;
+    /// aborted on shutdown.
+    bootstrap_cache_maintenance: Arc<tokio::task::JoinHandle<()>>,
+
     /// Advanced externally supplied peer hints keyed by authenticated peer ID.
     ///
     /// This is intentionally separate from the persisted bootstrap cache so
@@ -2881,13 +2886,28 @@ impl P2pEndpoint {
         // Create NAT traversal endpoint with the same identity key used for auth
         // This ensures P2pEndpoint and NatTraversalEndpoint use the same keypair
         let mut nat_config = config.to_nat_config_with_key(public_key.clone(), secret_key);
-        let bootstrap_cache = Arc::new(
-            BootstrapCache::open(config.bootstrap_cache.clone())
-                .await
-                .map_err(|e| {
+        let bootstrap_cache = match BootstrapCache::open(config.bootstrap_cache.clone()).await {
+            Ok(cache) => Arc::new(cache),
+            Err(e) => {
+                // Degrade to an in-memory cache rather than failing endpoint
+                // creation: the cache is an optimization, not a correctness
+                // requirement, and a corrupt file or unwritable directory
+                // must not keep the node offline.
+                warn!(
+                    "Failed to open bootstrap cache at {:?} ({e}); continuing with an in-memory cache",
+                    config.bootstrap_cache.cache_dir
+                );
+                let mut memory_config = config.bootstrap_cache.clone();
+                memory_config.persist = false;
+                Arc::new(BootstrapCache::open(memory_config).await.map_err(|e| {
                     EndpointError::Config(format!("Failed to open bootstrap cache: {}", e))
-                })?,
-        );
+                })?)
+            }
+        };
+        // The endpoint owns cache maintenance so every embedder gets periodic
+        // saves and stale-entry cleanup without extra wiring.
+        let bootstrap_cache_maintenance =
+            Arc::new(Arc::clone(&bootstrap_cache).start_maintenance());
 
         // Create token store
         let token_store = Arc::new(BootstrapTokenStore::new(bootstrap_cache.clone()).await);
@@ -3088,6 +3108,7 @@ impl P2pEndpoint {
             shutdown: CancellationToken::new(),
             pending_data: Arc::new(RwLock::new(BoundedPendingBuffer::default())),
             bootstrap_cache,
+            bootstrap_cache_maintenance,
             peer_hint_records: Arc::new(RwLock::new(HashMap::new())),
             transport_registry,
             router: Arc::new(RwLock::new(router)),
@@ -8013,6 +8034,13 @@ impl P2pEndpoint {
         info!("Shutting down P2P endpoint");
         self.shutdown.cancel();
 
+        // Stop cache maintenance and flush learned peers so they survive
+        // restart without waiting for the next periodic save tick.
+        self.bootstrap_cache_maintenance.abort();
+        if let Err(e) = self.bootstrap_cache.save().await {
+            warn!("Failed to save bootstrap cache on shutdown: {e}");
+        }
+
         // Abort all background reader tasks.
         let handles = {
             let mut handles = self.reader_handles.write().await;
@@ -9459,6 +9487,7 @@ impl Clone for P2pEndpoint {
             shutdown: self.shutdown.clone(),
             pending_data: Arc::clone(&self.pending_data),
             bootstrap_cache: Arc::clone(&self.bootstrap_cache),
+            bootstrap_cache_maintenance: Arc::clone(&self.bootstrap_cache_maintenance),
             peer_hint_records: Arc::clone(&self.peer_hint_records),
             transport_registry: Arc::clone(&self.transport_registry),
             router: Arc::clone(&self.router),


### PR DESCRIPTION
## Problem

The high-level `Node` API had no way to configure the endpoint's bootstrap cache, so every embedder silently got the **host-shared** default directory (`$TMPDIR/ant-quic-cache` / `~/.cache/ant-quic`):

- multiple nodes on one host commingle peer planes (e.g. prod + testnet daemons on a VPS)
- embedders (x0x) worked around it by opening a *second*, divergent cache on their own directory — the endpoint's reconnection quality data and the embedder's enrichment never met
- **nothing inside ant-quic ever called `start_maintenance`**, so the endpoint's cache never persisted or cleaned up at all

## Changes

- `NodeConfig::bootstrap_cache` + builder method — plumb a per-instance `BootstrapCacheConfig` through `node_config_to_p2p_config` (the low-level `P2pConfig` field existed but was unreachable from `Node`)
- `Node::bootstrap_cache()` — expose the endpoint's single `Arc<BootstrapCache>` so embedders enrich/query one instance
- `BootstrapCacheConfig::persist` (default `true`) — `persist(false)` gives a purely in-memory cache: nothing loaded, nothing written, no cache dir or lock file created
- `P2pEndpoint` starts cache maintenance itself and aborts it + flushes the cache on `shutdown()` so learned peers survive restart without waiting for the 5-min save tick
- endpoint creation degrades to an in-memory cache (warn) instead of hard-failing when the cache file can't be opened

## Validation

- 2638/2638 lib tests pass; fmt + clippy clean; doc gate shows the same 8 pre-existing `--all-features` errors as master (none new)
- New tests: `in_memory_cache_never_touches_disk`, `builder_plumbs_bootstrap_cache_config`
- Proven end-to-end via the companion x0x branch `fix/single-bootstrap-cache`: per-instance dir honored, cache flushed on SIGTERM (32 KB after 38 s uptime), restart rebootstraps cache-first, host-shared dir stays empty

Companion PR: saorsa-labs/x0x `fix/single-bootstrap-cache` (requires this released as 0.27.33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the endpoint own and expose its bootstrap cache. The main changes are:

- Adds bootstrap-cache configuration to the high-level node API.
- Adds a diskless in-memory cache mode.
- Starts cache maintenance during endpoint creation.
- Stops maintenance and flushes the cache during shutdown.

<h3>Confidence Score: 4/5</h3>

Endpoint construction can leak maintenance work, and shutdown can omit learned peers from the persisted cache.

- Later construction failures leave the newly spawned maintenance task detached.
- The shutdown flush still applies the minimum-peer threshold and can skip all disk writes.
- The configuration plumbing and in-memory cache path otherwise appear consistent.

src/p2p_endpoint.rs and src/bootstrap_cache/cache.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Adds cache fallback, automatic maintenance, and shutdown flushing; task startup and final-save behavior contain lifecycle bugs. |
| src/bootstrap_cache/cache.rs | Makes persistence optional and keeps the existing peer-count threshold on all saves. |
| src/bootstrap_cache/config.rs | Adds the `persist` setting with a backward-compatible default and builder method. |
| src/node_config.rs | Adds optional bootstrap-cache configuration to `NodeConfig` and its builder. |
| src/node.rs | Plumbs cache configuration into `P2pConfig` and exposes the endpoint-owned cache. |
| src/bootstrap_cache/persistence.rs | Exposes instance ID generation to the parent bootstrap-cache module. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[P2pEndpoint creation] --> B[Open bootstrap cache]
    B --> C[Start maintenance task]
    C --> D{Remaining setup succeeds?}
    D -- No --> E[Return construction error]
    E --> F[Maintenance task remains detached]
    D -- Yes --> G[Run endpoint]
    G --> H[Shutdown]
    H --> I[Abort maintenance]
    I --> J[Call regular cache save]
    J --> K{Enough peers to save?}
    K -- No --> L[Return without writing]
    K -- Yes --> M[Write cache to disk]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[P2pEndpoint creation] --> B[Open bootstrap cache]
    B --> C[Start maintenance task]
    C --> D{Remaining setup succeeds?}
    D -- No --> E[Return construction error]
    E --> F[Maintenance task remains detached]
    D -- Yes --> G[Run endpoint]
    G --> H[Shutdown]
    H --> I[Abort maintenance]
    I --> J[Call regular cache save]
    J --> K{Enough peers to save?}
    K -- No --> L[Return without writing]
    K -- Yes --> M[Write cache to disk]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/p2p_endpoint.rs:2909-2910
**Failed Construction Leaks Maintenance**

The maintenance task starts before later fallible endpoint setup, including socket binding. If that setup returns an error, dropping this `JoinHandle` detaches the task instead of stopping it, so a failed endpoint can leave an orphan task holding the cache and periodically writing to its configured files.

### Issue 2 of 2
src/p2p_endpoint.rs:8039-8042
**Shutdown Flush Skips Small Caches**

This final flush calls the regular `save()`, which returns without writing when the cache has fewer than `min_peers_to_save` entries. With the default threshold of 10, a node that learns 1–9 peers loses them on shutdown, so those peers are unavailable after restart despite the new flush.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cache): endpoint-owned bootstrap ca..."](https://github.com/saorsa-labs/ant-quic/commit/cab5e855b3e92a1f4397380eeacd288789f4b0c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44431557)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=aa5b0a72-43fc-4512-856d-2b1369850c99))
- Context used - .cursorrules ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=08a064d6-4d62-436c-b6c5-725c2d6871b8))
- Context used - AGENTS.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=0fcbf7d8-485f-4997-9d42-680f49b36e91))
</details>

<!-- /greptile_comment -->