### PR TITLE
feat(diagnostics): #[doc(hidden)] connection-accounting accessors (#368)

### DIFF
--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -7811,6 +7811,51 @@ impl P2pEndpoint {
         self.stats.read().await.clone()
     }
 
+    // === #368 churn-residue instrumentation (test/368-churn-residue) ===
+    // Instrumentation only: no behaviour change. These expose the
+    // connection-accounting surfaces the x0x leak bisection needs
+    // (issue #368 gate 3); nothing here is on any production path.
+
+    /// Proto-level open connection count (includes draining/retained
+    /// generations) — the divergence signal versus [`Self::stats`]'s
+    /// active_connections.
+    #[doc(hidden)]
+    pub fn quic_open_connections(&self) -> usize {
+        self.inner
+            .get_endpoint()
+            .map_or(0, |ep| ep.open_connections())
+    }
+
+    /// Number of per-peer reader-task handles currently tracked
+    /// (`reader_handles` map entries, summed over peers).
+    #[doc(hidden)]
+    pub async fn reader_handle_count(&self) -> usize {
+        self.reader_handles
+            .read()
+            .await
+            .values()
+            .map(Vec::len)
+            .sum()
+    }
+
+    /// Number of distinct peers in the reader-handles map.
+    #[doc(hidden)]
+    pub async fn reader_handle_peer_count(&self) -> usize {
+        self.reader_handles.read().await.len()
+    }
+
+    /// Number of per-peer activity records (`peer_activity` map entries).
+    #[doc(hidden)]
+    pub async fn peer_activity_count(&self) -> usize {
+        self.peer_activity.read().await.len()
+    }
+
+    /// Number of entries in the connected-peers map.
+    #[doc(hidden)]
+    pub async fn connected_peers_map_len(&self) -> usize {
+        self.connected_peers.read().await.len()
+    }
+
     /// Snapshot stage-by-stage ACK-v2 latency and outcome diagnostics.
     pub fn ack_diagnostics(&self) -> AckDiagnosticsSnapshot {
         self.ack_diagnostics.snapshot()


### PR DESCRIPTION
## What

Instrumentation only, zero behaviour change — cherry-picked from `test/368-churn-residue` (accessors only; the churn harness stays on that branch as a future regression rig).

Adds `#[doc(hidden)]` accessors on `P2pEndpoint` so x0x can report proto-level connection accounting in production (issue #368 gate 4):

- `quic_open_connections()` — proto-level open connection count **including draining/retained generations**; the divergence signal vs `EndpointStats::active_connections` that x0x cannot reach today.
- `reader_handle_count()` / `reader_handle_peer_count()` — per-peer reader-task handle tracking.
- `peer_activity_count()` — per-peer activity records.
- `connected_peers_map_len()` — connected-peers map length.

## Why

`Endpoint::open_connections()` is public in ant-quic but `P2pEndpoint`'s low-level endpoint handle is private, so x0x's `/diagnostics/transport` cannot see whether proto Connections are retained per closed generation. The #368 bisection so far: residue ≈ 4 MB per closed generation survives the close path in production; gate 3 ruled out p2p map growth and supersede-specific teardown on loopback. The leading hypothesis is proto Connections retained by NAT/coordination/relay session maps — visible only through this number. x0x PR #373 bumps to the release carrying these accessors and adds the field to `/diagnostics/transport`.

Gate: fmt + clippy clean (lib/tests); pre-commit hook passed (machete/unwrap warnings pre-existing on master).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds hidden, read-only connection-accounting accessors to `P2pEndpoint` for external transport diagnostics.
- Exposes the protocol-level open connection count, including retained or draining generations.
- Exposes aggregate counts for reader handles, peer activity records, and connected-peer entries.
- Introduces no mutation or transport behavior changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the new accessors are read-only and no concrete behavioral, security, or API-contract failure was identified.

The accessors directly read existing endpoint and bookkeeping state, use appropriate read locks for shared maps, and preserve existing connection lifecycle behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Adds five narrowly scoped diagnostic accessors whose implementations match the documented underlying accounting structures; no actionable correctness issue was found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(diagnostics): #\[doc(hidden)\] connec..."](https://github.com/saorsa-labs/ant-quic/commit/7e776a0db5f4775dddb7c196876215d3ed1c5d72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55514340)</sub>

<!-- /greptile_comment -->