### PR TITLE
fix(connection): prevent 30s P2P reader timeout (#234)

### DIFF
--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -7201,18 +7201,28 @@ impl NatTraversalEndpoint {
                                 .find(|entry| entry.stable_id() == snapshot.stable_id)
                                 .map(|entry| entry.connection.clone())
                         });
-                let transport_close_reason = connection
-                    .as_ref()
-                    .and_then(|connection| connection.close_reason())
-                    .map(|error| ConnectionCloseReason::from_connection_error(&error));
-                if let Some(connection) = connection
+                let mut closed_by_reader_exit = false;
+                if let Some(connection) = &connection
                     && connection.close_reason().is_none()
                     && let Some(code) = ConnectionCloseReason::ReaderExit.app_error_code()
                 {
                     connection.close(code, ConnectionCloseReason::ReaderExit.reason_bytes());
+                    closed_by_reader_exit = true;
                 }
-                let default_close_reason =
-                    transport_close_reason.unwrap_or(ConnectionCloseReason::ReaderExit);
+                // Observe the transport reason only after the close attempt: a
+                // transport close landing between the guard above and this read
+                // would otherwise be reported as ReaderExit, which
+                // `mark_connection_closed` treats as authoritative and never
+                // re-checks against the connection.
+                let default_close_reason = if closed_by_reader_exit {
+                    ConnectionCloseReason::ReaderExit
+                } else {
+                    connection
+                        .as_ref()
+                        .and_then(|connection| connection.close_reason())
+                        .map(|error| ConnectionCloseReason::from_connection_error(&error))
+                        .unwrap_or(ConnectionCloseReason::ReaderExit)
+                };
                 let close_reason = self
                     .mark_connection_closed(peer_id, snapshot.stable_id, default_close_reason)
                     .unwrap_or(default_close_reason);
@@ -11221,11 +11231,21 @@ mod tests {
             transport_config.keep_alive_interval,
             Some(Duration::from_secs(10))
         );
+        // Compare against the idle timeout this config actually sets, not a
+        // literal: pinning 30s here would keep passing if the idle timeout were
+        // lowered below the keepalive interval, which is the failure this
+        // assertion exists to catch.
+        let idle_timeout = transport_config
+            .max_idle_timeout
+            .map(|timeout| Duration::from_millis(timeout.into_inner()));
         assert!(
-            transport_config
-                .keep_alive_interval
-                .is_some_and(|interval| { interval < Duration::from_secs(30) }),
-            "QUIC keepalive must fire before the 30s idle timeout"
+            matches!(
+                (transport_config.keep_alive_interval, idle_timeout),
+                (Some(keepalive), Some(idle)) if keepalive < idle
+            ),
+            "QUIC keepalive ({:?}) must fire before the configured idle timeout ({:?})",
+            transport_config.keep_alive_interval,
+            idle_timeout
         );
         assert_ne!(
             transport_config.keep_alive_interval,

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -4817,9 +4817,15 @@ impl NatTraversalEndpoint {
     // Private implementation methods
 
     fn build_nat_transport_config(config: &NatTraversalConfig) -> TransportConfig {
+        const MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+        const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(10);
+
         let mut transport_config = TransportConfig::default();
         transport_config.enable_address_discovery(true);
-        transport_config.max_idle_timeout(Some(crate::VarInt::from_u32(30000).into()));
+        transport_config.max_idle_timeout(Some(
+            crate::VarInt::from_u32(MAX_IDLE_TIMEOUT.as_millis() as u32).into(),
+        ));
+        transport_config.keep_alive_interval(Some(KEEP_ALIVE_INTERVAL));
         transport_config.max_concurrent_uni_streams(
             crate::VarInt::from_u32(config.max_concurrent_uni_streams).into(),
         );
@@ -7185,7 +7191,7 @@ impl NatTraversalEndpoint {
                     return ReaderExitOutcome::ConnectionReaped;
                 }
 
-                if let Some(connection) =
+                let connection =
                     self.connection_lifecycle
                         .read()
                         .get(peer_id)
@@ -7194,19 +7200,22 @@ impl NatTraversalEndpoint {
                                 .iter()
                                 .find(|entry| entry.stable_id() == snapshot.stable_id)
                                 .map(|entry| entry.connection.clone())
-                        })
+                        });
+                let transport_close_reason = connection
+                    .as_ref()
+                    .and_then(|connection| connection.close_reason())
+                    .map(|error| ConnectionCloseReason::from_connection_error(&error));
+                if let Some(connection) = connection
                     && connection.close_reason().is_none()
                     && let Some(code) = ConnectionCloseReason::ReaderExit.app_error_code()
                 {
                     connection.close(code, ConnectionCloseReason::ReaderExit.reason_bytes());
                 }
