### PR TITLE
test(congestion): use fixed instants in new_reno congestion tests

### DIFF
--- a/src/congestion.rs
+++ b/src/congestion.rs
@@ -323,49 +323,86 @@ mod tests {
     }
 
     // Congestion event tests
+    //
+    // These use a single fixed base instant per test: the controller ignores
+    // events whose `sent` time is not after `recovery_start_time`, so comparing
+    // against fresh `Instant::now()` calls is non-deterministic under scheduler
+    // load (see issue #233).
 
     #[test]
     fn new_reno_congestion_halves_window() {
-        let mut cc = NewReno::new(2000, 100_000, now());
+        let t0 = now();
+        let mut cc = NewReno::new(2000, 100_000, t0);
         cc.window = 50000;
         let before = cc.window;
-        cc.on_congestion_event(now() + Duration::from_millis(100), now(), false, 1200);
+        cc.on_congestion_event(
+            t0 + Duration::from_millis(100),
+            t0 + Duration::from_millis(1),
+            false,
+            1200,
+        );
         assert!(cc.window < before);
         assert_eq!(cc.window, 25000);
     }
 
     #[test]
     fn new_reno_congestion_sets_ssthresh() {
-        let mut cc = NewReno::new(2000, 100_000, now());
+        let t0 = now();
+        let mut cc = NewReno::new(2000, 100_000, t0);
         cc.window = 50000;
-        cc.on_congestion_event(now() + Duration::from_millis(100), now(), false, 1200);
+        cc.on_congestion_event(
+            t0 + Duration::from_millis(100),
+            t0 + Duration::from_millis(1),
+            false,
+            1200,
+        );
         assert_eq!(cc.ssthresh, cc.window);
     }
 
     #[test]
     fn new_reno_congestion_not_below_min() {
-        let mut cc = NewReno::new(2000, 100_000, now());
+        let t0 = now();
+        let mut cc = NewReno::new(2000, 100_000, t0);
         for i in 0..20 {
-            cc.on_congestion_event(now() + Duration::from_millis(100 + i), now(), false, 1200);
+            let t = t0 + Duration::from_millis(100 * (i + 1));
+            cc.on_congestion_event(t, t, false, 1200);
         }
         assert!(cc.window >= cc.min_window);
     }
 
     #[test]
     fn new_reno_persistent_congestion_resets_to_min() {
-        let mut cc = NewReno::new(2000, 100_000, now());
+        let t0 = now();
+        let mut cc = NewReno::new(2000, 100_000, t0);
         cc.window = 50000;
-        cc.on_congestion_event(now() + Duration::from_millis(200), now(), true, 1200);
+        cc.on_congestion_event(
+            t0 + Duration::from_millis(200),
+            t0 + Duration::from_millis(1),
+            true,
+            1200,
+        );
         assert_eq!(cc.window, cc.min_window);
     }
 
     #[test]
     fn new_reno_duplicate_congestion_during_recovery_ignored() {
-        let mut cc = NewReno::new(2000, 100_000, now());
+        let t0 = now();
+        let mut cc = NewReno::new(2000, 100_000, t0);
         cc.window = 50000;
-        cc.on_congestion_event(now() + Duration::from_millis(100), now(), false, 1200);
+        cc.on_congestion_event(
+            t0 + Duration::from_millis(100),
+            t0 + Duration::from_millis(1),
+            false,
+            1200,
+        );
         let after_first = cc.window;
-        cc.on_congestion_event(now() + Duration::from_millis(150), now(), false, 1200);
+        // Sent before the recovery period started, so it must be ignored.
+        cc.on_congestion_event(
+            t0 + Duration::from_millis(150),
+            t0 + Duration::from_millis(50),
+            false,
+            1200,
+        );
         assert_eq!(cc.window, after_first);
     }
 

--- a/src/congestion/new_reno.rs
+++ b/src/congestion/new_reno.rs
@@ -286,46 +286,87 @@ mod tests {
     }
 
     // Congestion event tests
