### PR TITLE
ci: let the PR-target guard post its reminder comment

### DIFF
--- a/.github/workflows/prevent-upstream-pr.yml
+++ b/.github/workflows/prevent-upstream-pr.yml
@@ -10,6 +10,9 @@ jobs:
   check-pr-target:
     runs-on: ubuntu-latest
     if: github.repository == 'saorsa-labs/ant-quic'
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Check PR Target
         run: |
@@ -37,9 +40,16 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '⚠️ **Reminder**: ant-quic is an independent project, not a fork of Quinn. We do not contribute changes back to quinn-rs/quinn.'
-            })
+            // The reminder is best-effort: pull_request events from forks get a
+            // read-only token no matter what permissions are declared, and the
+            // reminder must not fail the check when it cannot be posted.
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: '⚠️ **Reminder**: ant-quic is an independent project, not a fork of Quinn. We do not contribute changes back to quinn-rs/quinn.'
+              })
+            } catch (error) {
+              core.warning(`Could not post reminder comment: ${error.message}`)
+            }


### PR DESCRIPTION
The "Add Warning Comment" step in the PR-target guard workflow ran with a read-only default token, so any PR whose title/body matched the reminder condition failed the `check-pr-target` job with `Resource not accessible by integration` (seen on #231) instead of posting the reminder.

- Grant the job `issues: write` + `pull-requests: write`.
- Wrap the comment call in try/catch with a `core.warning`: fork-originated `pull_request` events get a read-only token regardless of declared permissions, and a best-effort reminder must never fail the check.

No change to the guard's actual enforcement (the target-repo check is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR grants the PR-target guard permission to post reminder comments and converts comment-posting failures into warnings so they cannot fail enforcement.
- Adds job-level issue and pull-request write permissions.
- Awaits the reminder API request and handles failures as best-effort warnings.
- The shared permissions also allow both opening-event workflows to post duplicate reminders for matching same-repository PRs.

<h3>Confidence Score: 4/5</h3>

The duplicate reminder path for matching same-repository PRs should be fixed before merging.

Both configured opening events execute the same newly writable comment step, so one matching same-repository PR can receive two identical reminders.

**Files Needing Attention:** .github/workflows/prevent-upstream-pr.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/prevent-upstream-pr.yml | Adds the necessary posting permissions and best-effort error handling, but enables duplicate comments because both opening-event variants execute the same reminder step. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as Contributor
    participant G as GitHub Events
    participant PR as pull_request run
    participant PRT as pull_request_target run
    participant I as PR comments
    U->>G: Open matching same-repository PR
    par pull_request: opened
        G->>PR: Start guard
        PR->>I: Post reminder
    and pull_request_target: opened
        G->>PRT: Start guard
        PRT->>I: Post identical reminder
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/prevent-upstream-pr.yml:13-15
**Duplicate reminder comments on open**

When a matching same-repository PR is opened, both the `pull_request` and `pull_request_target` workflows run with permission to execute the same comment step, causing two identical reminders to be posted.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: let the PR-target guard post its rem..."](https://github.com/saorsa-labs/ant-quic/commit/08fea5cc6f0748a9a3291531a70caa714502d383) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51208750)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->