### PR TITLE
test(p2p): isolate upsert_peer_hints tests from the machine bootstrap cache (closes #247)

### DIFF
--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -9823,6 +9823,7 @@ impl Clone for P2pEndpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bootstrap_cache::BootstrapCacheConfig;
     use crate::coordinator_control::RejectionReason;
 
     fn collect_broadcast_events(
@@ -12230,20 +12231,38 @@ mod tests {
         endpoint.shutdown().await;
     }
 
+    /// Endpoint config for the `upsert_peer_hints` tests, isolated from any real
+    /// bootstrap cache on this machine.
+    ///
+    /// The default cache dir is shared per user, so a populated cache both
+    /// crowds freshly hinted peers out of the capped relay/coordinator
+    /// selections these tests assert on, and takes on the tests' synthetic peers
+    /// when the endpoint saves.
+    fn peer_hint_test_config() -> P2pConfig {
+        P2pConfig::builder()
+            .bind_addr(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                0,
+            ))
+            .port_mapping_enabled(false)
+            .bootstrap_cache(
+                BootstrapCacheConfig::builder()
+                    .cache_dir(
+                        std::env::temp_dir()
+                            .join(format!("ant-quic-peer-hint-tests-{}", std::process::id())),
+                    )
+                    .persist(false)
+                    .build(),
+            )
+            .build()
+            .expect("config should build")
+    }
+
     #[tokio::test]
     async fn test_upsert_peer_hints_ignores_synthetic_peer_id() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(peer_hint_test_config())
+            .await
+            .expect("endpoint should bind");
 
         let hinted_addr: SocketAddr = "127.0.0.1:9001".parse().expect("valid addr");
         let peer_id = peer_id_from_socket_addr(hinted_addr);
@@ -12260,18 +12279,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_feeds_coordinator_candidates() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(peer_hint_test_config())
+            .await
+            .expect("endpoint should bind");
 
         let peer_id = PeerId([0x5a; 32]);
         let hinted_addr: SocketAddr = "127.0.0.1:9000".parse().expect("valid addr");
@@ -12295,18 +12305,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(peer_hint_test_config())
+            .await
+            .expect("endpoint should bind");
 
         let peer_id = PeerId([0x6b; 32]);
         let hinted_addr: SocketAddr = "198.51.100.61:9000".parse().expect("valid addr");
@@ -12344,18 +12345,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_merge_addrs_and_roles() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(peer_hint_test_config())
+            .await
+            .expect("endpoint should bind");
 
         let peer_id = PeerId([0x7c; 32]);
         let addr_a: SocketAddr = "198.51.100.71:9000".parse().expect("valid addr");


### PR DESCRIPTION
## Status at head

Head: `755faa06` — single commit on `origin/master`. Diff: `src/p2p_endpoint.rs` +40/−48, entirely inside `mod tests` (verified: the one hunk outside the test-fn region is a `use` import at the top of the test module). Built by a dispatched agent, verified and landed by the lead.

## The bug (#247)

`test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear` failed **deterministically** on any machine with a populated bootstrap cache (this machine: ~1400 persisted peers). `select_relays_for_target` sorts all cached peers by score and takes the top N; the default `cache_dir` (`$TMPDIR/ant-quic-cache`) is shared per-user, so the machine's real peers crowd the test's freshly-hinted peer out of the capped selection. Same non-hermeticity disease PR #245 fixed for the lifecycle suite.

## The fix

A shared `peer_hint_test_config()` gives the four `upsert_peer_hints` tests a **per-process temp `cache_dir` + `persist(false)`** (PR #245's pattern), so they neither read the machine's cache nor persist their synthetic peers into it. Test-only.

## Validation

- Before: `test_upsert_..._after_runtime_hints_clear` fails 2/2 on clean master here.
- After: the whole `upsert_peer_hints` family passes **4/4 across 3 consecutive runs**.
- fmt clean; clippy `--all-features --all-targets -D warnings` clean.

Closes #247. (The other two local full-suite failure modes noted in #247 — the load-dependent `shutdown_releases_udp_socket` flake and parallel-lib SIGKILL resource exhaustion — are separate environmental issues, not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the four `upsert_peer_hints` tests independent of the machine-wide bootstrap cache.
- Adds a shared test configuration using a per-process temporary cache path.
- Disables persistence while retaining the in-memory cache behavior exercised by the tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the test-isolation change.

The new helper gives each endpoint an independent in-memory bootstrap cache; disabling persistence prevents machine-cache contamination while preserving the upsert and selection paths asserted by all four tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Adds and applies a test-only endpoint configuration that prevents bootstrap-cache disk reads and writes without changing the tested in-memory peer operations. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(p2p): isolate upsert\_peer\_hints tes..."](https://github.com/saorsa-labs/ant-quic/commit/755faa06e4df2306d6266d4fc37ba4750a12eac9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54483175)</sub>

<!-- /greptile_comment -->