### PR TITLE
fix(endpoint): transient ICMP-derived recv errors must not kill the endpoint driver (x0x#262)

### DIFF
--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -45,7 +45,23 @@ use super::{
 };
 use crate::{EndpointConfig, VarInt};
 
-fn is_expected_background_io_error(error: &io::Error) -> bool {
+/// Transient per-datagram socket errors that must NOT terminate the endpoint
+/// driver (x0x issue #262).
+///
+/// On Linux, an unconnected UDP socket surfaces asynchronous ICMP errors
+/// (host/net unreachable, port unreachable) as a pending socket error on the
+/// next `recvmsg` — i.e. one unreachable *peer* manifests as a recv error on
+/// the *shared* socket. Terminating the driver on such an error kills all
+/// QUIC I/O for the process: `driver_lost` makes every future `connect()`
+/// fail synchronously and nothing polls the socket again, while the host
+/// process stays alive. A production bootstrap node sat in exactly that
+/// wedged state for 14+ hours. These errors are scoped to a single datagram
+/// exchange: drop it and keep polling.
+///
+/// Raw errnos cover platform gaps in `io::ErrorKind` mapping: 49
+/// (EADDRNOTAVAIL, macOS), 51/65 (ENETUNREACH/EHOSTUNREACH, macOS),
+/// 101/113 (ENETUNREACH/EHOSTUNREACH, Linux).
+fn is_transient_socket_error(error: &io::Error) -> bool {
     matches!(
         error.kind(),
         io::ErrorKind::AddrNotAvailable
@@ -252,11 +268,16 @@ impl Endpoint {
         runtime.spawn(Box::pin(
             async {
                 if let Err(e) = driver.await {
-                    if is_expected_background_io_error(&e) {
-                        debug!("background I/O path ended: {}", e);
-                    } else {
-                        tracing::error!("I/O error: {}", e);
-                    }
+                    // A driver exit is never routine: it permanently ends all
+                    // QUIC I/O on this endpoint (`driver_lost` fails every
+                    // future connect and nothing polls the socket again).
+                    // Transient per-datagram errors are handled inside
+                    // poll_socket; anything that reaches here is fatal and
+                    // must be loud (x0x issue #262 hid for 14h at debug!).
+                    tracing::error!(
+                        "endpoint driver terminated: {} — transport is dead on this endpoint",
+                        e
+                    );
                 }
             }
             .instrument(Span::current()),
@@ -625,6 +646,16 @@ impl Future for EndpointDriver {
 impl Drop for EndpointDriver {
     fn drop(&mut self) {
         if let Ok(mut endpoint) = self.0.state.lock() {
+            // Loud by design (x0x issue #262): once `driver_lost` is set,
+            // every future connect() fails and the socket is never polled
+            // again — operators need that in logs, not just the effect.
+            // An intentional close() (close reason recorded) stays quiet.
+            if endpoint.recv_state.connections.close.is_none() {
+                tracing::warn!(
+                    "endpoint driver dropped without close — driver_lost set; \
+                     no further QUIC I/O on this endpoint"
+                );
+            }
             endpoint.driver_lost = true;
             self.0.shared.incoming.notify_waiters();
             // Drop all outgoing channels, signaling the termination of the endpoint to the associated
@@ -1143,8 +1174,13 @@ impl RecvState {
                     });
                 }
                 // Ignore ECONNRESET as it's undefined in QUIC and may be injected by an
-                // attacker
-                Poll::Ready(Err(ref e)) if e.kind() == io::ErrorKind::ConnectionReset => {
+                // attacker; likewise every ICMP-derived transient error a
+                // single unreachable peer can pin on the shared socket —
+                // terminating the driver here silently kills ALL transport
+                // for the process (x0x issue #262). Drop the datagram and
+                // keep polling.
+                Poll::Ready(Err(ref e)) if is_transient_socket_error(e) => {
+                    debug!("ignoring transient socket recv error: {}", e);
                     continue;
                 }
                 Poll::Ready(Err(e)) => {
@@ -1178,4 +1214,56 @@ struct PollProgress {
     received_connection_packet: bool,
     /// Whether datagram handling was interrupted early by the work limiter for fairness
     keep_going: bool,
+}
+
+#[cfg(test)]
+mod driver_error_tests {
+    use super::is_transient_socket_error;
+    use std::io;
+
+    /// WHY (x0x issue #262): on Linux, one unreachable peer surfaces as an
+    /// ICMP-derived recv error on the SHARED endpoint socket. If any of
+    /// these terminate the driver, the whole process loses QUIC I/O
+    /// silently — a prod bootstrap sat wedged like that for 14+ hours.
+    #[test]
+    fn icmp_derived_errors_are_transient() {
+        for kind in [
+            io::ErrorKind::HostUnreachable,
+            io::ErrorKind::NetworkUnreachable,
+            io::ErrorKind::ConnectionRefused,
+            io::ErrorKind::ConnectionReset,
+            io::ErrorKind::AddrNotAvailable,
+            io::ErrorKind::NotConnected,
+            io::ErrorKind::TimedOut,
+        ] {
+            assert!(
+                is_transient_socket_error(&io::Error::new(kind, "test")),
+                "{kind:?} must not kill the endpoint driver"
+            );
+        }
+        // Raw errnos with platform-dependent ErrorKind mapping.
+        for errno in [49, 51, 65, 101, 113] {
+            assert!(
+                is_transient_socket_error(&io::Error::from_raw_os_error(errno)),
+                "errno {errno} must not kill the endpoint driver"
+            );
+        }
+    }
+
+    /// Genuinely fatal socket states must still terminate the driver: a
+    /// dead file descriptor or permission loss is not per-datagram.
+    #[test]
+    fn fatal_errors_still_terminate() {
+        for kind in [
+            io::ErrorKind::BrokenPipe,
+            io::ErrorKind::PermissionDenied,
+            io::ErrorKind::NotFound,
+            io::ErrorKind::InvalidInput,
+        ] {
+            assert!(
+                !is_transient_socket_error(&io::Error::new(kind, "test")),
+                "{kind:?} must remain driver-fatal"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Root-cause fix for the saorsa-labs/x0x#262 production wedge: a single ICMP-unreachable peer could terminate the sole endpoint driver task via a pending socket error, silently (debug!-level) killing all QUIC I/O for the process while it stayed alive — and the bootstrap cache made the wedge survive restarts by re-dialing the poisoned target first.

- `poll_socket`: transient ICMP-derived errors → drop datagram + continue (was: ConnectionReset only; everything else driver-fatal)
- driver termination now error!-logged; `Drop` warns on driver_lost without intentional close
- classification pinned by unit tests

Local note: `test_connect_to_nonexistent_peer`, `test_tiebreaker_deterministic`, `test_connect_timeout_no_orphans`, `test_upsert_peer_hints_feeds_relay_cache_selection…` fail identically on clean master in my environment (live daemons on the host) — pre-existing, not introduced here; CI should confirm.

Follow-ups filed: #220 (supervise/respawn driver), #221 (synthetic PeerId leak + warn hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps transient UDP receive errors from terminating the endpoint driver. The main changes are:

- Classify ICMP-derived socket errors as transient.
- Retry receives after transient socket errors.
- Raise driver termination logs to error level.
- Warn when the endpoint driver is dropped without a recorded close.
- Add unit tests for transient and fatal error classification.

<h3>Confidence Score: 4/5</h3>

The transient receive-error loop needs bounded yielding before merging.

- Repeated ready errors can keep one driver poll running indefinitely and starve its executor thread.
- The new drop warning also reports normal endpoint teardown as driver loss.
- The error classification tests cover membership but not repeated-error scheduling behavior.

src/high_level/endpoint.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/high_level/endpoint.rs | Adds transient receive-error recovery and stronger driver diagnostics, but repeated errors bypass the fairness limiter and clean teardown triggers the new warning. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/high_level/endpoint.rs:1182-1184
**Transient Errors Bypass Fairness Limit**

When `poll_recv` repeatedly returns an immediately ready transient error, this `continue` skips the receive work limiter and never returns `Pending`. A sustained network-unreachable state or stream of ICMP errors can therefore pin the executor thread, flood debug logs, and stall all QUIC and application tasks running on it.

### Issue 2 of 2
src/high_level/endpoint.rs:653
**Normal Teardown Reports Driver Loss**

When the last endpoint handle is dropped with no active connections, the driver normally returns `Ok(())` and its completed future is then dropped. Since that path does not set `connections.close`, this condition emits the new warning during clean teardown, producing a false transport-failure alarm.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(endpoint): transient ICMP-derived re..."](https://github.com/saorsa-labs/ant-quic/commit/0a105335522b863155246700e33b1eae0d8d81b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45354118)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=aa5b0a72-43fc-4512-856d-2b1369850c99))
- Context used - .cursorrules ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=08a064d6-4d62-436c-b6c5-725c2d6871b8))
- Context used - AGENTS.md ([source](https://app.greptile.com/saorsa-labs/github/saorsa-labs/ant-quic/-/custom-context?memory=0fcbf7d8-485f-4997-9d42-680f49b36e91))
</details>

<!-- /greptile_comment -->