### PR TITLE
fix(high-level): reset unfinished SendStream on drop instead of finish (closes #244)

### DIFF
--- a/src/high_level/mod.rs
+++ b/src/high_level/mod.rs
@@ -31,7 +31,7 @@ pub use self::endpoint::{Accept, Endpoint, EndpointStats};
 pub use self::incoming::{Incoming, IncomingFuture, RetryError};
 pub use self::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream, ResetError};
 pub use self::runtime::{AsyncTimer, AsyncUdpSocket, Runtime, UdpSender, default_runtime};
-pub use self::send_stream::{SendStream, StoppedError, WriteError};
+pub use self::send_stream::{DROPPED_UNFINISHED_ERROR_CODE, SendStream, StoppedError, WriteError};
 pub use crate::path::{Path, PathId, WeakPathHandle};
 
 // TokioRuntime is always available (tokio is a required dependency)

--- a/src/high_level/send_stream.rs
+++ b/src/high_level/send_stream.rs
@@ -19,10 +19,25 @@ use thiserror::Error;
 use super::connection::{ConnectionRef, State};
 use crate::VarInt;
 
+/// Application error code used to [`reset()`] a stream that is dropped without having been
+/// explicitly [`finish()`]ed.
+///
+/// The value is deliberately distinctive so that it is unambiguous in packet captures and peer-side
+/// logs, and so that it is vanishingly unlikely to collide with an application's own error codes,
+/// which conventionally start at 0.
+///
+/// [`reset()`]: SendStream::reset
+/// [`finish()`]: SendStream::finish
+pub const DROPPED_UNFINISHED_ERROR_CODE: VarInt = VarInt::from_u32(0xA17C_0244);
+
 /// A stream that can only be used to send data
 ///
-/// If dropped, streams that haven't been explicitly [`reset()`] will be implicitly [`finish()`]ed,
-/// continuing to (re)transmit previously written data until it has been fully acknowledged or the
+/// If dropped without an explicit [`finish()`], the stream is [`reset()`] with
+/// [`DROPPED_UNFINISHED_ERROR_CODE`], so that the peer observes a stream error rather than a
+/// graceful end-of-stream at whatever offset writing happened to reach. Dropping is therefore safe
+/// in the face of a cancelled write: an abandoned transfer cannot masquerade as a complete one.
+/// A sender that wants the graceful path must call [`finish()`] itself, after which the stream will
+/// continue to (re)transmit previously written data until it has been fully acknowledged or the
 /// connection is closed.
 ///
 /// # Cancellation
@@ -40,6 +55,13 @@ pub struct SendStream {
     conn: ConnectionRef,
     stream: StreamId,
     is_0rtt: bool,
+    /// Whether the application explicitly asked for a graceful close.
+    ///
+    /// `Drop` needs this to tell an intentional end-of-stream from an abandoned one. It cannot be
+    /// recovered from the underlying stream state, because `reset()` is legal *after* `finish()`
+    /// (it abandons still-buffered data), so a dropped stream that reset unconditionally would
+    /// destroy every well-behaved sender's graceful close.
+    finished: bool,
 }
 
 impl SendStream {
@@ -48,6 +70,7 @@ impl SendStream {
             conn,
             stream,
             is_0rtt,
+            finished: false,
         }
     }
 
@@ -152,13 +175,17 @@ impl SendStream {
         let mut conn = self.conn.state.lock("finish");
         match conn.inner.send_stream(self.stream).finish() {
             Ok(()) => {
+                self.finished = true;
                 conn.wake();
                 Ok(())
             }
             Err(FinishError::ClosedStream) => Err(ClosedStream::default()),
             // Harmless. If the application needs to know about stopped streams at this point, it
             // should call `stopped`.
-            Err(FinishError::Stopped(_)) => Ok(()),
+            Err(FinishError::Stopped(_)) => {
+                self.finished = true;
+                Ok(())
+            }
             Err(FinishError::ConnectionClosed) => Err(ClosedStream::default()),
         }
     }
