### PR TITLE
test(p2p): isolate upsert_peer_hints tests from the machine bootstrap cache (closes #247) [reland of #252]

### DIFF
--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -9823,6 +9823,7 @@ impl Clone for P2pEndpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bootstrap_cache::BootstrapCacheConfig;
     use crate::coordinator_control::RejectionReason;
 
     fn collect_broadcast_events(
@@ -12230,20 +12231,38 @@ mod tests {
         endpoint.shutdown().await;
     }
 
+    /// Endpoint config for the `upsert_peer_hints` tests, isolated from any real
+    /// bootstrap cache on this machine.
+    ///
+    /// The default cache dir is shared per user, so a populated cache both
+    /// crowds freshly hinted peers out of the capped relay/coordinator
+    /// selections these tests assert on, and takes on the tests' synthetic peers
+    /// when the endpoint saves.
+    fn peer_hint_test_config() -> P2pConfig {
+        P2pConfig::builder()
+            .bind_addr(SocketAddr::new(
+                IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                0,
+            ))
+            .port_mapping_enabled(false)
+            .bootstrap_cache(
+                BootstrapCacheConfig::builder()
+                    .cache_dir(
+                        std::env::temp_dir()
+                            .join(format!("ant-quic-peer-hint-tests-{}", std::process::id())),
+                    )
+                    .persist(false)
+                    .build(),
+            )
+            .build()
+            .expect("config should build")
+    }
+
     #[tokio::test]
     async fn test_upsert_peer_hints_ignores_synthetic_peer_id() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(peer_hint_test_config())
+            .await
+            .expect("endpoint should bind");
 
         let hinted_addr: SocketAddr = "127.0.0.1:9001".parse().expect("valid addr");
         let peer_id = peer_id_from_socket_addr(hinted_addr);
@@ -12260,18 +12279,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_feeds_coordinator_candidates() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(peer_hint_test_config())
+            .await
+            .expect("endpoint should bind");
 
         let peer_id = PeerId([0x5a; 32]);
         let hinted_addr: SocketAddr = "127.0.0.1:9000".parse().expect("valid addr");
@@ -12295,18 +12305,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(peer_hint_test_config())
+            .await
+            .expect("endpoint should bind");
 
         let peer_id = PeerId([0x6b; 32]);
         let hinted_addr: SocketAddr = "198.51.100.61:9000".parse().expect("valid addr");
@@ -12344,18 +12345,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_upsert_peer_hints_merge_addrs_and_roles() {
-        let endpoint = P2pEndpoint::new(
-            P2pConfig::builder()
-                .bind_addr(SocketAddr::new(
-                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-                    0,
-                ))
-                .port_mapping_enabled(false)
-                .build()
-                .expect("config should build"),
-        )
-        .await
-        .expect("endpoint should bind");
+        let endpoint = P2pEndpoint::new(peer_hint_test_config())
+            .await
+            .expect("endpoint should bind");
 
         let peer_id = PeerId([0x7c; 32]);
         let addr_a: SocketAddr = "198.51.100.71:9000".parse().expect("valid addr");


### PR DESCRIPTION
## Reland of #252

PR #252 (755faa06) was **closed without merging and its branch deleted** — no explanatory comment, and the fix never reached master. #247 **still fails deterministically on current master (0.27.40)**: verified just now — `test_upsert_peer_hints_feeds_relay_cache_selection_after_runtime_hints_clear` FAILs 1/1 on `324b7257`. This reopens the same verified fix, rebased onto 0.27.40 (`4c8c3006`).

If #252 was closed deliberately (a different fix planned, or a decision not to isolate these tests), say so and I'll close this — but the test is red on master right now, so something should land.

## The fix (unchanged from #252)

Root cause: `select_relays_for_target` takes the top-N cached peers by score; the default `cache_dir` (`$TMPDIR/ant-quic-cache`) is shared per-user, so a machine with ~1400 persisted peers crowds the test's fresh hint out of the capped selection. Fix = a shared `peer_hint_test_config()` giving the four `upsert_peer_hints` tests a per-process temp `cache_dir` + `persist(false)` (PR #245's pattern). Test-only (`+40/−48`, all inside `mod tests`).

## Validation

- Before (clean master `324b7257`): the target test FAILs 1/1.
- After: `upsert_peer_hints` family 4/4 across 3 consecutive runs; fmt + clippy clean.

Closes #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR isolates four `upsert_peer_hints` tests from the machine-wide bootstrap cache without changing production behavior.
- Adds a shared test configuration using an inert per-process cache path with persistence disabled.
- Refactors all four peer-hint tests to construct their endpoints from that isolated configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the test-isolation change.

Disabling persistence prevents bootstrap-cache disk loading and saving while retaining the in-memory upsert and selection operations exercised by all four tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Adds a test-only endpoint configuration that preserves in-memory bootstrap-cache behavior while preventing machine cache contents from affecting peer-hint assertions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(p2p): isolate upsert\_peer\_hints tes..."](https://github.com/saorsa-labs/ant-quic/commit/4c8c30068a023ec492eaf64e7b7018d278338105) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54543191)</sub>

<!-- /greptile_comment -->