### PR TITLE
test(lifecycle): hermetic tests + x0x fleet defaults for connectivity matrix

### DIFF
--- a/scripts/run-connectivity-matrix.sh
+++ b/scripts/run-connectivity-matrix.sh
@@ -29,21 +29,28 @@ SSH_OPTS=(
     -o StrictHostKeyChecking=accept-new
 )
 
-PUBLIC_NAMES=("saorsa1" "saorsa2" "vultr1" "vultr2")
+# Default public fleet: the six x0x bootstrap VPS nodes
+# (docs: ../x0x/docs/ecosystem.md). Override per-run with *_CSV env vars.
+PUBLIC_NAMES=("saorsa-2" "saorsa-3" "saorsa-6" "saorsa-7" "saorsa-8" "saorsa-9")
 PUBLIC_TARGETS=(
-    "root@77.42.75.115"
     "root@142.93.199.50"
-    "root@149.28.156.231"
-    "root@45.77.176.184"
+    "root@147.182.234.192"
+    "root@65.21.157.229"
+    "root@116.203.101.172"
+    "root@152.42.210.67"
+    "root@170.64.176.102"
 )
 PUBLIC_IPV4S=(
-    "77.42.75.115"
     "142.93.199.50"
-    "149.28.156.231"
-    "45.77.176.184"
+    "147.182.234.192"
+    "65.21.157.229"
+    "116.203.101.172"
+    "152.42.210.67"
+    "170.64.176.102"
 )
 
 LOCAL_NAMES=("macbook" "studio1" "studio2")
+# studio2 is currently offline; override with LOCAL_NAMES_CSV/LOCAL_TARGETS_CSV
 LOCAL_TARGETS=("LOCAL" "studio1@studio1.local" "studio2@studio2.local")
 
 REMOTE_LINUX_BINARY_PATH="/root/ant-quic-matrix/bin/ant-quic"

--- a/tests/connection_lifecycle_tests.rs
+++ b/tests/connection_lifecycle_tests.rs
@@ -8,7 +8,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use ant_quic::{
-    EndpointError, NatConfig, P2pConfig, P2pEndpoint, PeerId, PqcConfig, transport::TransportAddr,
+    EndpointError, NatConfig, P2pConfig, P2pEndpoint, PeerId, PqcConfig,
+    bootstrap_cache::BootstrapCacheConfig, transport::TransportAddr,
 };
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -60,6 +61,18 @@ fn test_node_config(known_peers: Vec<SocketAddr>) -> P2pConfig {
     P2pConfig::builder()
         .bind_addr(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
         .known_peers(known_peers)
+        // Isolate from any real bootstrap cache on this machine: a populated
+        // cache would surface coordinator candidates for connect_peer, turning
+        // the unknown-peer error tests into full NAT-traversal attempts.
+        .bootstrap_cache(
+            BootstrapCacheConfig::builder()
+                .cache_dir(
+                    std::env::temp_dir()
+                        .join(format!("ant-quic-lifecycle-tests-{}", std::process::id())),
+                )
+                .persist(false)
+                .build(),
+        )
         .nat(NatConfig {
             enable_relay_fallback: false,
             ..Default::default()


### PR DESCRIPTION
## Summary
- `test_connect_to_nonexistent_peer` failed on any machine with a populated default bootstrap cache (1000+ persisted peers surfaced coordinator candidates, turning the fast PeerNotFound path into a full NAT-traversal attempt that outlives the 5s test timeout). The shared test config now uses a per-process temp cache dir with `persist: false`.
- Default public fleet in `run-connectivity-matrix.sh` updated from the dead/repurposed nodes to the six x0x bootstrap VPS nodes (saorsa-2/3/6/7/8/9). Validated with a full green matrix run of v0.27.37 (saorsa-3 + saorsa-9 + macbook + studio1): base connectivity, public→local NAT probes, IPv6 matrix, mDNS discovery all passed.

## Notes
- studio2 (LAN test node) is offline; per-run `*_CSV` env overrides still work.

All quality gates pass: fmt, strict clippy, cargo check.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the connectivity-matrix script’s default public fleet to six x0x bootstrap VPS nodes and documents the offline local node override. It also isolates connection-lifecycle tests from machine bootstrap-cache state by using nonpersistent in-memory caches.
- Replaces four public connectivity targets with six current bootstrap nodes.
- Configures lifecycle-test endpoints with `persist(false)` bootstrap caches.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code defects identified.

The revised fleet arrays remain aligned, and the lifecycle tests receive fresh in-memory bootstrap caches because persistence is disabled.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/run-connectivity-matrix.sh | Updates the public fleet’s names and addresses and documents how to override the currently offline local target. |
| tests/connection_lifecycle_tests.rs | Prevents host bootstrap-cache contents from influencing unknown-peer lifecycle tests by selecting a nonpersistent cache configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(scripts): default the connectivity..."](https://github.com/saorsa-labs/ant-quic/commit/afad4e2b33426d4adbcbd3a2cbac374f30e8b284) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54051751)</sub>

<!-- /greptile_comment -->