### PR TITLE
test(dual-stack): pin the inbound reply path for IPv4 dials (refutes the wrong-socket hypothesis)

### DIFF
--- a/src/high_level/runtime/dual_stack.rs
+++ b/src/high_level/runtime/dual_stack.rs
@@ -593,6 +593,12 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Pins that `select_family` routes IPv4-mapped destinations (`::ffff:x.x.x.x`) through the
+    /// v4 socket, not the v6 socket. The discriminating assertion is the egress source port: since
+    /// the two sender sockets are bound independently (OS assigns ephemeral ports from separate
+    /// pools for AF_INET vs AF_INET6), their ports will differ. If `select_family`'s IPv4-mapped
+    /// arm is broken — e.g. inverted to route to v6 — the receiver sees the v6 sender port and
+    /// the assertion fails with a clear message.
     #[tokio::test]
     async fn test_send_routing_ipv4_mapped() {
         // Create a v4 receiver
@@ -600,14 +606,26 @@ mod tests {
         receiver.set_nonblocking(true).unwrap();
         let recv_port = receiver.local_addr().unwrap().port();
 
-        // Create dual-stack socket — await writability before try_send
+        // Create dual-stack socket — await writability before try_send.
+        // Bind v4 and v6 independently so they get distinct OS-assigned ports.
+        // v6 is bound to [::] (not [::1]) so that under mutation the send to an
+        // IPv4-mapped destination succeeds from the v6 socket; the packet arrives at
+        // the receiver from a different source port, triggering the discriminating assertion.
         let v4 = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
         v4.writable().await.unwrap();
-        let v6 = tokio::net::UdpSocket::bind("[::1]:0").await.unwrap();
+        let v6 = tokio::net::UdpSocket::bind("[::]:0").await.unwrap();
         v6.writable().await.unwrap();
         let ds = DualStackSocket::new(Some(v4), Some(v6)).unwrap();
 
-        // Send to an IPv4-mapped IPv6 address — should route to v4 socket
+        // Capture sender ports before the sockets are moved into the sender.
+        let v4_port = ds.local_addr_v4().unwrap().port();
+        let v6_port = ds.local_addr_v6().unwrap().port();
+        assert_ne!(
+            v4_port, v6_port,
+            "test requires distinct v4/v6 sender ports to discriminate egress socket"
+        );
+
+        // Send to an IPv4-mapped IPv6 address — select_family must route to the v4 socket.
         let mapped_dest: SocketAddr = format!("[::ffff:127.0.0.1]:{recv_port}").parse().unwrap();
         let transmit = Transmit {
             destination: mapped_dest,
@@ -621,13 +639,22 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify receipt on the v4 receiver
+        // Verify receipt on the v4 receiver and check the egress socket by source port.
         let mut buf = [0u8; 64];
         let mut received = false;
         for _ in 0..50 {
             match receiver.recv_from(&mut buf) {
-                Ok((len, _)) => {
+                Ok((len, sender_addr)) => {
                     assert_eq!(&buf[..len], b"hello-v4-mapped");
+                    // The packet must have egressed the v4 socket, not the v6 socket.
+                    // Under mutation (IPv4-mapped arm inverted to route to v6), the
+                    // source port would be v6_port and this assertion catches it.
+                    assert_eq!(
+                        sender_addr.port(),
+                        v4_port,
+                        "reply must egress the v4 socket (port {v4_port}), saw port {} (v6 socket is {v6_port})",
+                        sender_addr.port()
+                    );
                     received = true;
                     break;
                 }
@@ -640,6 +667,10 @@ mod tests {
         assert!(received, "v4 receiver should get the IPv4-mapped datagram");
     }
 
+    /// Pins that `select_family` routes native IPv6 destinations (`::1`) through the v6 socket.
+    /// This test does not carry the egress-port discriminator (that is in
+    /// `test_send_routing_ipv4_mapped`); it verifies that a native-v6 send reaches a v6 receiver
+    /// at all — covering the `SocketAddr::V6(_)` arm of `select_family`.
     #[tokio::test]
     async fn test_send_routing_native_v6() {
         // Create a v6 receiver
@@ -778,13 +809,28 @@ mod tests {
     /// straight back as a `Transmit` destination. If the wrapper routed that
     /// mapped address to the IPv6 socket, a native-IPv4 peer would never see the
     /// reply — the field symptom.
-    #[cfg(feature = "network-discovery")]
+    /// Pins that `select_family` routes IPv4-mapped destinations back through the v4 socket.
+    ///
+    /// The sockets are bound independently (not via `create_dual_stack_sockets(0)`, which
+    /// co-allocates both to the same port) so that the OS assigns each a distinct ephemeral
+    /// port. The final assertion checks the source port: under the mutation that inverts the
+    /// v4-mapped arm of `select_family` to route to the v6 socket, the receiver sees the v6
+    /// port and the assertion fails with a clear message. Without distinct ports the assertion
+    /// is non-discriminating (both sockets share the same port).
     #[tokio::test]
     async fn reply_to_v4_mapped_peer_egresses_from_the_v4_socket() {
-        let (v4, v6) = create_dual_stack_sockets(0).expect("bind dual-stack sockets");
-        let v4 = v4.expect("IPv4 socket required for this test");
-        let v6 = v6.expect("IPv6 socket required for this test");
+        // Independent binds → OS assigns separate ephemeral ports to AF_INET and AF_INET6.
+        let v4 = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
         let listener_v4_port = v4.local_addr().unwrap().port();
+        // v6 is bound to [::] (not [::1]) so that under mutation the send to an
+        // IPv4-mapped destination succeeds from the v6 socket; the packet then arrives
+        // from the v6 source port, triggering the discriminating port assertion.
+        let v6 = std::net::UdpSocket::bind("[::]:0").unwrap();
+        let listener_v6_port = v6.local_addr().unwrap().port();
+        assert_ne!(
+            listener_v4_port, listener_v6_port,
+            "test requires distinct v4/v6 listener ports to discriminate egress socket"
+        );
 
         let dual = wrap_dual_stack(Some(v4), Some(v6)).expect("wrap dual-stack");
 
@@ -845,7 +891,9 @@ mod tests {
         assert_eq!(
             src,
             SocketAddr::from((Ipv4Addr::LOCALHOST, listener_v4_port)),
-            "reply must come from the listener's IPv4 socket so the dialer accepts it"
+            "reply must egress the v4 socket (port {listener_v4_port}), saw port {} \
+             (v6 socket is {listener_v6_port}); check select_family's IPv4-mapped arm",
+            src.port()
         );
     }
 
@@ -856,7 +904,11 @@ mod tests {
     /// then black-holed every server->client byte, so this asserts on delivered
     /// stream payload in the server->client direction. A connect-only assertion
     /// would have stayed green throughout the outage.
-    #[cfg(feature = "network-discovery")]
+    /// Pins that an inbound IPv4 QUIC connection delivers server→client stream data.
+    ///
+    /// Uses distinct v4/v6 listener ports (independent binds, not `create_dual_stack_sockets(0)`)
+    /// so that if `select_family`'s IPv4-mapped arm routes replies to the v6 socket, the QUIC
+    /// client sees packets from an unexpected source and the connection/read fails.
     #[tokio::test]
     async fn inbound_ipv4_connection_delivers_server_to_client_data() {
         use crate::config::{ClientConfig, EndpointConfig, ServerConfig};
@@ -865,10 +917,18 @@ mod tests {
 
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-        let (v4, v6) = create_dual_stack_sockets(0).expect("bind dual-stack sockets");
-        let v4 = v4.expect("IPv4 socket required for this test");
-        let v6 = v6.expect("IPv6 socket required for this test");
+        // Independent binds ensure v4 and v6 get distinct OS-assigned ports.
+        // v6 is bound to [::] so that under mutation the v6 socket can reach IPv4-mapped
+        // destinations; distinct ports cause QUIC to reject the mis-routed packets.
+        let v4 = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
         let listener_v4_port = v4.local_addr().unwrap().port();
+        let v6 = std::net::UdpSocket::bind("[::]:0").unwrap();
+        let listener_v6_port = v6.local_addr().unwrap().port();
+        assert_ne!(
+            listener_v4_port, listener_v6_port,
+            "test requires distinct v4/v6 listener ports to discriminate egress socket"
+        );
+        let _ = listener_v6_port; // captured for the assert_ne; QUIC discriminates through peer mismatch
 
         let dual: Arc<dyn AsyncUdpSocket> =
             Arc::new(wrap_dual_stack(Some(v4), Some(v6)).expect("wrap dual-stack"));
@@ -962,7 +1022,11 @@ mod tests {
     /// IPv4-mapped form and both must route their sends back down to the IPv4
     /// socket. Host A and host B were both dual-stack in the field, so this is
     /// the configuration that actually failed.
-    #[cfg(feature = "network-discovery")]
+    /// Pins the field topology: both peers true dual-stack, dial over IPv4.
+    ///
+    /// Uses distinct v4/v6 ports per peer (independent binds, not `create_dual_stack_sockets(0)`)
+    /// so that the mutation — routing IPv4-mapped sends to the v6 socket — produces packets from
+    /// an unexpected source port, causing QUIC to reject them and the test to fail.
     #[tokio::test]
     async fn dual_stack_peers_exchange_data_over_an_ipv4_dial() {
         use crate::config::{ClientConfig, EndpointConfig, ServerConfig};
@@ -971,11 +1035,16 @@ mod tests {
 
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
+        // Independent binds ensure v4 and v6 get distinct OS-assigned ports per endpoint.
         let make_dual = || {
-            let (v4, v6) = create_dual_stack_sockets(0).expect("bind dual-stack sockets");
-            let v4 = v4.expect("IPv4 socket required for this test");
-            let v6 = v6.expect("IPv6 socket required for this test");
+            let v4 = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind v4");
             let v4_port = v4.local_addr().unwrap().port();
+            let v6 = std::net::UdpSocket::bind("[::]:0").expect("bind v6");
+            let v6_port = v6.local_addr().unwrap().port();
+            assert_ne!(
+                v4_port, v6_port,
+                "test requires distinct v4/v6 ports to discriminate egress socket"
+            );
             let socket: Arc<dyn AsyncUdpSocket> =
                 Arc::new(wrap_dual_stack(Some(v4), Some(v6)).expect("wrap dual-stack"));
             (socket, v4_port)

--- a/src/high_level/runtime/dual_stack.rs
+++ b/src/high_level/runtime/dual_stack.rs
@@ -759,4 +759,297 @@ mod tests {
             .await
             .unwrap()
     }
+
+    // ─── Inbound reply path (ant-quic #234/#235) ─────────────────────────────
+    //
+    // Field failure: host B dials host A over IPv4 on a shared LAN. A binds true
+    // dual-stack, so A's endpoint reports `local_addr() == [::]:port` and runs
+    // with `ipv6 = true`; every peer address A handles is therefore the
+    // IPv4-mapped form `[::ffff:192.168.1.108]:port`. B's packets kept arriving
+    // at A for minutes, but no application data A sent ever reached B.
+    //
+    // The two tests below pin the invariants that inbound replies depend on.
+
+    /// A datagram received on the IPv4 socket must be answered *from* the IPv4
+    /// socket.
+    ///
+    /// This mirrors what the QUIC endpoint does: it takes the peer address
+    /// `poll_recv` reports (handed back IPv4-mapped) and feeds that same address
+    /// straight back as a `Transmit` destination. If the wrapper routed that
+    /// mapped address to the IPv6 socket, a native-IPv4 peer would never see the
+    /// reply — the field symptom.
+    #[cfg(feature = "network-discovery")]
+    #[tokio::test]
+    async fn reply_to_v4_mapped_peer_egresses_from_the_v4_socket() {
+        let (v4, v6) = create_dual_stack_sockets(0).expect("bind dual-stack sockets");
+        let v4 = v4.expect("IPv4 socket required for this test");
+        let v6 = v6.expect("IPv6 socket required for this test");
+        let listener_v4_port = v4.local_addr().unwrap().port();
+
+        let dual = wrap_dual_stack(Some(v4), Some(v6)).expect("wrap dual-stack");
+
+        // Stand in for the remote LAN host: a plain IPv4 socket that knows
+        // nothing about IPv6, dialling the listener's IPv4 port as host B did.
+        let peer = std::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .unwrap();
+        let peer_port = peer.local_addr().unwrap().port();
+        peer.send_to(b"dial", (Ipv4Addr::LOCALHOST, listener_v4_port))
+            .unwrap();
+
+        let mut buf = [0u8; 512];
+        let mut bufs = [IoSliceMut::new(&mut buf)];
+        let mut meta = [RecvMeta::default()];
+        let n = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            std::future::poll_fn(|cx| dual.poll_recv(cx, &mut bufs, &mut meta)),
+        )
+        .await
+        .expect("listener should receive the dial")
+        .expect("poll_recv should succeed");
+        assert_eq!(n, 1);
+
+        // The wrapper reports the peer IPv4-mapped because the endpoint believes
+        // it owns an IPv6 socket. This is the address the connection records as
+        // its remote, and the address every reply is sent to.
+        let learned_peer = meta[0].addr;
+        assert!(
+            matches!(learned_peer, SocketAddr::V6(a) if a.ip().to_ipv4_mapped().is_some()),
+            "peer learned on the v4 socket should be reported IPv4-mapped, got {learned_peer}"
+        );
+        assert_eq!(learned_peer.port(), peer_port);
+
+        let transmit = Transmit {
+            destination: learned_peer,
+            ecn: None,
+            contents: b"reply",
+            segment_size: None,
+            src_ip: None,
+        };
+        let mut sender = dual.create_sender();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            std::future::poll_fn(|cx| sender.as_mut().poll_send(&transmit, cx)),
+        )
+        .await
+        .expect("send should not stall")
+        .expect("send should succeed");
+
+        // The native-IPv4 peer must see it, and must see it from the listener's
+        // IPv4 address — not from an IPv6 source it never talked to.
+        let mut reply = [0u8; 512];
+        let (len, src) = peer
+            .recv_from(&mut reply)
+            .expect("native-IPv4 peer must receive the reply; a v6 egress black-holes it");
+        assert_eq!(&reply[..len], b"reply");
+        assert_eq!(
+            src,
+            SocketAddr::from((Ipv4Addr::LOCALHOST, listener_v4_port)),
+            "reply must come from the listener's IPv4 socket so the dialer accepts it"
+        );
+    }
+
+    /// An inbound IPv4 connection into a true-dual-stack listener must carry
+    /// application data back to the dialer.
+    ///
+    /// The field failure completed its handshake and reached Live on both hosts,
+    /// then black-holed every server->client byte, so this asserts on delivered
+    /// stream payload in the server->client direction. A connect-only assertion
+    /// would have stayed green throughout the outage.
+    #[cfg(feature = "network-discovery")]
+    #[tokio::test]
+    async fn inbound_ipv4_connection_delivers_server_to_client_data() {
+        use crate::config::{ClientConfig, EndpointConfig, ServerConfig};
+        use crate::high_level::{Endpoint, TokioRuntime};
+        use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        let (v4, v6) = create_dual_stack_sockets(0).expect("bind dual-stack sockets");
+        let v4 = v4.expect("IPv4 socket required for this test");
+        let v6 = v6.expect("IPv6 socket required for this test");
+        let listener_v4_port = v4.local_addr().unwrap().port();
+
+        let dual: Arc<dyn AsyncUdpSocket> =
+            Arc::new(wrap_dual_stack(Some(v4), Some(v6)).expect("wrap dual-stack"));
+
+        // Precondition that makes this test meaningful: the endpoint must
+        // believe it is IPv6, which is what forces every peer address through
+        // the IPv4-mapped representation.
+        assert!(
+            dual.local_addr().unwrap().is_ipv6(),
+            "true dual-stack listener must report an IPv6 local_addr"
+        );
+
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("self-signed cert");
+        let cert_der = CertificateDer::from(cert.cert);
+        let key_der = PrivateKeyDer::Pkcs8(cert.signing_key.serialize_der().into());
+        let chain = vec![cert_der];
+        let server_cfg =
+            ServerConfig::with_single_cert(chain.clone(), key_der).expect("server config");
+
+        let server_ep = Endpoint::new_with_abstract_socket(
+            EndpointConfig::default(),
+            Some(server_cfg),
+            dual,
+            Arc::new(TokioRuntime),
+        )
+        .expect("dual-stack server endpoint");
+
+        // The server echoes on a bidirectional stream; everything it writes
+        // travels in the direction that died in the field.
+        let server = tokio::spawn(async move {
+            let incoming = server_ep.accept().await.expect("incoming connection");
+            let conn = incoming.await.expect("server handshake");
+            let (mut send, mut recv) = conn.accept_bi().await.expect("server accept_bi");
+            let got = recv.read_to_end(64).await.expect("server read");
+            assert_eq!(got, b"ping");
+            send.write_all(b"pong").await.expect("server write");
+            send.finish().expect("server finish");
+            // Hold the connection open until the client has drained the reply:
+            // dropping here could close before delivery and mask a real failure
+            // as a clean shutdown.
+            conn.closed().await;
+        });
+
+        let mut roots = rustls::RootCertStore::empty();
+        for c in chain {
+            roots.add(c).expect("add server cert to roots");
+        }
+        let client_cfg =
+            ClientConfig::with_root_certificates(Arc::new(roots)).expect("client config");
+
+        // The dialer is plain IPv4, exactly like the LAN host in the field report.
+        let mut client_ep =
+            Endpoint::client((Ipv4Addr::LOCALHOST, 0).into()).expect("client endpoint");
+        client_ep.set_default_client_config(client_cfg);
+
+        let conn = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client_ep
+                .connect((Ipv4Addr::LOCALHOST, listener_v4_port).into(), "localhost")
+                .expect("start connect"),
+        )
+        .await
+        .expect("handshake must not stall")
+        .expect("client connected");
+
+        let (mut send, mut recv) = conn.open_bi().await.expect("client open_bi");
+        send.write_all(b"ping").await.expect("client write");
+        send.finish().expect("client finish");
+
+        // The assertion the field bug fails: handshake succeeded, but no server
+        // payload ever arrived.
+        let echoed = tokio::time::timeout(std::time::Duration::from_secs(10), recv.read_to_end(64))
+            .await
+            .expect("server->client data must arrive on an inbound dual-stack connection")
+            .expect("client read");
+        assert_eq!(
+            echoed, b"pong",
+            "server reply must reach the IPv4 dialer intact"
+        );
+
+        conn.close(0u32.into(), b"done");
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server).await;
+    }
+
+    /// The exact field topology: *both* peers bind true dual-stack, and the
+    /// dialer reaches the listener over IPv4.
+    ///
+    /// This differs from the test above in that the dialer's endpoint also
+    /// reports an IPv6 `local_addr`, so both sides record the peer in
+    /// IPv4-mapped form and both must route their sends back down to the IPv4
+    /// socket. Host A and host B were both dual-stack in the field, so this is
+    /// the configuration that actually failed.
+    #[cfg(feature = "network-discovery")]
+    #[tokio::test]
+    async fn dual_stack_peers_exchange_data_over_an_ipv4_dial() {
+        use crate::config::{ClientConfig, EndpointConfig, ServerConfig};
+        use crate::high_level::{Endpoint, TokioRuntime};
+        use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        let make_dual = || {
+            let (v4, v6) = create_dual_stack_sockets(0).expect("bind dual-stack sockets");
+            let v4 = v4.expect("IPv4 socket required for this test");
+            let v6 = v6.expect("IPv6 socket required for this test");
+            let v4_port = v4.local_addr().unwrap().port();
+            let socket: Arc<dyn AsyncUdpSocket> =
+                Arc::new(wrap_dual_stack(Some(v4), Some(v6)).expect("wrap dual-stack"));
+            (socket, v4_port)
+        };
+
+        let (server_socket, server_v4_port) = make_dual();
+        let (client_socket, _client_v4_port) = make_dual();
+        assert!(server_socket.local_addr().unwrap().is_ipv6());
+        assert!(client_socket.local_addr().unwrap().is_ipv6());
+
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("self-signed cert");
+        let cert_der = CertificateDer::from(cert.cert);
+        let key_der = PrivateKeyDer::Pkcs8(cert.signing_key.serialize_der().into());
+        let chain = vec![cert_der];
+        let server_cfg =
+            ServerConfig::with_single_cert(chain.clone(), key_der).expect("server config");
+
+        let server_ep = Endpoint::new_with_abstract_socket(
+            EndpointConfig::default(),
+            Some(server_cfg),
+            server_socket,
+            Arc::new(TokioRuntime),
+        )
+        .expect("dual-stack server endpoint");
+
+        let server = tokio::spawn(async move {
+            let incoming = server_ep.accept().await.expect("incoming connection");
+            let conn = incoming.await.expect("server handshake");
+            let (mut send, mut recv) = conn.accept_bi().await.expect("server accept_bi");
+            let got = recv.read_to_end(64).await.expect("server read");
+            assert_eq!(got, b"ping");
+            send.write_all(b"pong").await.expect("server write");
+            send.finish().expect("server finish");
+            conn.closed().await;
+        });
+
+        let mut roots = rustls::RootCertStore::empty();
+        for c in chain {
+            roots.add(c).expect("add server cert to roots");
+        }
+        let client_cfg =
+            ClientConfig::with_root_certificates(Arc::new(roots)).expect("client config");
+
+        let mut client_ep = Endpoint::new_with_abstract_socket(
+            EndpointConfig::default(),
+            None,
+            client_socket,
+            Arc::new(TokioRuntime),
+        )
+        .expect("dual-stack client endpoint");
+        client_ep.set_default_client_config(client_cfg);
+
+        let conn = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client_ep
+                .connect((Ipv4Addr::LOCALHOST, server_v4_port).into(), "localhost")
+                .expect("start connect"),
+        )
+        .await
+        .expect("handshake must not stall")
+        .expect("client connected");
+
+        let (mut send, mut recv) = conn.open_bi().await.expect("client open_bi");
+        send.write_all(b"ping").await.expect("client write");
+        send.finish().expect("client finish");
+
+        let echoed = tokio::time::timeout(std::time::Duration::from_secs(10), recv.read_to_end(64))
+            .await
+            .expect("server->client data must arrive between two dual-stack peers")
+            .expect("client read");
+        assert_eq!(echoed, b"pong");
+
+        conn.close(0u32.into(), b"done");
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server).await;
+    }
 }


### PR DESCRIPTION
## Context

The x0x field investigation `20260807-120832` traced a one-way black hole between two hosts on one LAN:

- B (`192.168.1.108`) dialed A (`192.168.1.213`).
- The handshake completed; the connection reached **Live** on both sides.
- B's packets kept arriving at A for minutes.
- **No application data A sent ever reached B** — direct-deliver timeouts began at establishment, ~24 s *before* the T+30 s `ReaderExit` that was previously assumed to be the trigger.
- A was later reaped by the ack-progress idle gate (tracked separately); B stayed Live.

The leading hypothesis was that A's **true dual-stack** bind (separate IPv4 and IPv6 sockets, `DualStackSocket`) sent those replies on the wrong socket. A's endpoint reports `local_addr() == [::]:port`, so it runs with `ipv6 = true` and records every peer in IPv4-mapped form (`[::ffff:192.168.1.108]:5493` appears 40× in A's log). If the wrapper routed a `::ffff:` destination to the **IPv6** socket, a native-IPv4 peer would never see the reply.

## Result: hypothesis REFUTED at this layer

`DualStackUdpSender::select_family` routes an IPv4-mapped destination to the **IPv4** socket whenever one exists (`src/high_level/runtime/dual_stack.rs`), and `convert_dest` unwraps it back to native IPv4 before `try_send_to`. Receive maps v4 sources up to `::ffff:`; send maps them back down. The two halves are symmetric.

The three tests added here exercise that path end-to-end and **all pass against the unmodified implementation**. No production code is changed by this PR.

## Tests added

In `src/high_level/runtime/dual_stack.rs` (the module is `pub(crate)`, so these live beside the code rather than widening the public API for a test):

| Test | What it pins |
|---|---|
| `reply_to_v4_mapped_peer_egresses_from_the_v4_socket` | Feeds the peer address `poll_recv` reports straight back as a `Transmit` destination, exactly as the endpoint does; asserts a native-IPv4 peer receives it **and** sees the listener's IPv4 source address. |
| `inbound_ipv4_connection_delivers_server_to_client_data` | Full QUIC connection dialed over IPv4 into a true-dual-stack listener; asserts delivered stream payload server→client. |
| `dual_stack_peers_exchange_data_over_an_ipv4_dial` | The actual field topology: **both** peers true dual-stack, dial over IPv4. |

All three assert on **delivered bytes in the server→client direction** — the direction that died. The field failure completed its handshake and reached Live, so a connect-only assertion stays green for the entire outage. That is why these assert on payload, not on connection state.

Note the scope limit: these drive the bare `high_level::Endpoint`, so they do **not** exercise the NAT-traversal state machine that the `P2pEndpoint`/`NatTraversalEndpoint` stack activates in the field. See the open defects below.

## Secondary suspect: "Failed to add remote candidate: security validation failed"

Checked and **cleared as a cause of the black hole**:

- The warning comes from `src/connection/mod.rs:4877`. Commit 45705c2c (#221, first shipped in v0.27.36) added an arm at `mod.rs:4863-4872` routing `SecurityValidationFailed` to `debug!`, so that exact WARN string is **unreachable on this branch** — a log containing it came from an ant-quic ≤ 0.27.35 binary. The rejection itself still happens, now silently.
- On rejection `handle_add_address` returns `Ok(())` and leaves `self.path.remote` untouched. Only `TooManyCandidates` is fatal.
- `perform_address_validation` (`src/connection/nat_traversal.rs:815-863`) contains **no RFC1918/private check**; `192.168.1.108:5493` validates as Valid, and so does its `::ffff:` form. `is_suspicious_ipv4` only trips when all four octets are equal.
- The live hazard in that function is `if addr.port() == 0 || addr.port() < 1024 { Suspicious }` (`:858`), which rejects every `:443` candidate from the ADR-0011 x0xd-443 daemons. Verdicts are cached per exact `SocketAddr` with no TTL, so the rejection is sticky. Unrelated to this failure, but worth a separate issue.

What a rejection *does* cost, permanently and silently, for that address: no PATH_CHALLENGE probe, no candidate pair, no port-prediction observation, and no `PeerAddressAdvertised` endpoint event — so the address is never learned for future dials and never written to the bootstrap cache. That is consistent with the field's `candidate_addrs=0` and empty `GET /peers`, and is the most likely reason A could not *re*-establish, though not why the live connection was one-way.

## Open defects found while tracing (NOT fixed here)

**Correction to an earlier claim in this PR's history: migration is *not* fully ruled out.** Stock `Connection::migrate` (`mod.rs:3760`) is packet-driven and safe — reachable only from the received-packet path at `mod.rs:3739-3752`, so the server can only retarget to an address it has just received from. But two NAT-traversal-specific sites retarget *without* packet confirmation:

1. **`migrate_to_nat_traversal_path` (`mod.rs:3807`, migrate at `:3842`)** — reached from `Frame::PathResponse` → `handle_coordination_success` → `mod.rs:3468`. The caller checks the responder against `best_pairs.first()`, but the callee independently re-derives its target (`:3824-3827`, `.find(|pair| pair.remote_addr != self.path.remote).or_else(...)`). It also rewrites the **source** address with no validation — `self.local_ip = Some(local_addr.ip())` at `:3845-3847`, the sole post-handshake writer of `local_ip`, which no later migrate restores. `path.remote` self-heals while the peer keeps sending; `local_ip` does not.
   *Currently unreachable*: `get_best_succeeded_pairs()` is always empty because `local_candidates`' only writers (`nat_traversal.rs:2020`, `:3483`) have no non-test callers, so it returns `Err` at `:3820`. Latent, not live.

2. **`start_nat_traversal_validation` (`mod.rs:4722`)** — reachable in production via `TimeoutAction::StartValidation` (`mod.rs:4699`). Two bugs: its loop stamps a fresh challenge onto **`self.path`** (the live path) rather than the candidate path and never actually sends a PATH_CHALLENGE to `pair.remote_addr`; and `timers.set(Timer::PathValidation, now + 3s)` sits **outside** the loop with no empty-pairs guard, so the timer is armed whenever `nat_traversal` is `Some`. If a legitimate migration is in flight, that clobbers its challenge token and replaces the correct `3 × max(pto, prev_pto)` deadline with a flat 3 s, after which `mod.rs:1697-1706` reverts `self.path = prev`. Harmless while `prev_path` is `None`, which is the common LAN case — so this is a real defect but an unlikely explanation for the reported failure.

Fixing either properly means implementing per-candidate path validation rather than a surgical patch, so both are left for a scoped follow-up.

**Third, separate:** `p2p_endpoint.rs:2974` sets `nat_config.bind_addr` from the dual-stack socket's **IPv6** `local_addr()`. Downstream code then classifies a genuinely dual-stack node as IPv6-only — A's own log says `Skipping best-effort router port mapping for an IPv6-only endpoint (UPnP IGD is IPv4-only) local_addr=[::]:5493` one line after declaring it dual-stack. UPnP is wrongly skipped on every dual-stack node.

## What this does not cover

Loopback cannot exercise real-NIC source-address selection on the two failing hosts. The mechanism the hypothesis proposed is refuted, but an environment-specific variant can only be settled by the packet capture — still blocked on BPF permissions on both machines (procedure and unblock commands are in `pcap-analysis-20260808.md` in the x0x investigation directory).

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo nextest run --all-features --lib` — **2682 passed**, 9 skipped
- New tests: 3 passed

Pre-existing failure, **not** caused by this PR (verified by re-running on the parent commit, where it fails identically): `connection_lifecycle_tests::error_conditions::test_connect_to_nonexistent_peer`.

Refs: ant-quic #234, #235; x0x investigation `20260807-120832`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)