### PR TITLE
chore(release): 0.27.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.40] - 2026-08-18
+
+### Fixed
+
+- **h2 0.4.16** closes RUSTSEC-2026-0258 (unbounded empty DATA frames). Lockfile-only
+  transitive bump from 0.4.15. Crate version 0.27.39 -> 0.27.40 so the clean
+  release is distinct from the v0.27.39 tag whose Security Audit jobs failed.
+
 ## [0.27.38] - 2026-08-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.39"
+version = "0.27.40"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.39"
+version = "0.27.40"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bump crate version 0.27.39 → 0.27.40 so we can tag a clean release after the h2 0.4.16 / RUSTSEC-2026-0258 lockfile fix (669ab881).

v0.27.39 already shipped with failed Security Audit jobs. This version is for the follow-up tag only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares the 0.27.40 follow-up release after the h2 advisory lockfile fix.
- Updates the crate version from 0.27.39 to 0.27.40.
- Adds release notes documenting the h2 0.4.16 security fix and the reason for the follow-up tag.

<h3>Confidence Score: 4/5</h3>

The release should not be tagged until Cargo.lock is regenerated to prevent the locked cross-build jobs from failing.

Cargo.toml declares version 0.27.40 while Cargo.lock still records 0.27.39, and the release workflow invokes Cargo with --locked for cross-compiled targets.

**Files Needing Attention:** Cargo.toml and Cargo.lock

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the crate to 0.27.40 but leaves Cargo.lock's root package version stale, causing locked release builds to fail. |
| CHANGELOG.md | Adds a correctly formatted 0.27.40 release entry explaining the h2 advisory fix and prior failed release tag. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
Cargo.toml:9
**Stale root package lock entry**

When the v0.27.40 release cross-builds run with `--locked`, `Cargo.toml` declares 0.27.40 while `Cargo.lock` still records the root package as 0.27.39, causing Cargo to reject the stale lockfile and block the release.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(changelog): record 0.27.40 h2 advis..."](https://github.com/saorsa-labs/ant-quic/commit/e2a89f69c67696c168aaaddb20284d35cf90f952) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54476104)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->