### PR TITLE
fix: make connection lifecycle replacement atomic

### DIFF
--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -409,7 +409,7 @@ pub(crate) enum ConnectionRegistrationOutcome {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ReaderExitOutcome {
     Noop,
-    ConnectionReaped,
+    ConnectionReaped { close_reason: ConnectionCloseReason },
     PeerDisconnected { close_reason: ConnectionCloseReason },
 }
 
@@ -6509,26 +6509,23 @@ impl NatTraversalEndpoint {
             }
 
             if let Some(pending) = self.pending_accepts.lock().pop_front() {
-                let still_live = self
-                    .lifecycle_snapshot_for_generation(&pending.peer_id, pending.generation)
-                    .is_some_and(|snapshot| {
-                        matches!(snapshot.state, ConnectionLifecycleState::Live)
+                let connection = self
+                    .connection_lifecycle
+                    .read()
+                    .get(&pending.peer_id)
+                    .and_then(|entries| {
+                        entries
+                            .iter()
+                            .find(|entry| {
+                                entry.generation == pending.generation
+                                    && matches!(entry.state, ConnectionLifecycleState::Live)
+                            })
+                            .map(|entry| entry.connection.clone())
                     });
-                if !still_live {
+                let Some(connection) = connection else {
                     debug!(
                         "Skipping stale pending accept for peer {:?}: generation {:?} no longer live",
                         pending.peer_id, pending.generation
-                    );
-                    continue;
-                }
-                let Some(connection) = self
-                    .connections
-                    .get(&pending.peer_id)
-                    .map(|entry| entry.value().clone())
-                else {
-                    debug!(
-                        "Skipping stale pending accept for peer {:?}: connection no longer in storage",
-                        pending.peer_id
                     );
                     continue;
                 };
@@ -6914,6 +6911,23 @@ impl NatTraversalEndpoint {
                 entries.push(tracked.clone());
             }
             Self::prune_closed_lifecycle_entries(entries);
+
+            // Winner-map update MUST be atomic with the supersede decision
+            // above. Previously this insert ran *after* the lifecycle
+            // write-lock was released, so a registration whose locked
+            // outcome was "first Live" could execute its insert AFTER a
+            // concurrent same-peer registration already marked it
+            // Superseded — leaving `connections[peer]` pointing at the
+            // loser while a Live survivor exists in the Vec. `is_peer_connected`
+            // and the stale-reaper read only that single winner and tore
+            // down the SURVIVOR reader (x0x "dead pair"). Bounding the
+            // insert to the locked decision keeps the winner map aliasing
+            // the unique Live entry. Lock-order safe: nothing holds a
+            // `connections` guard and then takes the lifecycle lock.
+            if rejected_connection.is_none() {
+                connections.insert(peer_id, connection.clone());
+                emitted_established_events.remove(&peer_id);
+            }
         }
 
         if let Some((rejected_connection, winner_generation)) = rejected_connection {
@@ -6925,8 +6939,6 @@ impl NatTraversalEndpoint {
             return ConnectionRegistrationOutcome::Rejected { winner_generation };
         }
 
-        connections.insert(peer_id, connection);
-        emitted_established_events.remove(&peer_id);
         ConnectionRegistrationOutcome::Live {
             generation,
             superseded_generation,
@@ -7102,6 +7114,199 @@ impl NatTraversalEndpoint {
         Some(effective_reason)
     }
 
+    /// Close a reader generation only if it is still superseded.
+    ///
+    /// A superseded connection can be promoted back to `Live` when the current
+    /// winner exits during its drain window. Claiming the `Closing` transition
+    /// under the lifecycle lock prevents the delayed reader-cancellation task
+    /// from cancelling a connection after such a promotion.
+    pub(crate) fn close_superseded_connection_if_current(
+        &self,
+        peer_id: &PeerId,
+        generation: u64,
+    ) -> bool {
+        let connection = {
+            let mut lifecycle = self.connection_lifecycle.write();
+            let Some(entries) = lifecycle.get_mut(peer_id) else {
+                return false;
+            };
+            let Some(entry) = entries
+                .iter_mut()
+                .find(|entry| entry.generation == generation)
+            else {
+                return false;
+            };
+            if !matches!(entry.state, ConnectionLifecycleState::Superseded { .. }) {
+                return false;
+            }
+
+            Self::log_lifecycle_transition(
+                peer_id,
+                entry.generation,
+                &entry.connection_id,
+                entry.stable_id(),
+                entry.state.name(),
+                ConnectionLifecycleState::Closing {
+                    reason: ConnectionCloseReason::Superseded,
+                }
+                .name(),
+                ConnectionCloseReason::Superseded,
+            );
+            entry.state = ConnectionLifecycleState::Closing {
+                reason: ConnectionCloseReason::Superseded,
+            };
+            entry.connection.clone()
+        };
+
+        if connection.close_reason().is_none()
+            && let Some(code) = ConnectionCloseReason::Superseded.app_error_code()
+        {
+            connection.close(code, ConnectionCloseReason::Superseded.reason_bytes());
+        }
+        true
+    }
+
+    /// Restore the best usable survivor when the winner is unavailable.
+    ///
+    /// Superseded readers intentionally remain open for a short drain window.
+    /// If the winner dies during that window, leaving the single-slot winner
+    /// map empty would make outbound sends fail while the survivor continues to
+    /// deliver inbound data. Promotion keeps the lifecycle vector and winner
+    /// map atomic under the same lock used by registration.
+    fn repromote_surviving_connection(
+        &self,
+        peer_id: &PeerId,
+        exiting_stable_id: Option<usize>,
+    ) -> Option<InnerConnection> {
+        let mut lifecycle = self.connection_lifecycle.write();
+        let entries = lifecycle.get_mut(peer_id)?;
+        if let Some(exiting_stable_id) = exiting_stable_id {
+            entries.retain(|entry| entry.stable_id() != exiting_stable_id);
+        }
+
+        let replacement_index = entries
+            .iter()
+            .position(|entry| {
+                matches!(entry.state, ConnectionLifecycleState::Live)
+                    && entry.connection.is_alive()
+                    && entry.connection.close_reason().is_none()
+            })
+            .or_else(|| {
+                entries
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, entry)| {
+                        matches!(entry.state, ConnectionLifecycleState::Superseded { .. })
+                            && entry.connection.is_alive()
+                            && entry.connection.close_reason().is_none()
+                    })
+                    .max_by(|(_, left), (_, right)| {
+                        Self::canonical_sort_key_cmp(
+                            Self::canonical_sort_key(
+                                left.connection_family_id,
+                                left.connection_id,
+                                left.generation,
+                                left.established_at_unix_ms,
+                                left.stable_id(),
+                            ),
+                            Self::canonical_sort_key(
+                                right.connection_family_id,
+                                right.connection_id,
+                                right.generation,
+                                right.established_at_unix_ms,
+                                right.stable_id(),
+                            ),
+                        )
+                    })
+                    .map(|(index, _)| index)
+            });
+
+        let Some(replacement_index) = replacement_index else {
+            if entries.is_empty() {
+                lifecycle.remove(peer_id);
+            }
+            return None;
+        };
+
+        let replacement = &mut entries[replacement_index];
+        if !matches!(replacement.state, ConnectionLifecycleState::Live) {
+            info!(
+                target: "ant_quic::p2p_endpoint::lifecycle",
+                peer_id = %Self::lifecycle_peer_prefix(peer_id),
+                generation = replacement.generation,
+                from_state = replacement.state.name(),
+                to_state = "Live",
+                reason = "WinnerUnavailableFallback",
+                connection_id = %replacement.connection_id_hex(),
+                stable_id = replacement.stable_id(),
+                "connection lifecycle transition"
+            );
+            replacement.state = ConnectionLifecycleState::Live;
+        }
+        let connection = replacement.connection.clone();
+        self.connections.insert(*peer_id, connection.clone());
+        self.emitted_established_events.insert(*peer_id);
+        Some(connection)
+    }
+
+    /// Retire exactly the observed connection generation and restore any
+    /// usable survivor without touching a concurrent replacement.
+    fn retire_connection_if_current(
+        &self,
+        peer_id: &PeerId,
+        connection: &InnerConnection,
+        default_reason: ConnectionCloseReason,
+    ) -> Option<InnerConnection> {
+        let stable_id = connection.stable_id();
+        let effective_reason = self
+            .mark_connection_closed(peer_id, stable_id, default_reason)
+            .unwrap_or(default_reason);
+        let removed = self
+            .connections
+            .remove_if(peer_id, |_, current| current.stable_id() == stable_id)
+            .is_some();
+
+        if connection.close_reason().is_none()
+            && let Some(code) = effective_reason.app_error_code()
+        {
+            connection.close(code, effective_reason.reason_bytes());
+        }
+        if removed && let Ok(mut peers) = self.relay_advertised_peers.lock() {
+            peers.remove(&connection.remote_address());
+        }
+
+        let replacement = self.repromote_surviving_connection(peer_id, Some(stable_id));
+        if replacement.is_none() && !self.connections.contains_key(peer_id) {
+            self.emitted_established_events.remove(peer_id);
+        }
+        replacement
+    }
+
+    /// Close one tracked generation without evicting a newer winner for the
+    /// same peer. Returns `false` when that generation is already gone.
+    pub(crate) fn remove_connection_generation_with_reason(
+        &self,
+        peer_id: &PeerId,
+        stable_id: usize,
+        close_reason: ConnectionCloseReason,
+    ) -> bool {
+        let connection = self
+            .connection_lifecycle
+            .read()
+            .get(peer_id)
+            .and_then(|entries| {
+                entries
+                    .iter()
+                    .find(|entry| entry.stable_id() == stable_id)
+                    .map(|entry| entry.connection.clone())
+            });
+        let Some(connection) = connection else {
+            return false;
+        };
+        let _ = self.retire_connection_if_current(peer_id, &connection, close_reason);
+        true
+    }
+
     pub(crate) fn handle_reader_exit(
         &self,
         peer_id: &PeerId,
@@ -7145,7 +7350,9 @@ impl NatTraversalEndpoint {
                         lifecycle.remove(peer_id);
                     }
                 }
-                ReaderExitOutcome::ConnectionReaped
+                ReaderExitOutcome::ConnectionReaped {
+                    close_reason: ConnectionCloseReason::Superseded,
+                }
             }
             ConnectionLifecycleState::Live => {
                 let current_live_stable_id = self
@@ -7182,7 +7389,9 @@ impl NatTraversalEndpoint {
                             lifecycle.remove(peer_id);
                         }
                     }
-                    return ReaderExitOutcome::ConnectionReaped;
+                    return ReaderExitOutcome::ConnectionReaped {
+                        close_reason: ConnectionCloseReason::Superseded,
+                    };
                 }
 
                 let connection =
@@ -7220,18 +7429,22 @@ impl NatTraversalEndpoint {
                 let close_reason = self
                     .mark_connection_closed(peer_id, snapshot.stable_id, default_close_reason)
                     .unwrap_or(default_close_reason);
-                self.connections.remove(peer_id);
-                self.emitted_established_events.remove(peer_id);
-                let mut lifecycle = self.connection_lifecycle.write();
-                if let Some(entries) = lifecycle.get_mut(peer_id) {
-                    entries.retain(|entry| entry.stable_id() != snapshot.stable_id);
-                    if entries.is_empty() {
-                        lifecycle.remove(peer_id);
-                    }
+                if self
+                    .repromote_surviving_connection(peer_id, Some(snapshot.stable_id))
+                    .is_some()
+                {
+                    return ReaderExitOutcome::ConnectionReaped { close_reason };
                 }
+                let _ = self.connections.remove_if(peer_id, |_, current| {
+                    current.stable_id() == snapshot.stable_id
+                });
+                if self.is_peer_connected(peer_id) {
+                    return ReaderExitOutcome::ConnectionReaped { close_reason };
+                }
+                self.emitted_established_events.remove(peer_id);
                 ReaderExitOutcome::PeerDisconnected { close_reason }
             }
-            ConnectionLifecycleState::Closing { .. } | ConnectionLifecycleState::Closed { .. } => {
+            ConnectionLifecycleState::Closing { reason } => {
                 let mut lifecycle = self.connection_lifecycle.write();
                 if let Some(entries) = lifecycle.get_mut(peer_id) {
                     entries.retain(|entry| entry.stable_id() != snapshot.stable_id);
@@ -7239,7 +7452,21 @@ impl NatTraversalEndpoint {
                         lifecycle.remove(peer_id);
                     }
                 }
-                ReaderExitOutcome::ConnectionReaped
+                ReaderExitOutcome::ConnectionReaped {
+                    close_reason: reason,
+                }
+            }
+            ConnectionLifecycleState::Closed { reason, .. } => {
+                let mut lifecycle = self.connection_lifecycle.write();
+                if let Some(entries) = lifecycle.get_mut(peer_id) {
+                    entries.retain(|entry| entry.stable_id() != snapshot.stable_id);
+                    if entries.is_empty() {
+                        lifecycle.remove(peer_id);
+                    }
+                }
+                ReaderExitOutcome::ConnectionReaped {
+                    close_reason: reason,
+                }
             }
         }
     }
@@ -7250,14 +7477,23 @@ impl NatTraversalEndpoint {
     /// from the connection table and returns `false`. This enables automatic
     /// cleanup of phantom connections during deduplication checks.
     pub fn is_peer_connected(&self, peer_id: &PeerId) -> bool {
-        if let Some(conn) = self.connections.get(peer_id) {
-            if conn.is_alive() && conn.close_reason().is_none() {
-                return true;
-            }
-            drop(conn);
-            let _ = self.remove_connection(peer_id);
+        let Some(connection) = self
+            .connections
+            .get(peer_id)
+            .map(|entry| entry.value().clone())
+        else {
+            return self.repromote_surviving_connection(peer_id, None).is_some();
+        };
+        if connection.is_alive() && connection.close_reason().is_none() {
+            return true;
         }
-        false
+        let reason = connection
+            .close_reason()
+            .as_ref()
+            .map(ConnectionCloseReason::from_connection_error)
+            .unwrap_or(ConnectionCloseReason::LifecycleCleanup);
+        self.retire_connection_if_current(peer_id, &connection, reason)
+            .is_some()
     }
 
     /// Get an active live connection by peer ID.
@@ -7270,14 +7506,14 @@ impl NatTraversalEndpoint {
             .get(peer_id)
             .map(|entry| entry.value().clone())
         else {
-            return Ok(None);
+            return Ok(self.repromote_surviving_connection(peer_id, None));
         };
         if let Some(reason) = connection.close_reason() {
-            let _ = self.remove_connection_with_reason(
+            return Ok(self.retire_connection_if_current(
                 peer_id,
+                &connection,
                 ConnectionCloseReason::from_connection_error(&reason),
-            );
-            return Ok(None);
+            ));
         }
         Ok(Some(connection))
     }
@@ -12881,5 +13117,516 @@ mod tests {
         );
 
         endpoint.shutdown().await.expect("Shutdown should succeed");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // close_superseded_connection_if_current — delayed-drain safety
+    //
+    // A superseded reader is intentionally left open for a short drain
+    // window. If the current winner exits during that window the superseded
+    // entry can be *promoted back to Live*. The delayed reader-cancellation
+    // task must therefore only close a generation that is *still* Superseded
+    // — claiming the Closing transition atomically under the lifecycle lock
+    // — and must leave a since-promoted Live generation untouched.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Build one real, fully authenticated QUIC connection over loopback
+    /// between two minimal endpoints. The returned handle is alive and has
+    /// no close reason. Both endpoints are retained so their IO drivers keep
+    /// the connection healthy for the duration of the test; the connection is
+    /// deliberately *not* registered through `add_connection`, so no
+    /// lifecycle/watch background task touches it.
+    async fn loopback_quic_connection()
+    -> (NatTraversalEndpoint, NatTraversalEndpoint, InnerConnection) {
+        fn test_config() -> NatTraversalConfig {
+            NatTraversalConfig {
+                bind_addr: Some("127.0.0.1:0".parse().expect("valid bind addr")),
+                ..Default::default()
+            }
+        }
+        let server = NatTraversalEndpoint::new(test_config(), None, None)
+            .await
+            .expect("server endpoint binds");
+        let client = NatTraversalEndpoint::new(test_config(), None, None)
+            .await
+            .expect("client endpoint binds");
+        let server_addr = server
+            .get_endpoint()
+            .expect("server endpoint present")
+            .local_addr()
+            .expect("server bound to a local address");
+        let connecting = client
+            .get_endpoint()
+            .expect("client endpoint present")
+            .connect(server_addr, "peer")
+            .expect("initiate client connection");
+        let conn = tokio::time::timeout(std::time::Duration::from_secs(10), connecting)
+            .await
+            .expect("loopback handshake must not hang")
+            .expect("loopback handshake must succeed");
+        (server, client, conn)
+    }
+
+    /// Seed a single tracked generation for `peer_id` directly into the
+    /// lifecycle map in the requested state, bypassing registration so the
+    /// state is exactly what the test needs.
+    fn seed_lifecycle_entry(
+        endpoint: &NatTraversalEndpoint,
+        peer_id: PeerId,
+        generation: u64,
+        connection: InnerConnection,
+        state: ConnectionLifecycleState,
+    ) {
+        endpoint.connection_lifecycle.write().insert(
+            peer_id,
+            vec![TrackedConnection {
+                connection,
+                generation,
+                established_at_unix_ms: 0,
+                connection_family_id: [0u8; 32],
+                connection_id: [0u8; 32],
+                state,
+            }],
+        );
+    }
+
+    /// A still-`Superseded` generation is claimed atomically: the entry
+    /// advances to `Closing { Superseded }` under the lifecycle lock and the
+    /// underlying connection is closed with the reserved `Superseded`
+    /// application error code.
+    #[tokio::test]
+    async fn close_superseded_claims_and_closes_still_superseded_generation() {
+        let (_server, client, conn) = loopback_quic_connection().await;
+        let peer_id = PeerId([0xAA; 32]);
+        let generation = 7u64;
+        seed_lifecycle_entry(
+            &client,
+            peer_id,
+            generation,
+            conn.clone(),
+            ConnectionLifecycleState::Superseded {
+                replaced_by_generation: generation + 1,
+            },
+        );
+        // Preconditions: connection open, entry is the seeded Superseded state.
+        assert!(
+            conn.close_reason().is_none(),
+            "precondition: connection open"
+        );
+        assert!(
+            matches!(
+                client
+                    .lifecycle_snapshot_for_generation(&peer_id, generation)
+                    .expect("seeded entry must be present")
+                    .state,
+                ConnectionLifecycleState::Superseded { .. }
+            ),
+            "precondition: entry must be Superseded"
+        );
+
+        let claimed = client.close_superseded_connection_if_current(&peer_id, generation);
+
+        assert!(claimed, "a still-Superseded generation must be claimed");
+        // The entry was claimed under the lock and advanced to Closing.
+        assert!(
+            matches!(
+                client
+                    .lifecycle_snapshot_for_generation(&peer_id, generation)
+                    .expect("claimed entry must remain tracked")
+                    .state,
+                ConnectionLifecycleState::Closing {
+                    reason: ConnectionCloseReason::Superseded
+                }
+            ),
+            "claimed entry must be Closing(Superseded)"
+        );
+        // The function closed the connection. In this codebase
+        // `high_level::Connection::close` records the close locally as
+        // `LocallyClosed` (the `Superseded` application code is carried on the
+        // wire to the peer; the local handle reports `LocallyClosed`), so the
+        // open→closed transition — `None` immediately before the call,
+        // `LocallyClosed` after — is exactly the function's effect and not a
+        // stray peer/idle close.
+        assert!(
+            matches!(
+                conn.close_reason(),
+                Some(crate::ConnectionError::LocallyClosed)
+            ),
+            "claimed connection must be locally closed by the function, got {:?}",
+            conn.close_reason()
+        );
+    }
+
+    /// A generation that has been promoted back to `Live` — exactly the race
+    /// the atomic claim protects against — is left untouched: the call
+    /// returns `false`, the entry stays `Live`, and the connection is NOT
+    /// closed.
+    #[tokio::test]
+    async fn close_superseded_leaves_promoted_live_generation_open() {
+        let (_server, client, conn) = loopback_quic_connection().await;
+        let peer_id = PeerId([0xBB; 32]);
+        let generation = 3u64;
+        seed_lifecycle_entry(
+            &client,
+            peer_id,
+            generation,
+            conn.clone(),
+            ConnectionLifecycleState::Live,
+        );
+        assert!(
+            conn.close_reason().is_none(),
+            "precondition: connection open"
+        );
+
+        let claimed = client.close_superseded_connection_if_current(&peer_id, generation);
+
+        assert!(!claimed, "a Live generation must not be claimed");
+        assert!(
+            matches!(
+                client
+                    .lifecycle_snapshot_for_generation(&peer_id, generation)
+                    .expect("entry must remain tracked")
+                    .state,
+                ConnectionLifecycleState::Live
+            ),
+            "promoted generation must remain Live"
+        );
+        assert!(
+            conn.close_reason().is_none(),
+            "promoted connection must stay open"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // retire_connection_if_current — stable-id conditional winner eviction
+    //
+    // A caller may hold a *stale observed winner* handle W — the handle it
+    // cloned when W was current — while a concurrent install has since placed
+    // a different, live connection N in the single-slot winner map. Retiring
+    // that stale W observation must evict W alone; it must never tear down N.
+    // The guard is `DashMap::remove_if(|_, c| c.stable_id() == W)`: when the
+    // slot already holds N (stable_id != W) the removal is a no-op and N
+    // survives.
+    //
+    // The race window lives *between* the public read of the winner slot and
+    // the internal `remove_if` — there is no production seam to hook there, so
+    // this drives the scoped retirement directly into the post-race state
+    // (slot already holds N, stale W handle is what is retired) and then
+    // re-checks the survivor through the public `is_peer_connected` /
+    // `get_connection` surface that the fix must keep correct.
+    //
+    // N is deliberately left *untracked* in the lifecycle map. That isolates
+    // the `remove_if` invariant: if retire wrongly evicted N, there is no
+    // survivor for `repromote_surviving_connection` to restore it from, so a
+    // regression to an unconditional peer-keyed `remove` is observable instead
+    // of being silently healed by repromotion.
+    // ─────────────────────────────────────────────────────────────────────
+    #[tokio::test]
+    async fn retire_stale_winner_leaves_concurrent_live_replacement_current() {
+        let (_server_a, endpoint, w_conn) = loopback_quic_connection().await;
+        // A second, independent loopback connection keeps a distinct stable_id
+        // (stable_id is the connection-state pointer). Both endpoint pairs are
+        // retained so each connection's IO driver keeps it healthy.
+        let (_server_b, _client_b, n_conn) = loopback_quic_connection().await;
+        let peer_id = PeerId([0x07; 32]);
+        let w_id = w_conn.stable_id();
+        let n_id = n_conn.stable_id();
+        assert_ne!(
+            w_id, n_id,
+            "precondition: W and N must be distinct connections"
+        );
+
+        // W is the stale observed winner: it is tracked in the lifecycle map ...
+        seed_lifecycle_entry(
+            &endpoint,
+            peer_id,
+            1,
+            w_conn.clone(),
+            ConnectionLifecycleState::Live,
+        );
+        // ... but a concurrent install has since replaced it in the winner slot
+        // with the live N. This is exactly the state the retire path would see
+        // if N landed between the public read and the internal `remove_if`.
+        endpoint.connections.insert(peer_id, n_conn.clone());
+
+        assert!(w_conn.close_reason().is_none(), "precondition: W open");
+        assert!(n_conn.close_reason().is_none(), "precondition: N open");
+        assert_eq!(
+            endpoint
+                .connections
+                .get(&peer_id)
+                .map(|entry| entry.value().stable_id()),
+            Some(n_id),
+            "precondition: winner slot holds N, not W"
+        );
+
+        // Retire the stale W observation. This is the call get_connection /
+        // is_peer_connected make when they find the current entry closed;
+        // invoking it directly removes the timing dependency we cannot inject.
+        let replacement = endpoint.retire_connection_if_current(
+            &peer_id,
+            &w_conn,
+            ConnectionCloseReason::LifecycleCleanup,
+        );
+
+        // The winner slot still holds N: `remove_if` refused to evict an entry
+        // whose stable_id differs from the retired W. Under an unconditional
+        // peer-keyed `remove`, N would be gone here and, untracked in the
+        // lifecycle map, nothing would restore it — this assertion reddens.
+        assert_eq!(
+            endpoint
+                .connections
+                .get(&peer_id)
+                .map(|entry| entry.value().stable_id()),
+            Some(n_id),
+            "concurrent live replacement N must remain the current winner"
+        );
+        // N was untouched: retire must never close a connection it did not own.
+        assert!(
+            n_conn.close_reason().is_none(),
+            "N must remain open after retiring the stale W"
+        );
+        // W alone was retired: its handle is now closed.
+        assert!(
+            w_conn.close_reason().is_some(),
+            "stale winner W must be closed by retirement"
+        );
+        // No phantom promotion overwrote the already-live N.
+        assert!(
+            replacement.is_none(),
+            "no survivor should be promoted while live N already holds the slot"
+        );
+
+        // The public surface agrees the peer is still connected via N. Under an
+        // unconditional remove the slot would be empty, so is_peer_connected
+        // would fall through to a fruitless repromote and report false, and
+        // get_connection would return None — both assertions reddens.
+        assert!(
+            endpoint.is_peer_connected(&peer_id),
+            "is_peer_connected must observe the surviving live N"
+        );
+        let observed = endpoint
+            .get_connection(&peer_id)
+            .expect("get_connection must not error");
+        assert_eq!(
+            observed.map(|conn| conn.stable_id()),
+            Some(n_id),
+            "get_connection must return the surviving live N"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // handle_reader_exit — Live winner reader exit repromotes with ReaderExit
+    //
+    // When the reader task for the *current Live winner* exits and a drained
+    // (Superseded) survivor is still open, the endpoint closes the winner with
+    // the reserved ReaderExit application code, promotes the survivor back to
+    // Live, and reports `ConnectionReaped { close_reason: ReaderExit }`.
+    // The reason mapping is load-bearing: an earlier version reported
+    // `Superseded` here, mislabeling an active reader-exit close as a passive
+    // supersession and corrupting downstream drain/telemetry decisions. This
+    // pins the exact variant a repromoting reader exit must surface.
+    // ─────────────────────────────────────────────────────────────────────
+    #[tokio::test]
+    async fn reader_exit_of_live_winner_repromotes_with_reader_exit_reason() {
+        let (_server_a, endpoint, w_conn) = loopback_quic_connection().await;
+        let (_server_b, _client_b, s_conn) = loopback_quic_connection().await;
+        let peer_id = PeerId([0x08; 32]);
+        let w_id = w_conn.stable_id();
+        let s_id = s_conn.stable_id();
+        assert_ne!(w_id, s_id, "precondition: winner and survivor are distinct");
+
+        // W is the current Live winner; S is a drained survivor that an earlier
+        // supersession left open for its short drain window. Seeding both
+        // directly fixes the exact state the reader-exit path branches on.
+        let w_generation = 5u64;
+        endpoint.connection_lifecycle.write().insert(
+            peer_id,
+            vec![
+                TrackedConnection {
+                    connection: s_conn.clone(),
+                    generation: w_generation - 1,
+                    established_at_unix_ms: 0,
+                    connection_family_id: [0u8; 32],
+                    connection_id: [0u8; 32],
+                    state: ConnectionLifecycleState::Superseded {
+                        replaced_by_generation: w_generation,
+                    },
+                },
+                TrackedConnection {
+                    connection: w_conn.clone(),
+                    generation: w_generation,
+                    established_at_unix_ms: 1,
+                    connection_family_id: [0u8; 32],
+                    connection_id: [0u8; 32],
+                    state: ConnectionLifecycleState::Live,
+                },
+            ],
+        );
+        // W occupies the winner slot, so the reader-exit path takes the
+        // Live-and-current branch — not the "a different live connection has
+        // already replaced it" branch that reports Superseded.
+        endpoint.connections.insert(peer_id, w_conn.clone());
+
+        assert!(w_conn.close_reason().is_none(), "precondition: W open");
+        assert!(s_conn.close_reason().is_none(), "precondition: S open");
+
+        let outcome = endpoint.handle_reader_exit(&peer_id, w_generation, w_id);
+
+        // A survivor was found, so the peer stays connected: ConnectionReaped,
+        // not PeerDisconnected.
+        let ReaderExitOutcome::ConnectionReaped { close_reason } = outcome else {
+            panic!("expected ConnectionReaped for a repromoting reader exit, got {outcome:?}");
+        };
+        // The reason MUST be ReaderExit. A regression that reports Superseded
+        // for an active close of the Live winner reddens here.
+        assert_eq!(
+            close_reason,
+            ConnectionCloseReason::ReaderExit,
+            "Live winner reader exit repromoting a survivor must report ReaderExit"
+        );
+
+        // The survivor was promoted back to Live and now holds the winner slot.
+        assert_eq!(
+            endpoint
+                .connections
+                .get(&peer_id)
+                .map(|entry| entry.value().stable_id()),
+            Some(s_id),
+            "survivor S must be promoted into the winner slot"
+        );
+        assert!(
+            s_conn.close_reason().is_none(),
+            "promoted survivor S must remain open"
+        );
+        assert!(
+            w_conn.close_reason().is_some(),
+            "exited Live winner W must be closed"
+        );
+        assert!(
+            matches!(
+                endpoint
+                    .lifecycle_snapshot_for_generation(&peer_id, w_generation - 1)
+                    .expect("survivor must remain tracked")
+                    .state,
+                ConnectionLifecycleState::Live
+            ),
+            "survivor S must be promoted back to Live"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // accept_connection — generation-bound ticket resolution
+    //
+    // A pending accept ticket carries the generation it was raised against.
+    // When that generation has since been superseded (G1 no longer Live while
+    // a newer G2 is the current winner), the ticket must NOT be satisfied by
+    // handing out the current G2 connection: a caller waiting on G1 would
+    // silently receive a different generation's handle. Production resolves
+    // the handle directly from the lifecycle entry matching
+    // (ticket.generation, Live) under a read lock, so a stale ticket finds no
+    // Live entry and is skipped instead of falling back to the current winner.
+    //
+    // Two peers make the regression observable through the public return: a
+    // stale G1 ticket for peer A (superseded; A's current winner is G2_A) is
+    // queued ahead of a live ticket for peer B (G2_B). If accept wrongly
+    // resolved the stale G1 ticket to A's current winner, the first accept
+    // would return peer A / G2_A; correctly it skips G1 and returns peer B /
+    // G2_B for the live ticket only.
+    // ─────────────────────────────────────────────────────────────────────
+    #[tokio::test]
+    async fn accept_skips_stale_generation_ticket_and_binds_only_live_generation() {
+        let (_sut_server, endpoint, g1_conn) = loopback_quic_connection().await;
+        let (_s2, _c2, g2_a_conn) = loopback_quic_connection().await;
+        let (_s3, _c3, g2_b_conn) = loopback_quic_connection().await;
+        let peer_a = PeerId([0xA1; 32]);
+        let peer_b = PeerId([0xB2; 32]);
+        let g2_a_id = g2_a_conn.stable_id();
+        let g2_b_id = g2_b_conn.stable_id();
+        assert_ne!(
+            g2_a_id, g2_b_id,
+            "precondition: the two current winners must differ"
+        );
+
+        // Peer A: G1 was superseded by G2_A, which is now the Live winner.
+        endpoint.connection_lifecycle.write().insert(
+            peer_a,
+            vec![
+                TrackedConnection {
+                    connection: g1_conn.clone(),
+                    generation: 1,
+                    established_at_unix_ms: 0,
+                    connection_family_id: [0u8; 32],
+                    connection_id: [0u8; 32],
+                    state: ConnectionLifecycleState::Superseded {
+                        replaced_by_generation: 2,
+                    },
+                },
+                TrackedConnection {
+                    connection: g2_a_conn.clone(),
+                    generation: 2,
+                    established_at_unix_ms: 1,
+                    connection_family_id: [0u8; 32],
+                    connection_id: [0u8; 32],
+                    state: ConnectionLifecycleState::Live,
+                },
+            ],
+        );
+        endpoint.connections.insert(peer_a, g2_a_conn.clone());
+
+        // Peer B: a single Live generation, the current winner.
+        endpoint.connection_lifecycle.write().insert(
+            peer_b,
+            vec![TrackedConnection {
+                connection: g2_b_conn.clone(),
+                generation: 1,
+                established_at_unix_ms: 0,
+                connection_family_id: [0u8; 32],
+                connection_id: [0u8; 32],
+                state: ConnectionLifecycleState::Live,
+            }],
+        );
+        endpoint.connections.insert(peer_b, g2_b_conn.clone());
+
+        // Queue the stale G1 ticket for peer A FIRST, then the live ticket for B.
+        {
+            let mut queue = endpoint.pending_accepts.lock();
+            queue.push_back(PendingAccept {
+                peer_id: peer_a,
+                generation: 1,
+            });
+            queue.push_back(PendingAccept {
+                peer_id: peer_b,
+                generation: 1,
+            });
+        }
+
+        // accept must skip the stale G1 ticket (no Live generation-1 entry for
+        // A) and resolve only the live ticket — returning peer B / G2_B. A
+        // regression that resolves the stale ticket to A's current winner
+        // returns peer A / G2_A on the first accept instead.
+        let (returned_peer, returned_conn) = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            endpoint.accept_connection(),
+        )
+        .await
+        .expect("accept must resolve: a live ticket is queued")
+        .expect("accept must succeed");
+
+        assert_eq!(
+            returned_peer, peer_b,
+            "stale G1 ticket must be skipped; only the live G2_B ticket may resolve"
+        );
+        assert_eq!(
+            returned_conn.stable_id(),
+            g2_b_id,
+            "must bind peer B's live G2_B connection, not peer A's current G2_A winner"
+        );
+        // The stale G1 ticket was consumed by the skip — not left queued for a
+        // later accept to wrongly satisfy with the current winner.
+        assert!(
+            endpoint.pending_accepts.lock().is_empty(),
+            "stale G1 ticket must be consumed by the skip, not left queued"
+        );
     }
 }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -13212,6 +13212,10 @@ mod tests {
     /// peer (candidate replacement marks the older one Superseded while it stays
     /// open); `handle_reader_exit` is invoked directly on the current Live
     /// winner. No reader tasks, no broadcast polling, no wall-clock races.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
     #[tokio::test]
     async fn reader_exit_winner_repromotes_open_superseded_survivor_keeps_peer_routable() {
         async fn build_endpoint() -> P2pEndpoint {
@@ -13496,6 +13500,10 @@ mod tests {
     /// Deterministic: two real authenticated connections (Live winner + open
     /// Superseded survivor); the winner is closed directly; the read path is
     /// then exercised. No reader tasks, no polling, no wall-clock races.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
     #[tokio::test]
     async fn get_connection_lazy_repromotes_open_survivor_when_winner_dies_before_reader_exit() {
         async fn build_endpoint() -> P2pEndpoint {
@@ -13639,6 +13647,10 @@ mod tests {
     /// replacement) is registered in `self.inner`; the older outer/reader/direct
     /// state is installed directly. No reader tasks are spawned, no polling, no
     /// wall-clock races. If the guard were dropped, every assertion below fails.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
     #[tokio::test]
     async fn if_unroutable_cleanup_is_noop_when_inner_replacement_is_live() {
         async fn build_endpoint() -> P2pEndpoint {
@@ -13870,6 +13882,10 @@ mod tests {
     /// Deterministic: two real authenticated QUIC connections registered in
     /// `self.inner`; older outer/reader/direct state installed directly. No
     /// reader tasks, no polling, no wall-clock races.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
     #[tokio::test]
     async fn cleanup_connection_generation_closes_only_failed_generation_preserving_live_replacement()
      {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -2338,6 +2338,12 @@ impl std::fmt::Display for HolePunchAwaitError {
     }
 }
 
+#[derive(Clone, Copy)]
+enum CleanupScope {
+    Peer,
+    IfUnroutable,
+}
+
 /// Shared cleanup logic for removing a peer from all tracking structures.
 ///
 /// Used by both `P2pEndpoint::cleanup_connection()` and the background reaper
@@ -2358,14 +2364,23 @@ async fn do_cleanup_connection(
     peer_id: &PeerId,
     reason: DisconnectReason,
     close_reason: ConnectionCloseReason,
+    scope: CleanupScope,
 ) -> bool {
-    let lifecycle_snapshot = inner
-        .get_connection(peer_id)
-        .ok()
-        .flatten()
-        .and_then(|connection| {
-            inner.connection_snapshot_by_stable_id(peer_id, connection.stable_id())
-        });
+    let if_unroutable = matches!(scope, CleanupScope::IfUnroutable);
+    if if_unroutable && inner.is_peer_connected(peer_id) {
+        return false;
+    }
+    let lifecycle_snapshot = if if_unroutable {
+        None
+    } else {
+        inner
+            .get_connection(peer_id)
+            .ok()
+            .flatten()
+            .and_then(|connection| {
+                inner.connection_snapshot_by_stable_id(peer_id, connection.stable_id())
+            })
+    };
 
     if let Some(snapshot) = lifecycle_snapshot {
         emit_peer_lifecycle_event(
@@ -2379,8 +2394,9 @@ async fn do_cleanup_connection(
         );
     }
 
-    let _ = inner.remove_connection_with_reason(peer_id, close_reason);
-    direct_path_statuses.write().remove(peer_id);
+    if !if_unroutable {
+        let _ = inner.remove_connection_with_reason(peer_id, close_reason);
+    }
 
     if let Some(snapshot) = lifecycle_snapshot {
         emit_peer_lifecycle_event(
@@ -2402,14 +2418,38 @@ async fn do_cleanup_connection(
     // Tear down all background readers for this peer. Cooperative cancel first
     // (allows any in-flight `read_to_end()` to complete and deliver its bytes),
     // then `abort()` as a backstop in case a reader is wedged.
-    if let Some(handles) = reader_handles.write().await.remove(peer_id) {
+    let handles = if if_unroutable {
+        let mut handles = reader_handles.write().await;
+        if inner.is_peer_connected(peer_id) {
+            return false;
+        }
+        handles.remove(peer_id)
+    } else {
+        reader_handles.write().await.remove(peer_id)
+    };
+    if let Some(handles) = handles {
         for handle in handles {
             handle.cancel.cancel();
             handle.abort_handle.abort();
         }
     }
 
-    let removed = remove_connected_peer(connected_peers, stats, event_tx, peer_id, reason).await;
+    let removed = if if_unroutable {
+        remove_connected_peer_if_unroutable(
+            connected_peers,
+            inner,
+            stats,
+            event_tx,
+            peer_id,
+            reason,
+        )
+        .await
+    } else {
+        remove_connected_peer(connected_peers, stats, event_tx, peer_id, reason).await
+    };
+    if removed {
+        direct_path_statuses.write().remove(peer_id);
+    }
     if removed {
         info!("Cleaned up connection for peer {:?}", peer_id);
     }
@@ -2523,7 +2563,38 @@ async fn remove_connected_peer(
     reason: DisconnectReason,
 ) -> bool {
     let removed = connected_peers.write().await.remove(peer_id);
+    record_connected_peer_removed(stats, event_tx, peer_id, reason, removed).await
+}
 
+/// Remove the outer peer record only while the inner transport remains
+/// unroutable. Holding the outer write lock across the final inner check makes
+/// a concurrent registration land after this removal rather than be erased by
+/// stale cleanup.
+async fn remove_connected_peer_if_unroutable(
+    connected_peers: &RwLock<HashMap<PeerId, PeerConnection>>,
+    inner: &NatTraversalEndpoint,
+    stats: &RwLock<EndpointStats>,
+    event_tx: &broadcast::Sender<P2pEvent>,
+    peer_id: &PeerId,
+    reason: DisconnectReason,
+) -> bool {
+    let removed = {
+        let mut peers = connected_peers.write().await;
+        if inner.is_peer_connected(peer_id) {
+            return false;
+        }
+        peers.remove(peer_id)
+    };
+    record_connected_peer_removed(stats, event_tx, peer_id, reason, removed).await
+}
+
+async fn record_connected_peer_removed(
+    stats: &RwLock<EndpointStats>,
+    event_tx: &broadcast::Sender<P2pEvent>,
+    peer_id: &PeerId,
+    reason: DisconnectReason,
+    removed: Option<PeerConnection>,
+) -> bool {
     if let Some(peer_conn) = removed {
         {
             let mut s = stats.write().await;
@@ -6529,6 +6600,67 @@ impl P2pEndpoint {
             peer_id,
             reason,
             close_reason,
+            CleanupScope::Peer,
+        )
+        .await;
+    }
+
+    /// Close one failed transport generation while preserving a replacement
+    /// that may have registered after the failure was observed.
+    async fn cleanup_connection_generation(
+        &self,
+        peer_id: &PeerId,
+        stable_id: usize,
+        reason: DisconnectReason,
+    ) {
+        let Some(snapshot) = self
+            .inner
+            .connection_snapshot_by_stable_id(peer_id, stable_id)
+        else {
+            return;
+        };
+        let close_reason = close_reason_for_disconnect(&reason);
+        emit_peer_lifecycle_event(
+            &self.peer_event_tx,
+            self.peer_event_channels.as_ref(),
+            *peer_id,
+            PeerLifecycleEvent::Closing {
+                generation: snapshot.generation,
+                reason: close_reason,
+            },
+        );
+        if !self
+            .inner
+            .remove_connection_generation_with_reason(peer_id, stable_id, close_reason)
+        {
+            return;
+        }
+        emit_peer_lifecycle_event(
+            &self.peer_event_tx,
+            self.peer_event_channels.as_ref(),
+            *peer_id,
+            PeerLifecycleEvent::Closed {
+                generation: snapshot.generation,
+                reason: close_reason,
+            },
+        );
+        fail_ack_waiters_for_connection(self.ack_waiters.as_ref(), stable_id, close_reason);
+
+        do_cleanup_connection(
+            &*self.connected_peers,
+            &*self.inner,
+            &*self.reader_handles,
+            &*self.direct_path_statuses,
+            &*self.stats,
+            &self.event_tx,
+            &self.peer_event_tx,
+            self.peer_event_channels.as_ref(),
+            self.peer_event_generations.as_ref(),
+            self.ack_waiters.as_ref(),
+            peer_id,
+            reason,
+            close_reason,
+            CleanupScope::IfUnroutable,
         )
         .await;
     }
@@ -7012,12 +7144,9 @@ impl P2pEndpoint {
         // the same (peer, stable_id) — vanishingly unlikely but defensive —
         // gets a clean slate.
         self.ack_liveness.forget(peer_id, stable_id);
-        // cleanup_connection is the source-of-truth disconnect path. With
-        // DisconnectReason::LivenessTimeout it threads LivenessTimeout through
-        // every layer: lifecycle events, inner state machine, ACK waiters,
-        // reader handles, connected_peers, stats, and the user-facing event
-        // channel. After this returns, `is_connected(peer_id)` is false.
-        self.cleanup_connection(&peer_id, DisconnectReason::LivenessTimeout)
+        // Retire only the generation that accumulated the failures. A newer
+        // winner may have registered since the threshold was observed.
+        self.cleanup_connection_generation(&peer_id, stable_id, DisconnectReason::LivenessTimeout)
             .await;
     }
 
@@ -8097,6 +8226,7 @@ impl P2pEndpoint {
             .read()
             .await
             .values()
+            .filter(|peer| self.inner.is_peer_connected(&peer.peer_id))
             .cloned()
             .collect()
     }
@@ -8104,6 +8234,7 @@ impl P2pEndpoint {
     /// Check if a peer is connected
     pub async fn is_connected(&self, peer_id: &PeerId) -> bool {
         self.connected_peers.read().await.contains_key(peer_id)
+            && self.inner.is_peer_connected(peer_id)
     }
 
     /// Check if a peer is authenticated
@@ -8112,8 +8243,8 @@ impl P2pEndpoint {
             .read()
             .await
             .get(peer_id)
-            .map(|p| p.authenticated)
-            .unwrap_or(false)
+            .is_some_and(|peer| peer.authenticated)
+            && self.inner.is_peer_connected(peer_id)
     }
 
     // === Lifecycle ===
@@ -8637,9 +8768,13 @@ impl P2pEndpoint {
     /// drain window. This lets in-flight request/ACK streams on the old
     /// generation finish before the reader exits at its next accept boundary.
     fn schedule_reader_generation_cancel(&self, peer_id: PeerId, generation: u64, after: Duration) {
+        let inner = Arc::clone(&self.inner);
         let reader_handles = Arc::clone(&self.reader_handles);
         tokio::spawn(async move {
             tokio::time::sleep(after).await;
+            if !inner.close_superseded_connection_if_current(&peer_id, generation) {
+                return;
+            }
             let handles = reader_handles.read().await;
             if let Some(handle) = handles
                 .get(&peer_id)
@@ -9400,12 +9535,14 @@ impl P2pEndpoint {
                         );
                         continue;
                     }
-                    crate::nat_traversal_api::ReaderExitOutcome::ConnectionReaped => {
+                    crate::nat_traversal_api::ReaderExitOutcome::ConnectionReaped {
+                        close_reason,
+                    } => {
                         if let Some(snapshot) = snapshot_before {
                             fail_ack_waiters_for_connection(
                                 ack_waiters.as_ref(),
                                 snapshot.stable_id,
-                                ConnectionCloseReason::Superseded,
+                                close_reason,
                             );
                             match snapshot.state {
                                 crate::connection_lifecycle::ConnectionLifecycleState::Superseded { .. }
@@ -9416,7 +9553,7 @@ impl P2pEndpoint {
                                         peer_id,
                                         PeerLifecycleEvent::Closed {
                                             generation: snapshot.generation,
-                                            reason: ConnectionCloseReason::Superseded,
+                                            reason: close_reason,
                                         },
                                     );
                                 }
@@ -9424,11 +9561,51 @@ impl P2pEndpoint {
                                 | crate::connection_lifecycle::ConnectionLifecycleState::Closed { .. } => {}
                             }
                         }
+                        // `ConnectionReaped` means this generation lost the
+                        // connection race (superseded / closing / closed). That
+                        // must NOT suppress peer-wide cleanup unless a live
+                        // replacement reader/connection actually exists.
+                        //
+                        // Under supersession churn the winner map can already
+                        // point at a dead connection by the time the *final*
+                        // reader exits; the previous unconditional skip left the
+                        // peer stranded in `connected_peers` (and therefore
+                        // `is_peer_connected()`-true for x0x reconnect
+                        // suppression) with no reader left to drive cleanup.
+                        //
+                        // Defer only when a surviving reader remains
+                        // (`!last_reader`) or a live connection still occupies
+                        // the winner map (`is_peer_connected`) — i.e. a genuine
+                        // replacement exists. Otherwise run the normal disconnect
+                        // path so the peer is removed and reconnect is unsuppressed.
+                        if !last_reader || inner.is_peer_connected(&peer_id) {
+                            debug!(
+                                "Reader task exited for peer {:?} (generation {}, conn stable_id {}); superseded connection reaped, live replacement remains",
+                                peer_id, generation, conn_stable_id
+                            );
+                            continue;
+                        }
                         debug!(
-                            "Reader task exited for peer {:?} (generation {}, conn stable_id {}); superseded connection reaped",
+                            "Last reader task for peer {:?} (generation {}, conn stable_id {}) reaped with no live replacement — triggering peer cleanup",
                             peer_id, generation, conn_stable_id
                         );
-                        continue;
+                        do_cleanup_connection(
+                            &*connected_peers,
+                            &*inner,
+                            &*reader_handles,
+                            &*direct_path_statuses,
+                            &*stats,
+                            &event_tx,
+                            &peer_event_tx,
+                            peer_event_channels.as_ref(),
+                            peer_event_generations.as_ref(),
+                            ack_waiters.as_ref(),
+                            &peer_id,
+                            DisconnectReason::ConnectionLost,
+                            ConnectionCloseReason::ReaderExit,
+                            CleanupScope::IfUnroutable,
+                        )
+                        .await;
                     }
                     crate::nat_traversal_api::ReaderExitOutcome::PeerDisconnected {
                         close_reason,
@@ -9469,6 +9646,14 @@ impl P2pEndpoint {
                             continue;
                         }
 
+                        if inner.is_peer_connected(&peer_id) {
+                            debug!(
+                                "Last reader exited for peer {:?}, but a replacement registered before cleanup",
+                                peer_id
+                            );
+                            continue;
+                        }
+
                         debug!(
                             "Last live reader task for peer {:?} (generation {}, conn stable_id {}) exited — triggering cleanup",
                             peer_id, generation, conn_stable_id
@@ -9488,6 +9673,7 @@ impl P2pEndpoint {
                             &peer_id,
                             DisconnectReason::ConnectionLost,
                             close_reason,
+                            CleanupScope::IfUnroutable,
                         )
                         .await;
                     }
@@ -9561,6 +9747,7 @@ impl P2pEndpoint {
                         peer_id,
                         DisconnectReason::Timeout,
                         ConnectionCloseReason::TimedOut,
+                        CleanupScope::IfUnroutable,
                     )
                     .await;
                 }
@@ -13004,6 +13191,909 @@ mod tests {
         assert_eq!(accepted.0, a_id, "app stream from the connected peer");
         send_a.finish().ok();
         drop(starved_send);
+        a.shutdown().await;
+        b.shutdown().await;
+    }
+    /// Regression for the winner-map repromotion defect (x0x "dead pair").
+    ///
+    /// When a peer has two tracked connections — a Live *winner* occupying the
+    /// single-slot winner map and an open *Superseded* survivor still draining in
+    /// the lifecycle Vec — the winner's reader exiting must NOT strand outbound
+    /// routability. The endpoint must repromote the best usable survivor back to
+    /// Live and re-alias the winner map onto it, reporting `ConnectionReaped`
+    /// (not `PeerDisconnected`).
+    ///
+    /// Pre-fix, the Live branch of `handle_reader_exit` unconditionally removed
+    /// the peer from the winner map and returned `PeerDisconnected`, leaving the
+    /// still-open Superseded connection stranded: outbound sends failed while the
+    /// survivor kept delivering inbound data and reconnect stayed suppressed.
+    ///
+    /// Deterministic: two real authenticated connections are registered for one
+    /// peer (candidate replacement marks the older one Superseded while it stays
+    /// open); `handle_reader_exit` is invoked directly on the current Live
+    /// winner. No reader tasks, no broadcast polling, no wall-clock races.
+    #[tokio::test]
+    async fn reader_exit_winner_repromotes_open_superseded_survivor_keeps_peer_routable() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        let b_addr = localhost_addr(b.local_addr().expect("b bound"));
+        let b_id = b.peer_id();
+
+        // Two distinct, fully-authenticated QUIC connections from a -> b.
+        // `attempt_direct_handshake` performs only the handshake — it does NOT
+        // register the connection or spawn a reader — so lifecycle registration
+        // is controlled explicitly below (zero real-reader interference).
+        let c0 = tokio::time::timeout(Duration::from_secs(10), a.attempt_direct_handshake(b_addr))
+            .await
+            .expect("c0 handshake timeout")
+            .expect("c0 handshake");
+        let c1 = tokio::time::timeout(Duration::from_secs(10), a.attempt_direct_handshake(b_addr))
+            .await
+            .expect("c1 handshake timeout")
+            .expect("c1 handshake");
+        let stable0 = c0.stable_id();
+        let stable1 = c1.stable_id();
+        assert_ne!(stable0, stable1, "two independent connections required");
+
+        // Probe clones share the underlying connection state, so their
+        // close_reason() reports whether the lifecycle code closed the
+        // superseded connection (it must not — the survivor stays open).
+        let c0_probe = c0.clone();
+        let c1_probe = c1.clone();
+
+        // Register both generations for the same peer: candidate replacement
+        // marks the older connection Superseded while it remains open; the
+        // newer one becomes the Live winner aliased by the winner map.
+        a.inner
+            .add_connection_with_outcome(b_id, c0)
+            .expect("register c0");
+        a.inner
+            .add_connection_with_outcome(b_id, c1)
+            .expect("register c1");
+
+        let winner_conn = a
+            .inner
+            .get_connection(&b_id)
+            .expect("get_connection ok")
+            .expect("a winner is live");
+        let winner_stable = winner_conn.stable_id();
+        let other_stable = if winner_stable == stable0 {
+            stable1
+        } else {
+            stable0
+        };
+        let winner_snap = a
+            .inner
+            .connection_snapshot_by_stable_id(&b_id, winner_stable)
+            .expect("winner lifecycle snapshot");
+        let other_snap = a
+            .inner
+            .connection_snapshot_by_stable_id(&b_id, other_stable)
+            .expect("non-winner lifecycle snapshot");
+        assert!(
+            matches!(
+                winner_snap.state,
+                crate::connection_lifecycle::ConnectionLifecycleState::Live
+            ),
+            "winner must be Live, got {:?}",
+            winner_snap.state
+        );
+        assert!(
+            matches!(
+                other_snap.state,
+                crate::connection_lifecycle::ConnectionLifecycleState::Superseded { .. }
+            ),
+            "candidate replacement must mark the older connection Superseded, got {:?}",
+            other_snap.state
+        );
+        let other_probe = if winner_stable == stable0 {
+            c1_probe
+        } else {
+            c0_probe
+        };
+        assert!(
+            other_probe.close_reason().is_none(),
+            "the Superseded connection must remain OPEN for drain (close_reason must be None)"
+        );
+
+        // (1) The current Live winner's reader exits while the open Superseded
+        // survivor is still tracked. The fix must repromote the survivor instead
+        // of clearing the winner map and reporting PeerDisconnected.
+        let outcome = a
+            .inner
+            .handle_reader_exit(&b_id, winner_snap.generation, winner_stable);
+        assert!(
+            matches!(
+                outcome,
+                crate::nat_traversal_api::ReaderExitOutcome::ConnectionReaped { .. }
+            ),
+            "winner exit with an open survivor must reap (repromote), not disconnect; got {:?}",
+            outcome
+        );
+
+        // The older, previously-Superseded connection is repromoted to Live.
+        let repromoted = a
+            .inner
+            .connection_snapshot_by_stable_id(&b_id, other_stable)
+            .expect("survivor snapshot after repromotion");
+        assert!(
+            matches!(
+                repromoted.state,
+                crate::connection_lifecycle::ConnectionLifecycleState::Live
+            ),
+            "surviving connection must be repromoted to Live, got {:?}",
+            repromoted.state
+        );
+
+        // The single-slot winner map is restored onto the survivor, so outbound
+        // routability survives the winner's death.
+        let routed = a
+            .inner
+            .get_connection(&b_id)
+            .expect("get_connection ok")
+            .expect("a routable connection must remain");
+        assert_eq!(
+            routed.stable_id(),
+            other_stable,
+            "winner map must alias the repromoted survivor"
+        );
+        assert!(
+            a.inner.is_peer_connected(&b_id),
+            "peer must remain routable after the winner reader exits"
+        );
+
+        // (2) Regression guard: repromotion must not break the normal
+        // last-reader teardown. When the repromoted survivor itself exits with no
+        // further replacement, the endpoint cleanly disconnects.
+        let final_outcome = a
+            .inner
+            .handle_reader_exit(&b_id, other_snap.generation, other_stable);
+        assert!(
+            matches!(
+                final_outcome,
+                crate::nat_traversal_api::ReaderExitOutcome::PeerDisconnected { .. }
+            ),
+            "final survivor exit with no replacement must disconnect; got {:?}",
+            final_outcome
+        );
+        assert!(
+            !a.inner.is_peer_connected(&b_id),
+            "peer must be unreachable after the final disconnect"
+        );
+        assert!(
+            a.inner.get_connection(&b_id).ok().flatten().is_none(),
+            "winner map must be cleared on the final disconnect"
+        );
+
+        a.shutdown().await;
+        b.shutdown().await;
+    }
+
+    /// Regression for the public connection-status gating introduced by the
+    /// atomic-connection-lifecycle hardening.
+    ///
+    /// A peer can be stranded in the outer `connected_peers` map while the
+    /// inner `NatTraversalEndpoint` has no live connection for it (reader-exit
+    /// stranding, supersession churn, or a stale map entry). Before the fix,
+    /// the three public async accessors surfaced such a peer purely from the
+    /// outer-map entry. They must instead gate on `inner.is_peer_connected`, so
+    /// a peer with no routable inner connection is never reported as present,
+    /// connected, or authenticated.
+    ///
+    /// Deterministic: no real peer connection is established. The stranded
+    /// entry is installed through the production `register_connected_peer`
+    /// helper (which writes only the outer map + stats/events, never the inner
+    /// endpoint), then all three accessors are asserted absent.
+    #[tokio::test]
+    async fn status_surface_ignores_peer_stranded_in_outer_connected_map() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+
+        // A synthetic peer `a` has never formed any inner connection with.
+        let stranded_id = PeerId([0x42; 32]);
+        assert_ne!(
+            stranded_id,
+            a.peer_id(),
+            "fixture: synthetic peer id must not collide with the endpoint's own id"
+        );
+
+        // Install the peer ONLY in the outer connected_peers map. The helper
+        // writes the outer map (+ stats/events) but never registers a
+        // connection in self.inner, reproducing the stranded state. The entry
+        // is deliberately marked authenticated to prove authentication is gated
+        // on a live connection rather than on the outer-map flag.
+        a.register_connected_peer(PeerConnection {
+            peer_id: stranded_id,
+            remote_addr: TransportAddr::Udp(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                9,
+            )),
+            traversal_method: TraversalMethod::Direct,
+            side: Side::Client,
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        })
+        .await;
+
+        // Precondition: the stranded state is real — the outer map holds the
+        // entry while the inner endpoint reports no routable connection.
+        assert!(
+            a.connected_peers.read().await.contains_key(&stranded_id),
+            "fixture: stranded peer must be present in the outer connected_peers map"
+        );
+        assert!(
+            !a.inner.is_peer_connected(&stranded_id),
+            "fixture: inner endpoint must have no live connection for the stranded peer"
+        );
+
+        // (1) connected_peers() must filter out peers with no inner connection.
+        let snapshot = a.connected_peers().await;
+        assert!(
+            !snapshot.iter().any(|p| p.peer_id == stranded_id),
+            "connected_peers() must not surface a peer stranded in the outer map; \
+             snapshot contained {:?}",
+            snapshot.iter().map(|p| p.peer_id).collect::<Vec<_>>()
+        );
+
+        // (2) is_connected() must be false despite the outer-map entry.
+        assert!(
+            !a.is_connected(&stranded_id).await,
+            "is_connected() must be false for a peer with no live inner connection, \
+             even when present in the outer connected_peers map"
+        );
+
+        // (3) is_authenticated() must be false even though the outer entry is
+        //     marked authenticated — auth status is gated on a live connection.
+        assert!(
+            !a.is_authenticated(&stranded_id).await,
+            "is_authenticated() must be false for a peer with no live inner connection, \
+             even when the outer-map entry carries authenticated=true"
+        );
+
+        a.shutdown().await;
+    }
+
+    /// Regression for the secondary (lazy) read path of winner-map self-heal.
+    ///
+    /// If the current winner connection dies *before* its reader task reports
+    /// the exit (e.g. a transport close races ahead of `handle_reader_exit`),
+    /// the single-slot winner map is left holding a dead connection while an
+    /// open Superseded survivor is still draining in the lifecycle Vec. A
+    /// subsequent read via `get_connection` / `is_peer_connected` must lazily
+    /// evict the dead winner and repromote the open survivor rather than report
+    /// the peer as unreachable (silent pre-reader-exit eviction).
+    ///
+    /// Deterministic: two real authenticated connections (Live winner + open
+    /// Superseded survivor); the winner is closed directly; the read path is
+    /// then exercised. No reader tasks, no polling, no wall-clock races.
+    #[tokio::test]
+    async fn get_connection_lazy_repromotes_open_survivor_when_winner_dies_before_reader_exit() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        let b_addr = localhost_addr(b.local_addr().expect("b bound"));
+        let b_id = b.peer_id();
+
+        let c0 = tokio::time::timeout(Duration::from_secs(10), a.attempt_direct_handshake(b_addr))
+            .await
+            .expect("c0 handshake timeout")
+            .expect("c0 handshake");
+        let c1 = tokio::time::timeout(Duration::from_secs(10), a.attempt_direct_handshake(b_addr))
+            .await
+            .expect("c1 handshake timeout")
+            .expect("c1 handshake");
+        let stable0 = c0.stable_id();
+        let stable1 = c1.stable_id();
+        assert_ne!(stable0, stable1, "two independent connections required");
+
+        // Register both: the newer connection wins (Live, aliased by the winner
+        // map); the older is Superseded but left OPEN for drain.
+        a.inner
+            .add_connection_with_outcome(b_id, c0)
+            .expect("register c0");
+        a.inner
+            .add_connection_with_outcome(b_id, c1)
+            .expect("register c1");
+
+        let winner = a
+            .inner
+            .get_connection(&b_id)
+            .expect("get_connection ok")
+            .expect("a winner is live");
+        let winner_stable = winner.stable_id();
+        let survivor_stable = if winner_stable == stable0 {
+            stable1
+        } else {
+            stable0
+        };
+        let survivor_snap = a
+            .inner
+            .connection_snapshot_by_stable_id(&b_id, survivor_stable)
+            .expect("survivor lifecycle snapshot");
+        assert!(
+            matches!(
+                survivor_snap.state,
+                crate::connection_lifecycle::ConnectionLifecycleState::Superseded { .. }
+            ),
+            "precondition: older connection must be Superseded, got {:?}",
+            survivor_snap.state
+        );
+
+        // Kill the winner directly — BEFORE any reader-exit is reported. The
+        // winner map now aliases a dead connection while the survivor remains
+        // open in the lifecycle Vec.
+        winner.close(crate::VarInt::from_u32(0), b"test winner pre-exit death");
+        assert!(
+            winner.close_reason().is_some(),
+            "fixture: winner must report closed immediately after explicit close"
+        );
+
+        // Secondary read path: get_connection must lazily evict the dead winner
+        // and repromote the open survivor — NOT return None.
+        let healed = a
+            .inner
+            .get_connection(&b_id)
+            .expect("get_connection ok")
+            .expect("lazy self-heal must repromote the open survivor, not report None");
+        assert_eq!(
+            healed.stable_id(),
+            survivor_stable,
+            "lazy read must repromote the open Superseded survivor into the winner map"
+        );
+        assert!(
+            healed.close_reason().is_none(),
+            "repromoted survivor must be open (routable)"
+        );
+
+        // The winner map and connection-status surface now reflect the survivor.
+        let again = a
+            .inner
+            .get_connection(&b_id)
+            .expect("get_connection ok")
+            .expect("winner map must hold the repromoted survivor");
+        assert_eq!(
+            again.stable_id(),
+            survivor_stable,
+            "winner map must alias the repromoted survivor on repeat reads"
+        );
+        assert!(
+            a.inner.is_peer_connected(&b_id),
+            "is_peer_connected must report true via the repromoted survivor"
+        );
+
+        // The repromoted survivor's lifecycle state advanced to Live.
+        let repromoted_snap = a
+            .inner
+            .connection_snapshot_by_stable_id(&b_id, survivor_stable)
+            .expect("survivor snapshot after lazy repromotion");
+        assert!(
+            matches!(
+                repromoted_snap.state,
+                crate::connection_lifecycle::ConnectionLifecycleState::Live
+            ),
+            "survivor must be repromoted to Live by the lazy read path, got {:?}",
+            repromoted_snap.state
+        );
+
+        a.shutdown().await;
+        b.shutdown().await;
+    }
+    /// Regression: `do_cleanup_connection(... CleanupScope::IfUnroutable)` must
+    /// be a complete no-op when a live inner replacement exists for the peer,
+    /// even though an older outer `connected_peers` entry, a reader-task handle,
+    /// and a direct-path status are all still installed.
+    ///
+    /// The reader-exit and stale-reaper paths run cleanup with
+    /// `CleanupScope::IfUnroutable`. If a new connection has registered in the
+    /// inner endpoint (making `inner.is_peer_connected` true) by the time the
+    /// reaper fires, tearing down the outer/reader/direct state would erase the
+    /// freshly registered connection's bookkeeping and emit a spurious
+    /// `PeerDisconnected`. The `is_peer_connected` guard — checked under each
+    /// held lock — keeps cleanup inert.
+    ///
+    /// Deterministic: one real authenticated QUIC connection (the live
+    /// replacement) is registered in `self.inner`; the older outer/reader/direct
+    /// state is installed directly. No reader tasks are spawned, no polling, no
+    /// wall-clock races. If the guard were dropped, every assertion below fails.
+    #[tokio::test]
+    async fn if_unroutable_cleanup_is_noop_when_inner_replacement_is_live() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        let b_addr = localhost_addr(b.local_addr().expect("b bound"));
+        let b_id = b.peer_id();
+
+        // Live inner replacement: one real authenticated QUIC connection,
+        // registered ONLY in the inner endpoint (no reader spawned).
+        let replacement =
+            tokio::time::timeout(Duration::from_secs(10), a.attempt_direct_handshake(b_addr))
+                .await
+                .expect("handshake timeout")
+                .expect("handshake ok");
+        let replacement_stable = replacement.stable_id();
+        let replacement_probe = replacement.clone();
+        a.inner
+            .add_connection_with_outcome(b_id, replacement)
+            .expect("register live replacement");
+
+        // Precondition: the inner endpoint routes the peer, the connection is
+        // open, and it is the current winner-map slot.
+        assert!(
+            a.inner.is_peer_connected(&b_id),
+            "fixture: replacement must register as a live inner connection"
+        );
+        assert_eq!(
+            a.inner
+                .get_connection(&b_id)
+                .expect("get_connection ok")
+                .expect("inner has a routable winner")
+                .stable_id(),
+            replacement_stable,
+            "fixture: winner slot must alias the live replacement"
+        );
+        assert!(
+            replacement_probe.close_reason().is_none(),
+            "fixture: replacement must be open"
+        );
+
+        // Older outer state installed directly: a connected_peers entry
+        // (distinct Relay metadata so it is unambiguously the pre-replacement
+        // record), a reader-task handle, and a direct-path status.
+        a.register_connected_peer(PeerConnection {
+            peer_id: b_id,
+            remote_addr: TransportAddr::Udp(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                9,
+            )),
+            traversal_method: TraversalMethod::Relay,
+            side: Side::Client,
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        })
+        .await;
+
+        // Reader-task handle whose liveness we can observe deterministically.
+        // `probe_cancel` is OUR release; cleanup would only touch the handle's
+        // own `cancel`/`abort_handle`, never `probe_cancel`. If cleanup reaches
+        // the remove+abort branch, the JoinHandle resolves to a cancelled error.
+        let probe_cancel = CancellationToken::new();
+        let task_token = probe_cancel.clone();
+        let probe_join: tokio::task::JoinHandle<u8> = tokio::spawn(async move {
+            task_token.cancelled().await;
+            42
+        });
+        {
+            let mut handles = a.reader_handles.write().await;
+            handles.insert(
+                b_id,
+                vec![ReaderTaskHandle {
+                    generation: 1,
+                    cancel: CancellationToken::new(),
+                    abort_handle: probe_join.abort_handle(),
+                }],
+            );
+        }
+
+        let direct_status = DirectPathStatus::Established {
+            remote_addr: SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 4242),
+        };
+        a.direct_path_statuses
+            .write()
+            .insert(b_id, direct_status.clone());
+
+        // Sanity: all four state stores hold the peer before cleanup.
+        assert!(
+            a.connected_peers.read().await.contains_key(&b_id),
+            "fixture: outer entry installed"
+        );
+        assert!(
+            a.reader_handles.read().await.contains_key(&b_id),
+            "fixture: reader handle installed"
+        );
+        assert_eq!(
+            a.direct_path_status(b_id),
+            Some(direct_status.clone()),
+            "fixture: direct status installed"
+        );
+
+        let mut events = a.subscribe();
+
+        // The contract: conditional cleanup must not erase a routable peer.
+        let removed = do_cleanup_connection(
+            &*a.connected_peers,
+            &*a.inner,
+            &*a.reader_handles,
+            &*a.direct_path_statuses,
+            &*a.stats,
+            &a.event_tx,
+            &a.peer_event_tx,
+            a.peer_event_channels.as_ref(),
+            a.peer_event_generations.as_ref(),
+            a.ack_waiters.as_ref(),
+            &b_id,
+            DisconnectReason::ConnectionLost,
+            close_reason_for_disconnect(&DisconnectReason::ConnectionLost),
+            CleanupScope::IfUnroutable,
+        )
+        .await;
+
+        // (1) Reports nothing removed.
+        assert!(
+            !removed,
+            "IfUnroutable cleanup must report no removal when the inner peer is routable"
+        );
+
+        // (2) The live replacement is untouched: still routable, still the
+        // current winner slot, still open. If the conditional path called the
+        // peer-wide remove_connection_with_reason, the connection would be
+        // closed and the winner slot cleared.
+        assert!(
+            a.inner.is_peer_connected(&b_id),
+            "replacement must remain routable in the inner endpoint"
+        );
+        assert_eq!(
+            a.inner
+                .get_connection(&b_id)
+                .expect("get_connection ok")
+                .expect("winner slot must still hold the replacement")
+                .stable_id(),
+            replacement_stable,
+            "winner slot must still alias the live replacement (not cleared/rotated)"
+        );
+        assert!(
+            replacement_probe.close_reason().is_none(),
+            "replacement must remain open; IfUnroutable must not call the peer-wide \
+             remove_connection_with_reason (that is Peer-scope teardown)"
+        );
+
+        // (3) The older outer entry is preserved. Fails if cleanup removed the
+        // outer peer without rechecking inner routability.
+        assert!(
+            a.connected_peers.read().await.contains_key(&b_id),
+            "outer connected_peers entry must survive conditional cleanup"
+        );
+
+        // (4) The reader handle is preserved AND was not aborted. Fails if
+        // cleanup removed the reader state without rechecking inner. We release
+        // the probe via OUR token: a clean Ok(42) proves the task was never
+        // aborted; a cancelled JoinError would mean cleanup aborted it.
+        assert!(
+            a.reader_handles.read().await.contains_key(&b_id),
+            "reader handle must not be removed by conditional cleanup"
+        );
+        probe_cancel.cancel();
+        let probe_outcome = probe_join.await;
+        assert!(
+            probe_outcome.is_ok(),
+            "reader task must not have been aborted by cleanup, got {:?}",
+            probe_outcome
+        );
+        assert_eq!(
+            probe_outcome.unwrap(),
+            42,
+            "probe task must exit cleanly via our token, confirming it survived cleanup"
+        );
+
+        // (5) The direct-path status is preserved.
+        assert_eq!(
+            a.direct_path_status(b_id),
+            Some(direct_status),
+            "direct-path status must survive conditional cleanup"
+        );
+
+        // (6) No PeerDisconnected event was emitted (no teardown happened).
+        let drained = collect_broadcast_events(&mut events);
+        assert!(
+            !drained.iter().any(|ev| matches!(
+                ev,
+                P2pEvent::PeerDisconnected { peer_id: p, .. } if *p == b_id
+            )),
+            "IfUnroutable cleanup must not emit PeerDisconnected for a routable peer, got {:?}",
+            drained
+        );
+
+        a.shutdown().await;
+        b.shutdown().await;
+    }
+    /// Regression for the generation-scoped liveness close
+    /// (`cleanup_connection_generation`): retiring one failed transport
+    /// generation must close ONLY that generation, leaving a concurrent live
+    /// replacement (and all outer/reader/direct bookkeeping) intact.
+    ///
+    /// Models the documented race: the ACK-liveness tracker observes failures
+    /// on generation W, but by the time `cleanup_connection_generation(W,
+    /// LivenessTimeout)` runs a newer connection N has registered and become the
+    /// Live winner (W is now Superseded). Production retires W via the inner
+    /// `remove_connection_generation_with_reason` (closes W, leaves the winner
+    /// map on N) and then runs `do_cleanup_connection(IfUnroutable)`, which is a
+    /// no-op because N is routable.
+    ///
+    /// Deterministic: two real authenticated QUIC connections registered in
+    /// `self.inner`; older outer/reader/direct state installed directly. No
+    /// reader tasks, no polling, no wall-clock races.
+    #[tokio::test]
+    async fn cleanup_connection_generation_closes_only_failed_generation_preserving_live_replacement()
+     {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        let b_addr = localhost_addr(b.local_addr().expect("b bound"));
+        let b_id = b.peer_id();
+
+        // W registered first, N second: N becomes the Live winner, W is
+        // Superseded but left OPEN for drain — the state W would be in if a
+        // replacement landed between liveness detection and the close.
+        let w = tokio::time::timeout(Duration::from_secs(10), a.attempt_direct_handshake(b_addr))
+            .await
+            .expect("w handshake timeout")
+            .expect("w handshake ok");
+        let n = tokio::time::timeout(Duration::from_secs(10), a.attempt_direct_handshake(b_addr))
+            .await
+            .expect("n handshake timeout")
+            .expect("n handshake ok");
+        let stable_w = w.stable_id();
+        let stable_n = n.stable_id();
+        assert_ne!(stable_w, stable_n, "two independent connections required");
+        let w_probe = w.clone();
+        let n_probe = n.clone();
+        a.inner
+            .add_connection_with_outcome(b_id, w)
+            .expect("register w");
+        a.inner
+            .add_connection_with_outcome(b_id, n)
+            .expect("register n");
+
+        // Precondition: N is the current Live winner; W is Superseded + open.
+        assert_eq!(
+            a.inner
+                .get_connection(&b_id)
+                .expect("get_connection ok")
+                .expect("a winner is live")
+                .stable_id(),
+            stable_n,
+            "fixture: N must be the live winner"
+        );
+        let w_snap = a
+            .inner
+            .connection_snapshot_by_stable_id(&b_id, stable_w)
+            .expect("w lifecycle snapshot");
+        assert!(
+            matches!(
+                w_snap.state,
+                crate::connection_lifecycle::ConnectionLifecycleState::Superseded { .. }
+            ),
+            "fixture: W must be Superseded (replacement landed), got {:?}",
+            w_snap.state
+        );
+        assert!(
+            w_probe.close_reason().is_none(),
+            "fixture: W must be open before the generation close"
+        );
+        assert!(
+            n_probe.close_reason().is_none(),
+            "fixture: N must be open before the generation close"
+        );
+
+        // Older outer/reader/direct state — all of which a peer-wide teardown
+        // would wrongly destroy.
+        a.register_connected_peer(PeerConnection {
+            peer_id: b_id,
+            remote_addr: TransportAddr::Udp(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                9,
+            )),
+            traversal_method: TraversalMethod::Relay,
+            side: Side::Client,
+            authenticated: true,
+            connected_at: Instant::now(),
+            last_activity: Instant::now(),
+        })
+        .await;
+
+        let probe_cancel = CancellationToken::new();
+        let task_token = probe_cancel.clone();
+        let probe_join: tokio::task::JoinHandle<u8> = tokio::spawn(async move {
+            task_token.cancelled().await;
+            42
+        });
+        {
+            let mut handles = a.reader_handles.write().await;
+            handles.insert(
+                b_id,
+                vec![ReaderTaskHandle {
+                    generation: 1,
+                    cancel: CancellationToken::new(),
+                    abort_handle: probe_join.abort_handle(),
+                }],
+            );
+        }
+
+        let direct_status = DirectPathStatus::Established {
+            remote_addr: SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 4242),
+        };
+        a.direct_path_statuses
+            .write()
+            .insert(b_id, direct_status.clone());
+
+        let mut events = a.subscribe();
+        let mut peer_events = a.subscribe_all_peer_events();
+
+        // Retire only W. If this used the peer-wide
+        // remove_connection_with_reason instead of the generation-scoped
+        // remove_connection_generation_with_reason, N would be closed too.
+        a.cleanup_connection_generation(&b_id, stable_w, DisconnectReason::LivenessTimeout)
+            .await;
+
+        // (1) W is closed AND tagged with LivenessTimeout. A locally-initiated
+        // close reports as LocallyClosed on the transport handle, so the reason
+        // is asserted through the lifecycle event the retire emits (the same
+        // surface downstream observers watch), and the close itself through the
+        // transport handle.
+        assert!(
+            w_probe.close_reason().is_some(),
+            "W's transport connection must be closed by the generation retire"
+        );
+        let lifecycle: Vec<_> = std::iter::from_fn(|| peer_events.try_recv().ok()).collect();
+        assert!(
+            lifecycle.iter().any(|(pid, ev)| *pid == b_id
+                && matches!(
+                    ev,
+                    PeerLifecycleEvent::Closed {
+                        generation,
+                        reason: ConnectionCloseReason::LivenessTimeout,
+                        ..
+                    } if *generation == w_snap.generation
+                )),
+            "W must emit a Closed(LivenessTimeout) lifecycle event for its generation, got {:?}",
+            lifecycle
+        );
+
+        // (2) N is untouched: still the current winner, still open, still Live.
+        assert_eq!(
+            a.inner
+                .get_connection(&b_id)
+                .expect("get_connection ok")
+                .expect("N must remain the routable winner")
+                .stable_id(),
+            stable_n,
+            "N must remain the current winner after W is retired"
+        );
+        assert!(
+            n_probe.close_reason().is_none(),
+            "N must remain open — generation retire must not close the replacement"
+        );
+        assert!(
+            a.inner.is_peer_connected(&b_id),
+            "peer must stay routable via N after W is retired"
+        );
+        let n_snap = a
+            .inner
+            .connection_snapshot_by_stable_id(&b_id, stable_n)
+            .expect("n lifecycle snapshot after retire");
+        assert!(
+            matches!(
+                n_snap.state,
+                crate::connection_lifecycle::ConnectionLifecycleState::Live
+            ),
+            "N must remain Live after W is retired, got {:?}",
+            n_snap.state
+        );
+
+        // (3) Outer peer preserved (IfUnroutable no-op because N is routable).
+        assert!(
+            a.connected_peers.read().await.contains_key(&b_id),
+            "outer connected_peers entry must survive the generation close"
+        );
+
+        // (4) Reader handle preserved and not aborted.
+        assert!(
+            a.reader_handles.read().await.contains_key(&b_id),
+            "reader handle must not be removed by the generation close"
+        );
+        probe_cancel.cancel();
+        let probe_outcome = probe_join.await;
+        assert!(
+            probe_outcome.is_ok(),
+            "reader task must not have been aborted by the generation close, got {:?}",
+            probe_outcome
+        );
+        assert_eq!(
+            probe_outcome.unwrap(),
+            42,
+            "probe task must exit cleanly, confirming it survived the generation close"
+        );
+
+        // (5) Direct-path status preserved.
+        assert_eq!(
+            a.direct_path_status(b_id),
+            Some(direct_status),
+            "direct-path status must survive the generation close"
+        );
+
+        // (6) No PeerDisconnected — only W was retired, the peer is still routed.
+        let drained = collect_broadcast_events(&mut events);
+        assert!(
+            !drained.iter().any(|ev| matches!(
+                ev,
+                P2pEvent::PeerDisconnected { peer_id: p, .. } if *p == b_id
+            )),
+            "generation close must not emit PeerDisconnected while N routes the peer, got {:?}",
+            drained
+        );
+
         a.shutdown().await;
         b.shutdown().await;
     }


### PR DESCRIPTION
## Problem
Concurrent mutual-dial registration released the lifecycle lock before updating the winner map. Two registrations could each mark a different connection Live, then write the map out of order. Reader-exit cleanup could also leave a stale connected peer after the final live inner connection disappeared.

## Fix
- update the winner map while holding the lifecycle decision lock
- evict stale connected peers and emit normal disconnect/reconnect flow when the final reader exits with no live inner connection
- add deterministic lifecycle and reader-exit regressions

## Verification
- `cargo fmt --all`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo clippy --all-features --lib --bins -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used`
- `cargo check --workspace --all-targets`
- `cargo test --lib reader_exit_reaped_last_reader_evicts_connected_peers_when_winner_dead -- --exact`
- `cargo test --test pqc_basic_integration test_local_p2p_connection_negotiates_pqc_and_ml_dsa_identity -- --exact`

Downstream x0x history stress still exposed a separate stale SWIM-admission loss; that fix is being handled in saorsa-gossip.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes lifecycle winner selection and winner-map replacement atomic, and adds cleanup for the last reaped reader when no live replacement is observed.

- Moves winner-map and established-event updates under the lifecycle decision lock.
- Runs normal peer cleanup when the final superseded reader exits without a live winner.
- Adds a deterministic regression test for stale `connected_peers` eviction.

<h3>Confidence Score: 4/5</h3>

The replacement-cleanup race should be fixed before merging because it can disconnect a newly established live connection.

The final-reader handler checks for a replacement without retaining synchronization and then performs peer-wide cleanup, allowing concurrent registration to install a new generation that the stale cleanup immediately removes.

**Files Needing Attention:** src/p2p_endpoint.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nat_traversal_api.rs | Moves winner-map publication into the lifecycle write-lock scope, closing the documented out-of-order registration window. |
| src/p2p_endpoint.rs | Adds final-reader stale-peer eviction, but its unlocked check followed by generation-agnostic cleanup can tear down a concurrently registered replacement. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant E as Reader-exit handler
    participant M as Winner map
    participant R as Replacement registration
    participant C as Peer-wide cleanup
    E->>M: is_peer_connected(peer)
    M-->>E: false
    R->>M: insert new live winner
    R->>R: install new reader handle
    E->>C: do_cleanup_connection(peer)
    C->>M: remove current winner
    C->>R: abort all peer reader handles
    Note over R,C: New live generation is disconnected by stale cleanup
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/p2p_endpoint.rs:9377
**Stale cleanup removes new winner**

If replacement registration overlaps the final reaped-reader cleanup, it can insert a new winner after this connectivity check but before `do_cleanup_connection` runs. That peer-wide cleanup then removes the new winner and aborts all of its reader handles, disconnecting a valid replacement connection.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: make connection lifecycle replaceme..."](https://github.com/saorsa-labs/ant-quic/commit/db4036900cb75901bb2e5dc770c925c87ebc9e49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50168436)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->