### PR TITLE
fix(transport): transient send errors must not kill the connection driver

### DIFF
--- a/src/high_level/connection.rs
+++ b/src/high_level/connection.rs
@@ -26,6 +26,7 @@ use tracing::{Instrument, Span, debug, debug_span, error};
 
 use super::{
     ConnectionEvent,
+    endpoint::is_transient_socket_error,
     mutex::Mutex,
     recv_stream::RecvStream,
     runtime::{AsyncTimer, AsyncUdpSocket, Runtime, UdpSender},
@@ -1448,6 +1449,24 @@ impl State {
                     }
                 }
                 Poll::Ready(Err(e)) => {
+                    // A destination the host cannot reach (a peer-advertised
+                    // NAT candidate on an unreachable subnet or address family)
+                    // must not be fatal. Returning `Err` here ends the
+                    // connection driver task for good: the connection stays
+                    // `Live` to the application while emitting no ACKs, no PTO
+                    // probes and no idle-timeout CONNECTION_CLOSE, so the peer
+                    // sees a black hole while this side reports a healthy
+                    // connection indefinitely. Drop the datagram and let loss
+                    // recovery retransmit over a path that works — the same
+                    // treatment the endpoint receive path already gives this
+                    // error class (x0x issue #262).
+                    if is_transient_socket_error(&e) {
+                        debug!(
+                            "ignoring transient socket send error to {}: {}",
+                            t.destination, e
+                        );
+                        continue;
+                    }
                     // X0X-0043: a hard error from the kernel send path is
                     // the closest measurable proxy for a "partial send"
                     // today. When the runtime is rewritten to use

--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -65,7 +65,7 @@ use crate::{EndpointConfig, VarInt};
 /// Raw errnos cover platform gaps in `io::ErrorKind` mapping: 49
 /// (EADDRNOTAVAIL, macOS), 51/65 (ENETUNREACH/EHOSTUNREACH, macOS),
 /// 101/113 (ENETUNREACH/EHOSTUNREACH, Linux).
-fn is_transient_socket_error(error: &io::Error) -> bool {
+pub(crate) fn is_transient_socket_error(error: &io::Error) -> bool {
     matches!(
         error.kind(),
         io::ErrorKind::AddrNotAvailable


### PR DESCRIPTION
## What

`State::drive_transmit` treats every non-`WouldBlock` error from `UdpSender::poll_send` as fatal:

```rust
Poll::Ready(Err(e)) => { ...; return Err(e); }
```

`ConnectionDriver::poll` propagates that with `?`, so the connection's driver task ends permanently. Nothing restarts it.

A single unreachable destination is enough to trigger this — for example a peer-advertised NAT-traversal candidate on a subnet or address family the local host cannot reach. The consequences are severe and silent:

- no ACKs, so the peer PTO-retransmits into a black hole
- no PTO probes of our own
- no idle timeout, therefore **no `CONNECTION_CLOSE` is ever sent**
- `Connection::is_closed()` stays `false`, so the application keeps reporting the peer as connected indefinitely

## Evidence

Reproduced live (x0x, two macOS hosts on one LAN, 4/4 runs). The joining node stopped transmitting 92 ms after its connection reached `Live`, then received 81 KB / 69 further datagrams over 95 s and answered none, while its own `/network/status` reported `connected_peers=1`. With `aqwedge` instrumentation on the driver:

```
20:52:16.448428 conn driver poll: enter ch=0 connected=true drained=false has_error=false
20:52:16.448468 conn driver: drive_transmit FATAL — driver ends ch=0
                  error=No route to host (os error 65)
20:52:16.448476 DEBUG ant_quic::high_level::connection: background I/O path ended:
                  No route to host (os error 65)
```

Note the only stock signal is that last line, at **DEBUG**. Three prior reproductions ran at `RUST_LOG=info` and produced no explanation at all — the same visibility trap as x0x#262.

## Why this is a re-run of a known defect

`is_transient_socket_error` (`high_level/endpoint.rs`) already classifies this exact error class, including `raw_os_error == 65`. It was added by **x0x#262** with the comment:

> every ICMP-derived transient error a single unreachable peer can pin on the shared socket — terminating the driver here silently kills ALL transport for the process

That hardening was applied only to the endpoint **receive** path (`RecvState::poll_socket`). The **send** path in the connection driver was never guarded, and the helper was private to `endpoint.rs` so it could not be reused. This PR closes that gap.

## Change

1. `high_level/endpoint.rs` — `is_transient_socket_error` becomes `pub(crate)`.
2. `high_level/connection.rs` — `drive_transmit` classifies the error first; transient errors log at `debug!` and `continue`, dropping that datagram so QUIC loss recovery retransmits over a path that works. Non-transient errors keep the existing fatal behaviour.

The drop is bounded: `continue` re-enters the loop with `buffered_transmit` already consumed, and the loop exits when `poll_transmit` returns `None` or `MAX_TRANSMIT_DATAGRAMS` is reached. No hot loop.

## Verification

- `cargo fmt --check`, `cargo clippy --lib --all-features -D warnings`: clean
- `cargo nextest run --lib --all-features` over driver/connection/endpoint tests: **614 passed**
- Live rerun on the reproducing pair with the fix applied: the connection driver **survives** (0 fatal exits, 62 transient sends dropped and logged), the endpoint driver keeps polling for the full run, and the connection now completes a correct `Live → Closing → Closed` idle-timeout and redials — instead of sitting mute and permanently "connected".

## Test gap (stated explicitly)

The classifier itself is covered by the existing `driver_error_tests`. There is **no** unit test asserting that the *send* path honours it, because that needs a mock `UdpSender` driving a full `ConnectionDriver`, which this crate has no fixture for. Worth adding; not done here.

## Scope note

This fix removes a permanent silent wedge. It does not by itself restore delivery on the reproducing pair: with the driver alive, the sends still fail with EHOSTUNREACH to the peer's IPv4-mapped address, which is a separate defect being investigated (a v6-only socket selected for an IPv4-mapped destination is the leading hypothesis). Fixing it there does not change the correctness of this change — a driver must not die on a per-datagram error regardless.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reuses the endpoint’s transient socket-error classifier in the connection send path so destination-specific failures no longer terminate the connection driver.
- Exposes `is_transient_socket_error` within the crate.
- Drops and logs classified failed sends while preserving fatal handling for other errors.
- The new `continue` bypasses the loop’s transmit-budget check.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking concern that persistent transient send failures can bypass the intended per-poll work limit.

The error-handling change preserves the driver as intended, but its early loop continuation can perform excess transmit generation and accounting during persistent failures.

**Files Needing Attention:** src/high_level/connection.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/high_level/connection.rs | Adds transient send-error recovery, but the recovery branch skips the per-poll transmit-budget check. |
| src/high_level/endpoint.rs | Widens the existing socket-error classifier to crate visibility without changing its classification behavior. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/high_level/connection.rs:1468
**Transient errors bypass transmit budget**

A classified send failure reaches `continue` before the `MAX_TRANSMIT_DATAGRAMS` check, so persistent transient errors can generate and account for more than the configured per-poll transmit budget, increasing CPU work and phantom in-flight accounting until the protocol stops producing transmits.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(transport): transient send errors mu..."](https://github.com/saorsa-labs/ant-quic/commit/6de3bdac4e7a08eab0ad1439ea0dac20027120bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51487926)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->