+                let default_close_reason =
+                    transport_close_reason.unwrap_or(ConnectionCloseReason::ReaderExit);
                 let close_reason = self
-                    .mark_connection_closed(
-                        peer_id,
-                        snapshot.stable_id,
-                        ConnectionCloseReason::ReaderExit,
-                    )
-                    .unwrap_or(ConnectionCloseReason::ReaderExit);
+                    .mark_connection_closed(peer_id, snapshot.stable_id, default_close_reason)
+                    .unwrap_or(default_close_reason);
                 self.connections.remove(peer_id);
                 self.emitted_established_events.remove(peer_id);
                 let mut lifecycle = self.connection_lifecycle.write();
@@ -11193,7 +11202,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_nat_transport_config_uses_transport_default_keepalive() {
+    fn test_build_nat_transport_config_enables_keepalive_below_idle_timeout() {
         let config = NatTraversalConfig {
             bind_addr: Some("127.0.0.1:0".parse().unwrap()),
             timeouts: crate::config::nat_timeouts::TimeoutConfig {
@@ -11207,9 +11216,17 @@ mod tests {
         };
 
         let transport_config = NatTraversalEndpoint::build_nat_transport_config(&config);
-        let default_keepalive = TransportConfig::default().keep_alive_interval;
 
-        assert_eq!(transport_config.keep_alive_interval, default_keepalive);
+        assert_eq!(
+            transport_config.keep_alive_interval,
+            Some(Duration::from_secs(10))
+        );
+        assert!(
+            transport_config
+                .keep_alive_interval
+                .is_some_and(|interval| { interval < Duration::from_secs(30) }),
+            "QUIC keepalive must fire before the 30s idle timeout"
+        );
         assert_ne!(
             transport_config.keep_alive_interval,
             Some(config.timeouts.nat_traversal.retry_interval),


### PR DESCRIPTION
## Summary

- enable a 10s QUIC keep-alive for NAT traversal transports, below the existing 30s idle timeout
- preserve the transport close reason when a reader exits, so a QUIC idle timeout is reported as `TimedOut` instead of being rewritten to `ReaderExit`
- update the transport-config regression test to pin the keepalive contract

## Root cause

NAT traversal connections configured a 30s `max_idle_timeout` but left QUIC keepalive disabled. An otherwise healthy P2P connection could therefore hit the idle timer, causing the per-connection reader to exit and the endpoint to tear down its side while the peer still considered the connection live. Reader-exit lifecycle handling also replaced the actual transport close reason with generic `ReaderExit`, hiding the timeout.

## Tests

- `cargo fmt --all`
- `cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used`
- `cargo check --workspace --all-targets`
- `cargo test --lib --all-features test_build_nat_transport_config_enables_keepalive_below_idle_timeout`
- `cargo test --test lifecycle_active_close --all-features`
- `cargo test --test reconnect_reader_task --all-features`

Closes #234

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables a 10-second QUIC keepalive for NAT traversal transports and attempts to preserve transport close reasons when reader tasks exit.
- Pins the NAT transport to a 30-second idle timeout with a 10-second keepalive.
- Propagates an observed transport close reason through reader-exit lifecycle handling.
- Updates the transport configuration regression test for the new keepalive contract.

<h3>Confidence Score: 4/5</h3>

The close-reason race should be fixed before merging because a concurrent QUIC close can still be reported as the generic reader-exit reason.

Reader-exit handling makes two independent close-reason reads and then records the first result, allowing a transport timeout occurring between those reads to be replaced with `ReaderExit`.

**Files Needing Attention:** src/nat_traversal_api.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nat_traversal_api.rs | The keepalive configuration is internally consistent, but reader-exit reason preservation retains a race that can still rewrite a concurrent transport timeout as `ReaderExit`. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/nat_traversal_api.rs:7204-7217
**Close-reason snapshot race**

When the transport records a close reason after the first `close_reason()` read but before the second, the second read prevents a local close while lifecycle marking still uses the stale `ReaderExit` fallback, causing timeout and other transport closures to be reported as `ReaderExit`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(connection): keep P2P QUIC connectio..."](https://github.com/saorsa-labs/ant-quic/commit/edfe420b3b0ec2706e064bc09d4d106df943f304) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51409042)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->