@@ -309,6 +336,24 @@ impl Drop for SendStream {
         if conn.error.is_some() || (self.is_0rtt && conn.check_0rtt().is_err()) {
             return;
         }
+
+        if !self.finished {
+            // The application abandoned this stream mid-transfer — a cancelled `write_all`, an
+            // aborted task. Finishing here would hand the peer a well-formed FIN at whatever offset
+            // writing reached, which reads as a complete but silently truncated message. Reset
+            // instead, so the truncation surfaces as a stream error. Already reset or already gone
+            // yields `ClosedStream`, which is fine.
+            if conn
+                .inner
+                .send_stream(self.stream)
+                .reset(DROPPED_UNFINISHED_ERROR_CODE)
+                .is_ok()
+            {
+                conn.wake();
+            }
+            return;
+        }
+
         match conn.inner.send_stream(self.stream).finish() {
             Ok(()) => conn.wake(),
             Err(FinishError::Stopped(reason)) => {

--- a/src/link_transport.rs
+++ b/src/link_transport.rs
@@ -1245,6 +1245,15 @@ pub struct ConnectionStats {
 }
 
 /// A send stream for writing data to a peer.
+///
+/// # Dropping
+///
+/// Dropping a send stream that has not been [`finish`](LinkSendStream::finish)ed
+/// resets it, and the peer observes a stream error. This is deliberate: an
+/// abandoned write — a cancelled future, an aborted task — would otherwise reach
+/// the peer as a graceful end-of-stream at whatever offset writing happened to
+/// stop, which is indistinguishable from a complete but shorter message. Callers
+/// that intend a graceful close must say so by calling `finish`.
 pub trait LinkSendStream: Send + Sync {
     /// Write data to the stream.
     fn write<'a>(&'a mut self, data: &'a [u8]) -> BoxFuture<'a, LinkResult<usize>>;
@@ -1253,6 +1262,8 @@ pub trait LinkSendStream: Send + Sync {
     fn write_all<'a>(&'a mut self, data: &'a [u8]) -> BoxFuture<'a, LinkResult<()>>;
 
     /// Finish the stream (signal end of data).
+    ///
+    /// Required for a graceful close; see the trait-level "Dropping" note.
     fn finish(&mut self) -> LinkResult<()>;
 
     /// Reset the stream with an error code.

--- a/src/masque/relay_server.rs
+++ b/src/masque/relay_server.rs
@@ -954,6 +954,11 @@ impl MasqueRelayServer {
         mut send_stream: crate::high_level::SendStream,
         mut recv_stream: crate::high_level::RecvStream,
     ) {
+        // Both bail-outs below drop `send_stream` without finishing it, which resets
+        // the stream. That is the intended signal: the relay accepted a CONNECT-UDP
+        // session and then could not serve it, so the client must see an error and
+        // re-establish. A graceful finish here would look to the client like a relay
+        // session that opened and closed normally, having forwarded nothing.
         let udp_socket = {
             let sessions = self.sessions.read().await;
             match sessions.get(&session_id) {
@@ -986,9 +991,11 @@ impl MasqueRelayServer {
         let stats = self.stats();
         let stats2 = self.stats();
 
-        tokio::select! {
+        // `true` once the forwarding loop ends with no half-written frame on the
+        // send stream, which is the only state in which a graceful finish is safe.
+        let send_stream_intact = tokio::select! {
             // Direction 1: UDP → Stream (target → relay → client)
-            _ = async {
+            intact = async {
                 let mut buf = vec![0u8; 65536];
                 loop {
                     match socket.recv_from(&mut buf).await {
@@ -1006,25 +1013,29 @@ impl MasqueRelayServer {
 
                             // Write length-prefixed frame to stream
                             let frame_len = encoded.len() as u32;
+                            // A failed write may have left a partial frame on the
+                            // wire, so the stream is no longer safe to finish.
                             if let Err(e) = send_stream.write_all(&frame_len.to_be_bytes()).await {
                                 tracing::debug!(session_id, error = %e, "Stream write error (length)");
-                                break;
+                                break false;
                             }
                             if let Err(e) = send_stream.write_all(&encoded).await {
                                 tracing::debug!(session_id, error = %e, "Stream write error (data)");
-                                break;
+                                break false;
                             }
 
                             stats.record_bytes(encoded.len() as u64);
                             stats.record_datagram();
                         }
                         Err(e) => {
+                            // The UDP side died between frames; every frame written
+                            // so far is complete, so a graceful finish is correct.
                             tracing::debug!(session_id, error = %e, "UDP recv error");
-                            break;
+                            break true;
                         }
                     }
                 }
-            } => {},
+            } => intact,
 
             // Direction 2: Stream → UDP (client → relay → target)
             _ = async {
@@ -1071,8 +1082,25 @@ impl MasqueRelayServer {
                         }
                     }
                 }
-            } => {},
+            } => {
+                // The read direction ended first, so `select!` cancelled the write
+                // direction at an arbitrary await point — possibly midway through a
+                // frame. Treat the send stream as compromised.
+                false
+            },
+        };
+
+        if send_stream_intact {
+            // Graceful teardown: finishing keeps QUIC retransmitting frames that are
+            // written but not yet acknowledged, so the last relayed packets still
+            // reach the client. Resetting here would discard them.
+            if let Err(e) = send_stream.finish() {
+                tracing::debug!(session_id, error = %e, "Error finishing relay send stream");
+            }
         }
+        // Otherwise `send_stream` is dropped unfinished and therefore reset, so a
+        // partial trailing frame surfaces at the client as a stream error instead of
+        // a truncated frame that its length-prefixed reader would misparse.
 
         tracing::info!(session_id, "Stream-based relay forwarding loop ended");
         if let Err(e) = self.close_session(session_id).await {

--- a/src/masque/relay_socket.rs
+++ b/src/masque/relay_socket.rs
@@ -128,15 +128,30 @@ impl MasqueRelaySocket {
 
         // Background task: write queued outbound packets to relay stream
         tokio::spawn(async move {
-            while let Some(encoded) = send_rx.recv().await {
+            loop {
+                let Some(encoded) = send_rx.recv().await else {
+                    // Every sender is gone, i.e. the socket was dropped. Nothing is
+                    // half-written, so finish gracefully: QUIC keeps retransmitting
+                    // frames that are queued but not yet acknowledged, so packets
+                    // already handed to the relay still arrive.
+                    if let Err(e) = send_stream.finish() {
+                        tracing::debug!(error = %e, "MasqueRelaySocket: stream finish error");
+                    }
+                    return;
+                };
+
+                // A failed write may have left a partial frame on the wire. Return
+                // without finishing so the drop resets the stream, and the relay's
+                // length-prefixed reader sees a stream error rather than misparsing
+                // a truncated frame.
                 let frame_len = encoded.len() as u32;
                 if let Err(e) = send_stream.write_all(&frame_len.to_be_bytes()).await {
                     tracing::debug!(error = %e, "MasqueRelaySocket: stream write error (length)");
-                    break;
+                    return;
                 }
                 if let Err(e) = send_stream.write_all(&encoded).await {
                     tracing::debug!(error = %e, "MasqueRelaySocket: stream write error (data)");
-                    break;
+                    return;
                 }
             }
         });

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -5532,12 +5532,17 @@ impl NatTraversalEndpoint {
 
                         let response_frame = encode_relay_response_frame(&response);
                         if let Err(e) = send_stream.write_all(&response_frame).await {
+                            // The response may be half-written. Returning drops the
+                            // stream unfinished, which resets it, so the client sees
+                            // a stream error instead of parsing a truncated frame.
                             warn!("Failed to send relay response to {}: {}", client_addr, e);
                             return;
                         }
 
-                        // Do NOT call finish() — successful relay streams stay
-                        // open for forwarding.
+                        // Do NOT call finish() on the success path — the response is
+                        // only a preamble and the stream stays open for forwarding.
+                        // `run_stream_forwarding_loop` takes ownership and decides how
+                        // to tear the stream down.
                         if is_success
                             && let Some(session_info) =
                                 relay_server.get_session_for_client(client_addr).await
@@ -5553,6 +5558,21 @@ impl NatTraversalEndpoint {
                                     recv_stream,
                                 )
                                 .await;
+                            return;
+                        }
+
+                        // Either the relay rejected the request, or it accepted but
+                        // has no session to forward for. The response frame is the
+                        // client's entire answer and it must survive: finish so the
+                        // client can read it. Dropping unfinished would reset the
+                        // stream, and a reset lets the peer discard data it has
+                        // already buffered — turning a structured rejection the
+                        // client parses into an opaque stream error.
+                        if let Err(e) = send_stream.finish() {
+                            debug!(
+                                "Failed to finish relay response stream to {}: {}",
+                                client_addr, e
+                            );
                         }
                     }
                     Err(e) => {
@@ -6381,9 +6401,24 @@ impl NatTraversalEndpoint {
             public_address
         );
 
-        // Create the MasqueRelaySocket from the open streams
-        let relay_socket = public_address
-            .map(|addr| crate::masque::MasqueRelaySocket::new(send_stream, recv_stream, addr));
+        // Create the MasqueRelaySocket from the open streams. The socket takes
+        // ownership of both halves and keeps them open for data forwarding, which
+        // is why the handshake above deliberately does not finish the send half.
+        let relay_socket = match public_address {
+            Some(addr) => Some(crate::masque::MasqueRelaySocket::new(
+                send_stream,
+                recv_stream,
+                addr,
+            )),
+            None => {
+                // No public address means there is no socket to hand the streams
+                // to, so they end here. Finish explicitly rather than letting the
+                // drop reset them: the CONNECT-UDP exchange itself succeeded, so
+                // the relay should see a clean end-of-stream, not a protocol error.
+                let _ = send_stream.finish();
+                None
+            }
+        };
 
         // Store the session
         let session = RelaySession {

--- a/src/node.rs
+++ b/src/node.rs
@@ -816,6 +816,10 @@ impl Node {
     /// let (mut send, mut recv) = node.open_bi(&peer_id).await?;
     /// use tokio::io::AsyncWriteExt;
     /// send.write_all(b"hello").await?;
+    /// // Always finish explicitly. A send stream dropped without `finish()` is
+    /// // reset, so the peer observes a stream error instead of a short read that
+    /// // looks like a complete message.
+    /// send.finish()?;
     /// ```
     ///
     /// # Errors

--- a/tests/quick/main.rs
+++ b/tests/quick/main.rs
@@ -14,6 +14,7 @@ mod connection_tests;
 mod crypto_tests;
 mod frame_tests;
 mod pure_pq_rpk_tests;
+mod send_stream_drop_tests;
 mod token_binding_tests;
 mod token_v2_server_side_tests;
 

--- a/tests/quick/send_stream_drop_tests.rs
+++ b/tests/quick/send_stream_drop_tests.rs
@@ -1,0 +1,206 @@
+//! Regression tests for issue #244.
+//!
+//! Dropping a `SendStream` that was never explicitly `finish()`ed must reset it. Otherwise a
+//! cancelled `write_all` (an outer timeout firing mid-write, an aborted task) gracefully FINs the
+//! stream at whatever offset writing reached, and the receiver's `read_to_end` returns `Ok` with a
+//! short but entirely plausible message — silent truncation. The explicit `finish()` path must keep
+//! delivering data normally.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use ant_quic::{
+    TransportConfig, VarInt,
+    config::{ClientConfig, ServerConfig},
+    high_level::{Connection, DROPPED_UNFINISHED_ERROR_CODE, Endpoint, ReadError, ReadToEndError},
+    masque::MasqueRelaySocket,
+};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use std::{net::SocketAddr, sync::Arc};
+use tokio::time::{Duration, timeout};
+
+/// Flow-control credit the receiver advertises when we want a write to stall. One byte is enough
+/// to open the stream on the receiver while guaranteeing the rest of the payload cannot be written.
+const STALLED_STREAM_WINDOW: u32 = 1;
+
+/// Payload that cannot fit in `STALLED_STREAM_WINDOW`, so `write_all` is guaranteed to block.
+const UNSENDABLE_PAYLOAD_LEN: usize = 5 * 1024;
+
+const READ_LIMIT: usize = 64 * 1024;
+
+fn gen_self_signed_cert() -> (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>) {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+        .expect("generate self-signed");
+    let cert_der = CertificateDer::from(cert.cert);
+    let key_der = PrivateKeyDer::Pkcs8(cert.signing_key.serialize_der().into());
+    (vec![cert_der], key_der)
+}
+
+/// Connect a client to a server over loopback, returning `(client_conn, server_conn)`.
+///
+/// `server_stream_window` constrains the per-stream flow-control credit the server advertises, so
+/// that a client-side write can be made to stall deterministically.
+async fn loopback_pair(server_stream_window: Option<u32>) -> (Connection, Connection) {
+    let (chain, key) = gen_self_signed_cert();
+    let mut server_cfg = ServerConfig::with_single_cert(chain.clone(), key).expect("server cfg");
+    if let Some(window) = server_stream_window {
+        let mut transport = TransportConfig::default();
+        transport.stream_receive_window(VarInt::from_u32(window));
+        server_cfg.transport = Arc::new(transport);
+    }
+    let server = Endpoint::server(server_cfg, ([127, 0, 0, 1], 0).into()).expect("server ep");
+    let addr: SocketAddr = server.local_addr().unwrap();
+
+    let accept = tokio::spawn(async move {
+        let inc = timeout(Duration::from_secs(10), server.accept())
+            .await
+            .unwrap()
+            .unwrap();
+        timeout(Duration::from_secs(10), inc)
+            .await
+            .unwrap()
+            .unwrap()
+    });
+
+    let mut roots = rustls::RootCertStore::empty();
+    for c in chain {
+        roots.add(c).unwrap();
+    }
+    let client_cfg = ClientConfig::with_root_certificates(Arc::new(roots)).unwrap();
+    let mut client = Endpoint::client(([127, 0, 0, 1], 0).into()).expect("client ep");
+    client.set_default_client_config(client_cfg);
+    let c_conn: Connection = timeout(
+        Duration::from_secs(10),
+        client.connect(addr, "localhost").expect("start"),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let s_conn: Connection = accept.await.unwrap();
+    (c_conn, s_conn)
+}
+
+/// A cancelled `write_all` followed by a drop must surface at the receiver as a stream reset.
+///
+/// The failure this guards against is not a missing error but a *convincing success*: before the
+/// fix the receiver read `Ok` with a short buffer and had no way to tell it from a complete
+/// message, which is how truncated frames reached application deserializers in production.
+#[tokio::test]
+async fn dropping_cancelled_write_resets_stream() {
+    let (client_conn, server_conn) = loopback_pair(Some(STALLED_STREAM_WINDOW)).await;
+
+    let mut send = client_conn.open_uni().await.expect("open uni");
+    let payload = vec![0xABu8; UNSENDABLE_PAYLOAD_LEN];
+
+    // The receiver never reads, so no further credit is issued and `write_all` cannot complete.
+    let write = timeout(Duration::from_millis(300), send.write_all(&payload)).await;
+    assert!(
+        write.is_err(),
+        "write_all unexpectedly completed against a {STALLED_STREAM_WINDOW}-byte window; the \
+         test can no longer exercise the cancellation path"
+    );
+
+    // Dropping without `finish()` is the whole point: this is what a cancelled send looks like.
+    drop(send);
+
+    let mut recv = timeout(Duration::from_secs(10), server_conn.accept_uni())
+        .await
+        .expect("accept_uni timed out")
+        .expect("accept uni");
+    let result = timeout(Duration::from_secs(10), recv.read_to_end(READ_LIMIT))
+        .await
+        .expect("read_to_end timed out");
+
+    match result {
+        Err(ReadToEndError::Read(ReadError::Reset(code))) => {
+            assert_eq!(
+                code, DROPPED_UNFINISHED_ERROR_CODE,
+                "stream was reset, but not with the dropped-unfinished code"
+            );
+        }
+        Ok(data) => panic!(
+            "receiver observed a graceful end-of-stream with {} of {UNSENDABLE_PAYLOAD_LEN} bytes \
+             — a truncated message indistinguishable from a complete one (issue #244)",
+            data.len()
+        ),
+        Err(other) => panic!("expected a stream reset, got {other:?}"),
+    }
+}
+
+/// The graceful path must not regress: an explicit `finish()` before drop still delivers the data.
+#[tokio::test]
+async fn explicit_finish_before_drop_delivers_data() {
+    let (client_conn, server_conn) = loopback_pair(None).await;
+
+    let message = b"issue-244 graceful finish".to_vec();
+    let mut send = client_conn.open_uni().await.expect("open uni");
+    send.write_all(&message).await.expect("write_all");
+    send.finish().expect("finish");
+    drop(send);
+
+    let mut recv = timeout(Duration::from_secs(10), server_conn.accept_uni())
+        .await
+        .expect("accept_uni timed out")
+        .expect("accept uni");
+    let data = timeout(Duration::from_secs(10), recv.read_to_end(READ_LIMIT))
+        .await
+        .expect("read_to_end timed out")
+        .expect("read_to_end should succeed on an explicitly finished stream");
+
+    assert_eq!(
+        data, message,
+        "explicitly finished stream lost or altered data"
+    );
+}
+
+/// The MASQUE relay data plane must tear its send stream down gracefully when the socket is simply
+/// dropped.
+///
+/// `MasqueRelaySocket`'s writer task owns the relay send stream for the life of the session, and it
+/// exits when the outbound channel closes — the ordinary "socket went away" shutdown, with nothing
+/// half-written. That path has to `finish()`: reset semantics would discard relayed packets that
+/// were queued but not yet acknowledged, and the relay's length-prefixed reader would see a stream
+/// error rather than a clean end of session. Reset stays reserved for the write-failure path, where
+/// a partial frame may already be on the wire.
+#[tokio::test]
+async fn masque_relay_socket_drop_finishes_relay_stream() {
+    let (client_conn, server_conn) = loopback_pair(None).await;
+
+    // Mirror `establish_relay_session`: the CONNECT-UDP preamble is written on the send half before
+    // the socket takes ownership of it, which is also what makes the peer observe the stream.
+    let preamble = b"connect-udp";
+    let (mut client_send, client_recv) = client_conn.open_bi().await.expect("open bi");
+    client_send
+        .write_all(preamble)
+        .await
+        .expect("write preamble");
+
+    let relay_addr: SocketAddr = ([127, 0, 0, 1], 9).into();
+    let socket = MasqueRelaySocket::new(client_send, client_recv, relay_addr);
+
+    let (mut server_send, mut server_recv) =
+        timeout(Duration::from_secs(10), server_conn.accept_bi())
+            .await
+            .expect("accept_bi timed out")
+            .expect("accept bi");
+    let mut seen = vec![0u8; preamble.len()];
+    timeout(Duration::from_secs(10), server_recv.read_exact(&mut seen))
+        .await
+        .expect("read_exact timed out")
+        .expect("read preamble");
+    assert_eq!(&seen[..], preamble, "relay preamble corrupted");
+
+    // Release our handle, then close the relay's send half. The socket's reader task holds the last
+    // `Arc`, so it must observe end-of-stream before the socket itself is dropped and its writer
+    // task learns the outbound channel has closed.
+    drop(socket);
+    server_send.finish().expect("relay finish");
+
+    let tail = timeout(Duration::from_secs(10), server_recv.read_to_end(READ_LIMIT))
+        .await
+        .expect("read_to_end timed out");
+
+    assert!(
+        tail.is_ok(),
+        "dropping the relay socket must finish the relay stream, not reset it; got {tail:?}"
+    );
+}


### PR DESCRIPTION
## Status at head

Head: `9e31d14c` — single commit on `origin/master` (f3234f12, v0.27.38). 8 files modified + 1 new test file (206 lines). Built by a dispatched agent from the #244 spec, blast-radius surveyed (11 implicit finish-on-drop production sites enumerated), reviewed and independently validated by the session lead.

## The bug (#244)

Dropping a `SendStream` called `finish()`, so a cancelled in-flight `write_all` (outer timeout, task abort) gracefully FIN'd at the current offset — the receiver's `read_to_end` returned `Ok` with a plausible short message. Silent truncation; field signature in x0x: `Failed to deserialize PubSub message: Hit the end of buffer`.

## The fix

`Drop` now `reset()`s with `DROPPED_UNFINISHED_ERROR_CODE` (`0xA17C_0244`, exported, deliberately distinctive in captures) unless `finish()` was called. `finish()` marks graceful intent in both its `Ok` and `Stopped` arms; `AsyncWriteExt::shutdown()` routes through `finish()` and counts. The `finished` flag is tracked in the wrapper because it cannot be recovered from stream state (`reset()` is legal after `finish()`).

## Blast-radius disposition (per the confirmed full-remediation scope: fix the bug, don't move it)

| Survey finding | Disposition |
|---|---|
| MASQUE relay forwarding loop (server end) | **Remediated**: `send_stream_intact` tracks whether any frame may be half-written; intact exit → explicit `finish()` (QUIC keeps retransmitting queued frames), compromised exit (write error / select-cancelled write arm) → drop-reset so the length-prefixed reader errors instead of misparsing. Justification in comments at the site. |
| MASQUE relay socket writer task (client end) | **Remediated**: channel-closed (socket dropped, nothing half-written) → explicit `finish()`; write error → drop-reset. |
| `establish_relay_session`, `None` public address | **Remediated**: explicit `finish()` — the CONNECT-UDP exchange succeeded; the relay sees a clean close, not a protocol error. |
| Relay-server response path (rejection / no session) | **Remediated**: explicit `finish()` so the client can parse the structured rejection (a reset would let the peer discard buffered data). Success path unchanged: stream ownership passes to the forwarding loop. |
| `LinkSendStream` / `P2pSendStream` consumers | **Remediated via contract**: trait-level "Dropping" section documents reset-on-unfinished-drop; `finish()` documented as required for graceful close. |
| `Node::open_bi` doc example | **Remediated**: example now finishes explicitly with a comment explaining why. |
| `IncomingAckBidiStream` dispatch failure | **Already safe** (verified at the call site): failure routes to `send_ack_bidi_not_supported`, which writes a structured rejection and explicitly finishes. Reset on hard shutdown is the intended abort signal for a peer awaiting an ACK response. |

## Tests

`tests/quick/send_stream_drop_tests.rs` (registered in the quick suite):
- `dropping_cancelled_write_resets_stream` — 1-byte flow-control window, 5KB `write_all` cancelled via timeout, drop; receiver observes reset with `DROPPED_UNFINISHED_ERROR_CODE`, not `Ok(short)`.
- `explicit_finish_before_drop_delivers_data` — graceful path regression pin.
- `masque_relay_socket_drop_finishes_relay_stream` — relay teardown semantics on the highest-risk remediated path.

## Validation

fmt clean; clippy `--all-features --all-targets -D warnings` zero; new tests 3/3 across 3 consecutive runs. Full local `nextest --all-features` is blocked by a **pre-existing, machine-environmental** failure: `test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear` fails 2/2 on **clean master** here (populated bootstrap cache; #245's hermeticity family) — filed as #247 with the attribution runs. `shutdown_releases_udp_socket_for_tight_loop_rebind_with_live_connection` passes 4/4 by name on both trees (ambient-load flake in full runs only). CI is the authoritative full-suite gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes unfinished `SendStream` drops from implicit graceful completion to an explicit reset and updates relay teardown paths and API documentation accordingly.
- Exports a distinctive dropped-unfinished reset code and tracks explicit finish intent.
- Adds explicit graceful finishes to relay paths that must preserve complete buffered messages.
- Adds regression coverage for cancelled writes, explicit finishes, and MASQUE socket teardown.

<h3>Confidence Score: 4/5</h3>

The relay teardown defect should be fixed before merging because a normal clean half-close can reset the independent reverse direction and discard valid relayed frames.

The core SendStream contract is implemented coherently, but the relay server classifies every receive-loop termination as a compromised send and therefore resets complete reverse-direction data on a reachable graceful shutdown path.

**Files Needing Attention:** src/masque/relay_server.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/high_level/send_stream.rs | Introduces explicit finish tracking and resets unfinished streams on drop, with focused regression tests covering the core contract. |
| src/masque/relay_server.rs | Adds conditional relay-stream finishing, but conflates clean receive-half termination with cancellation during a partial send. |
| src/masque/relay_socket.rs | Gracefully finishes after outbound-channel closure and preserves reset behavior after potentially partial writes. |
| src/nat_traversal_api.rs | Explicitly finishes complete relay responses and successful sessions that have no socket owner. |
| tests/quick/send_stream_drop_tests.rs | Covers the core drop-reset and graceful-finish paths but does not exercise relay-server clean half-close classification. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as MASQUE client
    participant R as Relay read branch
    participant W as Relay write branch
    C->>R: Graceful FIN on client-to-relay half
    R-->>R: read_exact returns FinishedEarly
    R-->>W: tokio::select cancels writer
    R-->>C: Drop send half triggers RESET
    Note over W,C: Complete buffered reverse frames may be abandoned
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/masque/relay_server.rs:1085-1090
**Clean half-close resets reverse stream**

When the client gracefully finishes its send half while the relay writer is between frames or has complete frames awaiting acknowledgement, this branch classifies the read-loop exit as a compromised write and drops the independent send half unfinished, causing valid relay-to-client datagrams to be abandoned instead of retransmitted through a graceful finish.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(high-level): reset unfinished SendSt..."](https://github.com/saorsa-labs/ant-quic/commit/9e31d14cdbe499af261d6aad99203c6c5cdc20f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54140069)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->