### PR TITLE
test(p2p): isolate upsert_peer_hints from on-disk bootstrap cache

### DIFF
--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -12230,20 +12230,35 @@ mod tests {
         endpoint.shutdown().await;
     }
 
+    /// Isolate the `upsert_peer_hints` family from any on-disk bootstrap cache
+    /// on the developer machine. A populated default cache makes bounded
+    /// selectors such as `select_relays_for_target` return host peers, so
+    /// "after runtime hints clear" is no longer empty (issue #247 / #245).
+    fn isolated_upsert_peer_hints_config() -> P2pConfig {
+        P2pConfig::builder()
+            .bind_addr(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                0,
+            ))
+            .port_mapping_enabled(false)
+            .bootstrap_cache(
+                crate::bootstrap_cache::BootstrapCacheConfig::builder()
+                    .cache_dir(std::env::temp_dir().join(format!(
+                        "ant-quic-upsert-peer-hints-tests-{}",
+                        std::process::id()
+                    )))
+                    .persist(false)
+                    .build(),
+            )
+            .build()
+            .expect("config should build")
+    }
+
     #[tokio::test]
     async fn test_upsert_peer_hints_ignores_synthetic_peer_id() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(isolated_upsert_peer_hints_config())
+            .await
+            .expect("endpoint should bind");
 
         let hinted_addr: SocketAddr = "127.0.0.1:9001".parse().expect("valid addr");
         let peer_id = peer_id_from_socket_addr(hinted_addr);
@@ -12260,18 +12275,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_feeds_coordinator_candidates() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(isolated_upsert_peer_hints_config())
+            .await
+            .expect("endpoint should bind");
 
         let peer_id = PeerId([0x5a; 32]);
         let hinted_addr: SocketAddr = "127.0.0.1:9000".parse().expect("valid addr");
@@ -12295,18 +12301,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(isolated_upsert_peer_hints_config())
+            .await
+            .expect("endpoint should bind");
+
+        assert_eq!(
+            endpoint.bootstrap_cache.peer_count().await,
+            0,
+            "isolated cache must start empty so host bootstrap history cannot leak into relay selection"
+        );
 
         let peer_id = PeerId([0x6b; 32]);
         let hinted_addr: SocketAddr = "198.51.100.61:9000".parse().expect("valid addr");
@@ -12319,6 +12322,12 @@ mod tests {
         endpoint
             .upsert_peer_hints(peer_id, vec![hinted_addr], Some(caps))
             .await;
+
+        assert_eq!(
+            endpoint.bootstrap_cache.peer_count().await,
+            1,
+            "isolated cache should contain only the hinted peer"
+        );
 
         endpoint.peer_hint_records.write().await.clear();
 
@@ -12344,18 +12353,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_merge_addrs_and_roles() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(isolated_upsert_peer_hints_config())
+            .await
+            .expect("endpoint should bind");
 
         let peer_id = PeerId([0x7c; 32]);
         let addr_a: SocketAddr = "198.51.100.71:9000".parse().expect("valid addr");

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -9823,6 +9823,7 @@ impl Clone for P2pEndpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bootstrap_cache::BootstrapCacheConfig;
     use crate::coordinator_control::RejectionReason;
 
     fn collect_broadcast_events(
@@ -12230,10 +12231,16 @@ mod tests {
         endpoint.shutdown().await;
     }
 
-    /// Isolate the `upsert_peer_hints` family from any on-disk bootstrap cache
-    /// on the developer machine. A populated default cache makes bounded
-    /// selectors such as `select_relays_for_target` return host peers, so
-    /// "after runtime hints clear" is no longer empty (issue #247 / #245).
+    /// Endpoint config for the `upsert_peer_hints` tests, isolated from any
+    /// real bootstrap cache on this machine.
+    ///
+    /// The default cache dir is shared per user, so a populated cache both
+    /// crowds freshly hinted peers out of the capped relay/coordinator
+    /// selections these tests assert on, and takes on the tests' synthetic
+    /// peers when the endpoint saves (issue #247 / #245). The explicit
+    /// `cache_dir` is inert while `persist(false)` holds — nothing is read,
+    /// written, or created — but keeps the tests isolated if persistence is
+    /// ever re-enabled here.
     fn isolated_upsert_peer_hints_config() -> P2pConfig {
         P2pConfig::builder()
             .bind_addr(SocketAddr::new(
@@ -12242,7 +12249,7 @@ mod tests {
             ))
             .port_mapping_enabled(false)
             .bootstrap_cache(
-                crate::bootstrap_cache::BootstrapCacheConfig::builder()
+                BootstrapCacheConfig::builder()
                     .cache_dir(std::env::temp_dir().join(format!(
                         "ant-quic-upsert-peer-hints-tests-{}",
                         std::process::id()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #247.

## Problem

`p2p_endpoint::tests::test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear` failed deterministically on machines with a populated bootstrap/peer cache (and inside full `cargo nextest run --all-features`). On a clean machine it could pass.

The test opened a `P2pEndpoint` with the default `BootstrapCacheConfig` (`persist: true`, machine cache dir). After clearing runtime hints it asked `select_relays_for_target(4, …)` to find the just-hinted peer. A populated host cache supplies higher-scoring candidates, so the hinted peer can miss the top-4 set. This is the same non-hermetic leak #245 fixed for the lifecycle suite.

## Change

Apply the #245 isolation pattern to the entire `upsert_peer_hints` family:

- `persist: false` so the cache is in-memory only (nothing loaded from disk)
- per-process temp `cache_dir` as belt-and-suspenders isolation
- the failing test now asserts the isolated cache starts empty and contains only the hinted peer after upsert

No production code changes. Crate version is unchanged (0.27.40).

## Note on #252

#252 is an independent, already-green implementation of the same isolation (shared `peer_hint_test_config()` + `persist: false`). This PR is the same approach with extra `peer_count` assertions so a future isolation regression fails on machines with a populated cache, not only on the relay-selection check.

## Tests

- `test_upsert_peer_hints_ignores_synthetic_peer_id`
- `test_upsert_peer_hints_feeds_coordinator_candidates`
- `test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear`
- `test_upsert_peer_hints_merge_addrs_and_roles`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f08cd20-b3af-447a-bbfd-89c5db4812ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f08cd20-b3af-447a-bbfd-89c5db4812ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the `upsert_peer_hints` tests independent of the machine-wide bootstrap cache.
- Adds a shared test configuration with persistence disabled and a temporary cache directory.
- Applies the isolated configuration to all four `upsert_peer_hints` tests.
- Adds cache-size assertions around the relay-cache selection scenario.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the changes are confined to test isolation and no actionable defect was identified.

Disabling bootstrap-cache persistence prevents disk loading and writing, while each endpoint receives a fresh instance-local in-memory cache, so the shared temporary path does not permit cross-test contamination.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | The test-only configuration reliably creates independent in-memory bootstrap caches, and the added assertions directly guard against host-cache leakage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(p2p): isolate upsert\_peer\_hints fro..."](https://github.com/saorsa-labs/ant-quic/commit/35ce4a23f82292d1a93335755c2d18e9521c492d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54527277)</sub>

<!-- /greptile_comment -->