+    //
+    // These use a single fixed base instant per test: the controller ignores
+    // events whose `sent` time is not after `recovery_start_time`, so comparing
+    // against fresh `Instant::now()` calls is non-deterministic under scheduler
+    // load (see issue #233).
 
     #[test]
     fn congestion_halves_window() {
-        let mut c = cc();
+        let t0 = now();
+        let mut c = NewReno::new(config(), t0, 1200);
         c.window = 50000;
-        c.on_congestion_event(now() + Duration::from_millis(100), now(), false, 1200);
+        c.on_congestion_event(
+            t0 + Duration::from_millis(100),
+            t0 + Duration::from_millis(1),
+            false,
+            1200,
+        );
         assert_eq!(c.window, 25000);
     }
 
     #[test]
     fn congestion_sets_ssthresh() {
-        let mut c = cc();
+        let t0 = now();
+        let mut c = NewReno::new(config(), t0, 1200);
         c.window = 50000;
-        c.on_congestion_event(now() + Duration::from_millis(100), now(), false, 1200);
+        c.on_congestion_event(
+            t0 + Duration::from_millis(100),
+            t0 + Duration::from_millis(1),
+            false,
+            1200,
+        );
         assert_eq!(c.ssthresh, c.window);
     }
 
     #[test]
     fn congestion_not_below_minimum() {
-        let mut c = cc();
+        let t0 = now();
+        let mut c = NewReno::new(config(), t0, 1200);
         c.window = 1000;
-        c.on_congestion_event(now() + Duration::from_millis(100), now(), false, 1200);
+        c.on_congestion_event(
+            t0 + Duration::from_millis(100),
+            t0 + Duration::from_millis(1),
+            false,
+            1200,
+        );
         assert_eq!(c.window, c.minimum_window());
     }
 
     #[test]
     fn persistent_congestion_resets_to_min() {
-        let mut c = cc();
+        let t0 = now();
+        let mut c = NewReno::new(config(), t0, 1200);
         c.window = 50000;
-        c.on_congestion_event(now() + Duration::from_millis(100), now(), true, 1200);
+        c.on_congestion_event(
+            t0 + Duration::from_millis(100),
+            t0 + Duration::from_millis(1),
+            true,
+            1200,
+        );
         assert_eq!(c.window, c.minimum_window());
     }
 
     #[test]
     fn duplicate_congestion_ignored_during_recovery() {
-        let mut c = cc();
+        let t0 = now();
+        let mut c = NewReno::new(config(), t0, 1200);
         c.window = 50000;
-        c.on_congestion_event(now() + Duration::from_millis(100), now(), false, 1200);
+        c.on_congestion_event(
+            t0 + Duration::from_millis(100),
+            t0 + Duration::from_millis(1),
+            false,
+            1200,
+        );
         let after = c.window;
-        c.on_congestion_event(now() + Duration::from_millis(200), now(), false, 1200);
+        // Sent before the recovery period started, so it must be ignored.
+        c.on_congestion_event(
+            t0 + Duration::from_millis(200),
+            t0 + Duration::from_millis(50),
+            false,
+            1200,
+        );
         assert_eq!(c.window, after);
     }
 


### PR DESCRIPTION
## Summary

Fixes the four flaky `new_reno` congestion unit tests from #233 by making their timing fully deterministic.

## Root cause

Both NewReno implementations guard congestion events (and acks) with:

```rust
if sent <= self.recovery_start_time { return; }
```

where `recovery_start_time` is initialized from the `now` passed to the constructor. The flaky tests called `Instant::now()\) fresh for every argument, e.g.:

```rust
let mut cc = NewReno::new(2000, 100_000, now());           // t_construct
cc.on_congestion_event(now() + 100ms, now(), false, 1200); // fresh t_sent
```

Under parallel test load (`--test-threads=2`), scheduler stalls/coarse clock granularity can make the fresh `sent` instant equal to (or not strictly after) the construction-time instant. The event is then silently ignored, the window never halves, and assertions like `assert_eq!(c.window, 25000)` or `assert!(cc.window < before)` fail — exactly the failure signatures reported in the issue. The `duplicate_congestion_*` tests had the inverse hazard: a fresh `now()` for the second event could land *after* the recovery start, so an event that must be ignored was applied.

## Fix

Test-only change: each affected test captures a single base instant `t0`, constructs the controller at `t0`, and passes `sent`/`now` as explicit fixed offsets from `t0` (e.g. `sent = t0 + 1ms`, duplicate event `sent = t0 + 50ms` so it provably falls inside the recovery window). No production code changed.

Tests updated (all the ones using the fresh-`now()` congestion-event pattern, covering all four named flakes plus their same-pattern siblings):

- `src/congestion.rs`: `new_reno_congestion_halves_window`, `new_reno_congestion_sets_ssthresh`, `new_reno_congestion_not_below_min`, `new_reno_persistent_congestion_resets_to_min`, `new_reno_duplicate_congestion_during_recovery_ignored`
- `src/congestion/new_reno.rs`: `congestion_halves_window`, `congestion_sets_ssthresh`, `congestion_not_below_minimum`, `persistent_congestion_resets_to_min`, `duplicate_congestion_ignored_during_recovery`

## Tests run

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used` — clean
- `cargo check --workspace --all-targets` — clean
- `cargo test --lib --all-features congestion` — 95/95 pass
- `cargo test --lib --all-features congestion -- --test-threads=2` ×5 — all pass (95/95 each)
- `cargo test --lib --all-features -- --test-threads=2` (the issue's repro config) — 2678 passed, 1 failed: `p2p_endpoint::tests::test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear`. This failure is **pre-existing and unrelated**: it fails identically on the clean base commit (verified via `git stash`) and even in isolation, and this patch touches only congestion test code. It is not currently tracked by an open issue — worth filing one.

Closes #233

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This test-only change makes NewReno congestion tests deterministic by deriving constructor, event, and packet-sent timestamps from one fixed base instant.
- Replaces independently sampled instants in two NewReno test suites with explicit offsets from `t0`.
- Ensures ordinary congestion events occur after recovery initialization and duplicate events fall inside the active recovery period.
- Preserves the previous controller configuration and assertions while eliminating scheduler-sensitive timing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it changes only test timing and preserves the intended NewReno test scenarios.

Both test suites now guarantee the timestamp ordering required by the recovery guard without changing controller configuration or production behavior, and no actionable defects remain.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/congestion.rs | Makes simplified NewReno congestion tests deterministic with fixed timestamps; the revised events correctly exercise accepted and ignored recovery paths. |
| src/congestion/new_reno.rs | Replaces the timing-dependent test helper usage with an equivalent explicit constructor call and deterministic event offsets. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(congestion): use fixed instants in ..."](https://github.com/saorsa-labs/ant-quic/commit/8a6c66c0b09b76ad734da478ec643bb844d2bc28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51338115)</sub>

<!-- /greptile_comment -->