### PR TITLE
fix(connection): let received application payload reset the idle timer (#234)

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -224,6 +224,12 @@ pub struct Connection {
     /// (zombie-connection defense; deliberate deviation from RFC 9000 §10.1 —
     /// see x0x#278).
     ack_progress_at: Instant,
+    /// Instant at which the peer last delivered application payload we had not
+    /// already received (new stream bytes or a datagram). `None` until the peer
+    /// delivers any. Distinguishes a peer doing useful work in the receive
+    /// direction — which must never be reaped while it keeps doing so — from a
+    /// zombie that only emits retransmits, keepalives and junk (x0x#234).
+    peer_payload_at: Option<Instant>,
     timers: TimerTable,
     /// Number of packets received which could not be authenticated
     authentication_failures: u64,
@@ -381,6 +387,7 @@ impl Connection {
                 Some(dur) => Some(Duration::from_millis(dur.0)),
             },
             ack_progress_at: now,
+            peer_payload_at: None,
             timers: TimerTable::default(),
             authentication_failures: 0,
             error: None,
@@ -2475,10 +2482,24 @@ impl Connection {
         //
         // When we hold no ack-eliciting data we reset unconditionally (healthy
         // keepalive, RFC 9000 §10.1 compatible). When we DO hold such data we
-        // only reset while the peer is making ACK progress within the idle
-        // window; otherwise we let `Timer::Idle` reap the connection. This is a
-        // deliberate hardening deviation from RFC 9000 §10.1.
-        if self.no_unacked_data() || self.ack_progress_recent(now) {
+        // reset while the peer is making ACK progress within the idle window.
+        //
+        // Neither of those covers a half-broken path: our packets are not
+        // reaching the peer (so it cannot ACK) while the peer's packets are
+        // reaching us and carrying application payload. The original gate reaped
+        // that connection at the idle timeout even though the peer was demonstrably
+        // alive and the receive direction was doing useful work, and — because an
+        // idle kill sends no CONNECTION_CLOSE — the peer never learned, leaving a
+        // permanent half-open link (x0x#234). Receipt of *new* application payload
+        // therefore also resets the timer.
+        //
+        // Payload receipt is the discriminator rather than packet receipt: the
+        // x0x#278 zombies did keep transmitting authenticated packets, so resetting
+        // on any authenticated packet would restore that leak verbatim. A peer that
+        // only retransmits data we already hold, PINGs and sends junk advances no
+        // offsets, so it still times out.
+        if self.no_unacked_data() || self.ack_progress_recent(now) || self.peer_payload_recent(now)
+        {
             self.reset_idle_timeout(now, space_id);
         }
         self.permit_idle_reset = true;
@@ -2542,6 +2563,21 @@ impl Connection {
             Some(d) => d,
         };
         now.saturating_duration_since(self.ack_progress_at) < timeout
+    }
+
+    /// Whether the peer delivered application payload we had not already received
+    /// within the current idle window. Such a peer is doing useful work in the
+    /// receive direction and must not be reaped merely because our own sends are
+    /// going unacknowledged (x0x#234).
+    fn peer_payload_recent(&self, now: Instant) -> bool {
+        let timeout = match self.idle_timeout {
+            None => return true,
+            Some(d) => d,
+        };
+        match self.peer_payload_at {
+            None => false,
+            Some(at) => now.saturating_duration_since(at) < timeout,
+        }
     }
 
     fn reset_keep_alive(&mut self, now: Instant) {
@@ -3346,6 +3382,10 @@ impl Connection {
         let mut close = None;
         let payload_len = payload.len();
         let mut ack_eliciting = false;
+        // Snapshot the peer's delivered stream bytes so we can tell new payload
+        // from a retransmission of data we already hold (x0x#234 idle gate).
+        let stream_bytes_before = self.streams.data_recvd();
+        let mut datagram_received = false;
         for result in frame::Iter::new(payload)? {
             let frame = result?;
             let span = match frame {
@@ -3639,6 +3679,7 @@ impl Connection {
                     token_store.insert(server_name, token);
                 }
                 Frame::Datagram(datagram) => {
+                    datagram_received = true;
                     let result = self
                         .datagrams
                         .received(datagram, &self.config.datagram_receive_buffer_size)?;
@@ -3712,6 +3753,12 @@ impl Connection {
                     self.handle_try_connect_to_response(&response)?;
                 }
             }
+        }
+
+        // Datagrams are never retransmitted, so any that arrived are new payload;
+        // stream frames count only where they advanced offsets we had not seen.
+        if datagram_received || self.streams.data_recvd() > stream_bytes_before {
+            self.peer_payload_at = Some(now);
         }
 
         let space = &mut self.spaces[SpaceId::Data];

--- a/src/connection/streams/state.rs
+++ b/src/connection/streams/state.rs
@@ -239,6 +239,14 @@ impl StreamsState {
         self.connection_blocked.clear();
     }
 
+    /// Sum of end offsets of all receive streams, i.e. a monotonic count of the
+    /// stream bytes the peer has delivered to us. Advances only for offsets we
+    /// have not seen before, so retransmissions of already-received data leave
+    /// it unchanged.
+    pub(crate) fn data_recvd(&self) -> u64 {
+        self.data_recvd
+    }
+
     /// Process incoming stream frame
     ///
     /// If successful, returns whether a `MAX_DATA` frame needs to be transmitted


### PR DESCRIPTION
## The defect

The x0x#278 hardening (`61ff6ba2`) gates the idle-timer reset on ACK progress whenever we hold unacked ack-eliciting data:

```rust
if self.no_unacked_data() || self.ack_progress_recent(now) {
    self.reset_idle_timeout(now, space_id);
}
```

It exists for a real leak: a peer that keeps transmitting authenticated packets but never acknowledges ours used to pin the connection and its ~9.5 MiB send window forever, measured at ~200 MB/h RSS growth and OOM in 12–24h on 4 GB fleet nodes.

The gate cannot distinguish two situations that look identical from the ACK side:

1. a zombie emitting retransmits, keepalives and junk, and
2. a peer actively delivering us application data over a path whose reverse direction is broken.

Both are reaped. The second is wrong: the peer is demonstrably alive, the receive direction is doing useful work, and because an idle kill is RFC-conformant in sending no `CONNECTION_CLOSE`, the peer cannot learn — which is the permanent half-open link reported in #234.

## The change

Add a third reset condition: the peer delivered application payload within the idle window.

```rust
if self.no_unacked_data() || self.ack_progress_recent(now) || self.peer_payload_recent(now) {
```

**Payload receipt, not packet receipt, is the discriminator.** The #278 zombies did keep transmitting authenticated packets, so resetting on any authenticated packet — the obvious reading of RFC 9000 §10.1 — would restore that leak verbatim. Payload is tracked by watching the connection-level received-stream-byte counter across `process_payload`, so only offsets we had not already seen count; retransmissions of data we already hold do not qualify. Datagrams are never retransmitted, so any that arrive always do.

This narrows the #278 gate rather than reverting it. A peer that goes silent is still reaped at the idle timeout; so is one that only PINGs.

## Verification status — please read before merging

**The asymmetric-survival property is not covered by an automated test, and I could not build one.** Reproducing #234's precondition end-to-end needs one side that simultaneously (a) holds unacked ack-eliciting data, (b) never makes ACK progress, and (c) keeps receiving from a peer that stays alive. With two real endpoints those are mutually exclusive:

- Keeping the peer alive requires delivering *some* of our packets to it, and any delivered ack-eliciting packet is acknowledged, restoring ACK progress and destroying (b). PTO probes are ack-eliciting and small, so a size-based filter does not separate them.
- Delivering nothing starves the peer, which is then reaped one idle window later — the same window in which our own ACK-progress record expires, so both sides die together and the two outcomes coincide.
- `AckFrequencyConfig::max_ack_delay` cannot stall the peer's ACKs either; it is clamped to at most `max(path RTT, 25ms)`.

Three harness variants were built and measured against both this branch and unmodified master; every one passed identically on both, i.e. vacuously. They are not included rather than shipped green and meaningless.

What would close this is a deterministic sans-io pair harness (quinn-proto's `tests/util.rs` shape) driving `LowLevelEndpoint`/`Connection` with virtual time, where delivery is chosen per packet and the peer's idle timer simply is not fired. ant-quic does not currently have one. I would treat that as the blocking follow-up.

**A related finding, which bears on #234's root cause:** because the gate only bites when *nothing* we send reaches the peer, it cannot reap a connection whose peer is reachable enough to acknowledge anything at all. That makes it an unlikely explanation for the field's 30s teardown on its own. Detail in my comment on #234.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --all-features --workspace` filtered to idle / lifecycle / reconnect / timeout / health: 126/126 pass, including `reconnect_reader_task::recv_after_reconnect` (known flake, #238) on the first attempt

Refs #234.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tracks newly delivered stream bytes and DATAGRAMs and uses their recency to keep receive-active, asymmetric connections alive. The current ordering misses the qualifying packet's own idle reset, while unconditional DATAGRAM qualification permits peers without ACK progress to retain connection resources indefinitely.
- Adds `peer_payload_at` state and a `peer_payload_recent` idle-reset condition.
- Exposes the aggregate received-stream-byte counter to distinguish new offsets from retransmissions.
- Marks successfully processed DATAGRAMs as new application payload.

<h3>Confidence Score: 2/5</h3>

This PR should not merge until payload receipt resets the current packet's idle deadline and DATAGRAM traffic cannot bypass the no-ACK-progress resource defense indefinitely.

The receive ordering leaves the reported asymmetric-timeout path reachable, and periodic DATAGRAMs create an authenticated resource-retention path that defeats the existing zombie-connection hardening.

**Files Needing Attention:** src/connection/mod.rs

<details open><summary><h3>Security Review</h3></summary>

An authenticated peer can withhold ACKs while sending periodic DATAGRAMs to continually reset the idle timer, retaining the connection and its unacknowledged send resources indefinitely.

**How this was verified:** The receive path marks every accepted DATAGRAM as recent payload, and that state directly bypasses the ACK-progress requirement without consuming stream or connection flow-control credit.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/connection/mod.rs | Adds payload-recency tracking and idle-reset integration, but records payload after the reset decision and lets periodic DATAGRAMs bypass ACK-progress reaping. |
| src/connection/streams/state.rs | Exposes the existing monotonic received-stream-byte counter for detecting newly delivered stream offsets; no independent defect was identified here. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Peer
    participant Auth as on_packet_authenticated
    participant Payload as process_payload
    participant Idle as Idle timer
    Peer->>Auth: Packet carrying new payload
    Auth->>Auth: Check peer_payload_recent (old value)
    Note over Auth,Idle: Current packet does not reset idle deadline
    Auth->>Payload: Process frames
    Payload->>Payload: "Set peer_payload_at = now"
    Idle-->>Payload: Existing deadline may expire first
    loop Periodic DATAGRAM traffic
        Peer->>Payload: Accepted DATAGRAM
        Payload->>Payload: Refresh peer_payload_at
        Peer->>Auth: Next authenticated packet
        Auth->>Idle: Reset despite no ACK progress
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/connection/mod.rs:3760-3761
**Current payload misses idle reset**

When the first new application payload arrives after `peer_payload_at` is absent or stale, `on_packet_authenticated` checks the old value before `process_payload` records the current packet, so that packet does not extend the idle deadline and the active connection can still time out before another packet arrives.

### Issue 2
src/connection/mod.rs:3679-3684
**Datagrams bypass ACK-progress reaping**

When an authenticated peer withholds ACKs while sending periodic DATAGRAMs, every accepted DATAGRAM refreshes `peer_payload_at` without consuming stream or connection flow-control credit, so the peer can continually reset the idle timer and retain the connection's unacknowledged send resources indefinitely.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(connection): let received applicatio..."](https://github.com/saorsa-labs/ant-quic/commit/10fc7b83e88883246f6d2cf9ed30c049bb201700) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51464202)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->