### PR TITLE
fix(lifecycle): report the real transport close reason on reader exit

### DIFF
--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -7185,7 +7185,7 @@ impl NatTraversalEndpoint {
                     return ReaderExitOutcome::ConnectionReaped;
                 }
 
-                if let Some(connection) =
+                let connection =
                     self.connection_lifecycle
                         .read()
                         .get(peer_id)
@@ -7194,19 +7194,32 @@ impl NatTraversalEndpoint {
                                 .iter()
                                 .find(|entry| entry.stable_id() == snapshot.stable_id)
                                 .map(|entry| entry.connection.clone())
-                        })
+                        });
+                let mut closed_by_reader_exit = false;
+                if let Some(connection) = &connection
                     && connection.close_reason().is_none()
                     && let Some(code) = ConnectionCloseReason::ReaderExit.app_error_code()
                 {
                     connection.close(code, ConnectionCloseReason::ReaderExit.reason_bytes());
+                    closed_by_reader_exit = true;
                 }
+                // Observe the transport reason only after the close attempt: a
+                // transport close landing between the guard above and this read
+                // would otherwise be reported as ReaderExit, which
+                // `mark_connection_closed` treats as authoritative and never
+                // re-checks against the connection.
+                let default_close_reason = if closed_by_reader_exit {
+                    ConnectionCloseReason::ReaderExit
+                } else {
+                    connection
+                        .as_ref()
+                        .and_then(|connection| connection.close_reason())
+                        .map(|error| ConnectionCloseReason::from_connection_error(&error))
+                        .unwrap_or(ConnectionCloseReason::ReaderExit)
+                };
                 let close_reason = self
-                    .mark_connection_closed(
-                        peer_id,
-                        snapshot.stable_id,
-                        ConnectionCloseReason::ReaderExit,
-                    )
-                    .unwrap_or(ConnectionCloseReason::ReaderExit);
+                    .mark_connection_closed(peer_id, snapshot.stable_id, default_close_reason)
+                    .unwrap_or(default_close_reason);
                 self.connections.remove(peer_id);
                 self.emitted_established_events.remove(peer_id);
                 let mut lifecycle = self.connection_lifecycle.write();
@@ -11210,6 +11223,22 @@ mod tests {
         let default_keepalive = TransportConfig::default().keep_alive_interval;
 
         assert_eq!(transport_config.keep_alive_interval, default_keepalive);
+        // Compare against the idle timeout this config actually sets, not a
+        // literal: pinning 30s here would keep passing if the idle timeout were
+        // lowered below the keepalive interval, which is the failure this
+        // assertion exists to catch.
+        let idle_timeout = transport_config
+            .max_idle_timeout
+            .map(|timeout| Duration::from_millis(timeout.into_inner()));
+        assert!(
+            matches!(
+                (transport_config.keep_alive_interval, idle_timeout),
+                (Some(keepalive), Some(idle)) if keepalive < idle
+            ),
+            "QUIC keepalive ({:?}) must fire before the configured idle timeout ({:?})",
+            transport_config.keep_alive_interval,
+            idle_timeout
+        );
         assert_ne!(
             transport_config.keep_alive_interval,
             Some(config.timeouts.nat_traversal.retry_interval),


### PR DESCRIPTION
Split out of #237, per the review there.

## What this is

Reader-exit handling always recorded `ConnectionCloseReason::ReaderExit`, so a connection the transport had already closed — a QUIC idle timeout above all — was filed under a reason that says nothing about why it ended. That is exactly the gap that made #234 hard to read from the field logs: they show `ReaderExit` where `TimedOut` would have named the reaper in one shot.

The connection's close reason is now observed *after* the reader-exit close attempt and used as the recorded reason. Reading it before the attempt leaves a window in which a transport close landing between the two reads is still reported as `ReaderExit`, because `mark_connection_closed` treats the first reason it is handed as authoritative and never re-checks it against the connection. That race fix is commit `c5c92384` from the original branch, carried here.

The keepalive test now also asserts the relationship it exists to protect — that the configured keepalive fires before the configured idle timeout — instead of only that the keepalive equals the transport default. Pinning the default alone would keep passing if the idle timeout were lowered beneath it.

## What this deliberately does not carry

#237's `keep_alive_interval` 15s → 10s change. `TransportConfig::default()` already sets `keep_alive_interval = Some(15s)`; keepalive was never disabled, so the interval change cannot explain a 30s teardown and does not fix #234. See the review comment on #237.

This PR therefore makes no behavioural claim about #234 — it is observability, and it is what makes the next field occurrence self-diagnosing.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all-features --workspace` filtered to lifecycle / reconnect / health / close-reason / keepalive / transport-config: 71/71 pass

Refs #234, #237.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves lifecycle observability by deriving reader-exit records from the transport’s close reason when the connection was already closed, while retaining `ReaderExit` when the reader initiates closure.
- Reads the transport close reason after the reader-exit close attempt to capture reasons such as idle timeout.
- Adds a keepalive configuration assertion requiring the interval to precede the configured idle timeout.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The updated lifecycle path preserves reader-initiated closure precedence while reporting an existing transport close reason, and the additional test directly checks the intended keepalive timing relationship.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/nat_traversal_api.rs | Refines reader-exit close-reason selection and strengthens the keepalive-versus-idle-timeout test without an identified actionable defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(lifecycle): report the real transpor..."](https://github.com/saorsa-labs/ant-quic/commit/3251a3e764332c1c10135ad2e1a5dc7bc09ebd68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51464127)</sub>

<!-- /greptile_comment -->