### PR TITLE
fix(p2p): stream-scoped read errors must not kill the connection reader (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stream-scoped read errors no longer kill the connection reader (#255 fix A).** A peer
+  resetting one stream mid-message (the fork's Drop⇒RESET abandonment class, `0xA17C0244` —
+  e.g. a gossip sender whose 2.5 s write timeout drops `write_all` mid-flight) used to
+  `break` the per-connection reader loop, tearing down the entire healthy connection:
+  reader exit → generation replacement → reconnect. That feedback loop is the
+  `reader_exited` ≈1,600/h / `generations_replaced` ≈800/h churn measured on prod
+  (x0x#380). The reader now classifies `read_to_end` errors: only
+  `ReadError::ConnectionLost` ends the reader; stream-scoped errors (`Reset`, `TooLong`,
+  `MissingData`, `ClosedStream`, `IllegalOrderedRead`, `ZeroRttRejected`) skip the stream
+  and keep the connection. New proof counter `P2pEndpoint::stream_read_errors_survived()`
+  (each increment = one avoided connection teardown; wire it into x0x
+  `/diagnostics/transport`).
+
+## [Unreleased]
+
 ## [0.27.40] - 2026-08-18
 
 ### Fixed

--- a/benches/relay_queue.rs
+++ b/benches/relay_queue.rs
@@ -176,7 +176,7 @@ fn bench_rate_limit_cleanup(c: &mut Criterion) {
                         let cutoff = now - Duration::from_secs(60);
 
                         // Cleanup old entries (current inefficient approach)
-                        for (_, timestamps) in rate_limits.iter_mut() {
+                        for timestamps in rate_limits.values_mut() {
                             while let Some(&front) = timestamps.front() {
                                 if front < cutoff {
                                     timestamps.pop_front();

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -13111,6 +13111,7 @@ mod tests {
 
     /// Poll until `endpoint` reports `peer` connected (inbound admission on
     /// the accepting side is asynchronous w.r.t. the dialer's connect call).
+    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
     async fn await_connected(endpoint: &P2pEndpoint, peer: &PeerId) -> bool {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         while tokio::time::Instant::now() < deadline {
@@ -13129,6 +13130,7 @@ mod tests {
     /// the `reader_exited`/`generations_replaced` churn in x0x#380). It must
     /// instead skip the reset stream, deliver its neighbours, keep the
     /// connection Live, and count the survival.
+    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
     #[tokio::test]
     async fn reader_survives_peer_reset_stream_and_keeps_connection() {
         let endpoint_a = P2pEndpoint::new(
@@ -13284,6 +13286,7 @@ mod tests {
     /// #255 fix A complement: connection-scoped loss must still end the
     /// reader (and trigger the normal disconnect path) — the classification
     /// must not swallow real connection death.
+    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
     #[tokio::test]
     async fn reader_still_exits_on_connection_scoped_loss() {
         let endpoint_a = P2pEndpoint::new(

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -832,6 +832,12 @@ pub struct P2pEndpoint {
 
     /// Saturation diagnostics for `data_tx` (X0X-0039).
     data_tx_diagnostics: Arc<DataChannelDiagnostics>,
+    /// #255 fix A: stream-scoped `read_to_end` errors (peer reset a stream
+    /// mid-message — the fork's Drop⇒RESET abandonment class — oversized, or
+    /// missing-data) that the per-connection reader survived by skipping the
+    /// stream instead of tearing the connection down. Each event here used to
+    /// cost a full generation replacement (reader exit → close → reconnect).
+    stream_read_errors_survived: Arc<std::sync::atomic::AtomicU64>,
 
     /// Sender side of the channel that hands inbound **application**
     /// bidirectional stream handles from each reader task to
@@ -2195,6 +2201,23 @@ fn endpoint_error_from_write_error(error: crate::high_level::WriteError) -> Endp
     }
 }
 
+/// Whether a `read_to_end` error describes the whole connection (reader must
+/// end) or just one stream (reader must skip the stream and keep the
+/// connection, #255 fix A).
+///
+/// Connection-scoped: only [`ReadError::ConnectionLost`] — the QUIC
+/// connection itself failed, so no further accept/read can succeed.
+/// Everything else (`Reset`, `TooLong`, `MissingData`, `ClosedStream`,
+/// `IllegalOrderedRead`, `ZeroRttRejected`) is stream-local by QUIC
+/// definition: streams multiplex independently and one failed stream says
+/// nothing about the others.
+fn read_to_end_error_is_connection_scoped(error: &crate::high_level::ReadToEndError) -> bool {
+    matches!(
+        error,
+        crate::high_level::ReadToEndError::Read(crate::high_level::ReadError::ConnectionLost(_))
+    )
+}
+
 fn endpoint_error_from_read_error(error: crate::high_level::ReadError) -> EndpointError {
     match error {
         crate::high_level::ReadError::ConnectionLost(error) => {
@@ -3224,6 +3247,7 @@ impl P2pEndpoint {
             data_rx: Arc::new(tokio::sync::Mutex::new(data_rx)),
             data_tx_capacity,
             data_tx_diagnostics,
+            stream_read_errors_survived: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             app_bi_tx,
             app_bi_rx: Arc::new(tokio::sync::Mutex::new(app_bi_rx)),
             reader_exit_tx,
@@ -7977,6 +8001,16 @@ impl P2pEndpoint {
         });
     }
 
+    /// #255 fix A: stream-scoped `read_to_end` errors the per-connection
+    /// readers survived by skipping the stream (peer-reset mid-message,
+    /// oversized, missing-data). Each increment is one avoided connection
+    /// teardown + generation replacement. Surface via
+    /// `/diagnostics/transport`-style snapshots (`stream_read_errors_survived`).
+    pub fn stream_read_errors_survived(&self) -> u64 {
+        self.stream_read_errors_survived
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// #368: orphan connections closed by repromotion refusal or the
     /// janitor (proof counter for the churn experiment).
     #[doc(hidden)]
@@ -8989,6 +9023,7 @@ impl P2pEndpoint {
     async fn spawn_reader_task(&self, peer_id: PeerId, connection: crate::high_level::Connection) {
         let data_tx = self.data_tx.clone();
         let data_tx_diagnostics = Arc::clone(&self.data_tx_diagnostics);
+        let stream_read_errors_survived = Arc::clone(&self.stream_read_errors_survived);
         let data_tx_capacity = self.data_tx_capacity;
         let connected_peers = Arc::clone(&self.connected_peers);
         let peer_activity = Arc::clone(&self.peer_activity);
@@ -9199,11 +9234,35 @@ impl P2pEndpoint {
                     Ok(data) if data.is_empty() => continue,
                     Ok(data) => data,
                     Err(e) => {
+                        // #255 fix A: classify before acting. A stream-scoped
+                        // error — the peer reset this one stream mid-message
+                        // (the fork's Drop⇒RESET abandonment class: a sender
+                        // whose write timed out drops `write_all` mid-flight,
+                        // `0xA17C0244`), an oversized stream, or missing
+                        // ranges after a cancelled read — describes ONE bad
+                        // stream, not the connection. Breaking here used to
+                        // tear down the entire healthy connection (reader
+                        // exit → generation replacement), which is the
+                        // `reader_exited` ≈1,600/h / `generations_replaced`
+                        // ≈800/h churn measured in x0x#380. Only
+                        // connection-scoped loss may end the reader.
+                        if read_to_end_error_is_connection_scoped(&e) {
+                            debug!(
+                                "Reader task for peer {:?} (conn stable_id={}): \
+                                 connection-scoped read_to_end error, ending reader: {}",
+                                peer_id, conn_stable_id, e
+                            );
+                            break;
+                        }
+                        stream_read_errors_survived
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         debug!(
-                            "Reader task for peer {:?} (conn stable_id={}): read_to_end error: {}",
-                            peer_id, conn_stable_id, e
+                            peer_id = ?peer_id,
+                            conn_stable_id,
+                            "Reader task skipped stream-scoped read error (connection kept): {}",
+                            e
                         );
-                        break;
+                        continue;
                     }
                 };
 
@@ -9995,6 +10054,7 @@ impl Clone for P2pEndpoint {
             data_rx: Arc::clone(&self.data_rx),
             data_tx_capacity: self.data_tx_capacity,
             data_tx_diagnostics: Arc::clone(&self.data_tx_diagnostics),
+            stream_read_errors_survived: Arc::clone(&self.stream_read_errors_survived),
             app_bi_tx: self.app_bi_tx.clone(),
             app_bi_rx: Arc::clone(&self.app_bi_rx),
             reader_exit_tx: self.reader_exit_tx.clone(),
@@ -13047,6 +13107,250 @@ mod tests {
         endpoint_a.shutdown().await;
         node_b.shutdown().await;
         let _ = accept_handle.await;
+    }
+
+    /// Poll until `endpoint` reports `peer` connected (inbound admission on
+    /// the accepting side is asynchronous w.r.t. the dialer's connect call).
+    async fn await_connected(endpoint: &P2pEndpoint, peer: &PeerId) -> bool {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while tokio::time::Instant::now() < deadline {
+            if endpoint.is_connected(peer).await {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        false
+    }
+
+    /// #255 fix A: a sender whose `write_all` is dropped mid-flight resets
+    /// the stream (fork Drop⇒RESET, `0xA17C0244`). The receiver's reader used
+    /// to `break` on the resulting stream-scoped read error — tearing down
+    /// the whole healthy connection (reader exit → generation replacement,
+    /// the `reader_exited`/`generations_replaced` churn in x0x#380). It must
+    /// instead skip the reset stream, deliver its neighbours, keep the
+    /// connection Live, and count the survival.
+    #[tokio::test]
+    async fn reader_survives_peer_reset_stream_and_keeps_connection() {
+        let endpoint_a = P2pEndpoint::new(
+            P2pConfig::builder()
+                .bind_addr(SocketAddr::new(
+                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                    0,
+                ))
+                .port_mapping_enabled(false)
+                .build()
+                .expect("config should build"),
+        )
+        .await
+        .expect("endpoint_a should bind");
+
+        let endpoint_b = P2pEndpoint::new(
+            P2pConfig::builder()
+                .bind_addr(SocketAddr::new(
+                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                    0,
+                ))
+                .port_mapping_enabled(false)
+                .known_peer(localhost_addr(
+                    endpoint_a.local_addr().expect("endpoint_a addr"),
+                ))
+                .build()
+                .expect("config should build"),
+        )
+        .await
+        .expect("endpoint_b should bind");
+
+        let a_id = endpoint_a.peer_id();
+        // Inbound connections only progress (reader spawn, stream accept)
+        // while someone calls accept() — same as production callers.
+        let accept_pump = {
+            let endpoint_a = endpoint_a.clone();
+            tokio::spawn(async move {
+                while let Some(_conn) = endpoint_a.accept().await {
+                    // Connection admission is enough; the per-connection
+                    // reader task is spawned by the endpoint.
+                }
+            })
+        };
+        let connected =
+            tokio::time::timeout(Duration::from_secs(20), endpoint_b.connect_known_peers())
+                .await
+                .expect("connect should not time out")
+                .expect("connect should succeed");
+        assert_eq!(connected, 1, "b should connect to a");
+        assert!(
+            await_connected(&endpoint_a, &endpoint_b.peer_id()).await,
+            "a must admit the inbound connection"
+        );
+
+        // B opens THREE uni streams on the live connection: 1 and 3 complete
+        // normally; 2 is dropped mid-write so Drop⇒RESET resets it.
+        let conn_b_to_a = endpoint_b
+            .inner
+            .get_connection(&a_id)
+            .ok()
+            .flatten()
+            .expect("b holds a connection to a");
+
+        // Stream 1: complete message.
+        {
+            let mut s = conn_b_to_a.open_uni().await.expect("open stream 1");
+            s.write_all(b"stream-one-payload").await.expect("write 1");
+            s.finish().expect("finish 1");
+        }
+        // Stream 2: partial write, then abandon (drop without finish) —
+        // SendStream::Drop resets it mid-stream.
+        {
+            let mut s = conn_b_to_a.open_uni().await.expect("open stream 2");
+            // Larger than the peer will read? No: just write and abandon.
+            s.write_all(b"stream-two-abandoned").await.expect("write 2");
+            // `s` drops here unfinished ⇒ RESET (0xA17C0244).
+        }
+        // Stream 3: complete message.
+        {
+            let mut s = conn_b_to_a.open_uni().await.expect("open stream 3");
+            s.write_all(b"stream-three-payload").await.expect("write 3");
+            s.finish().expect("finish 3");
+        }
+
+        // A delivers streams 1 and 3; stream 2's reset is skipped, counted,
+        // and the connection stays Live.
+        let mut delivered = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while delivered.len() < 2 && tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_secs(2), endpoint_a.recv()).await {
+                Ok(Ok((_peer, data))) => delivered.push(data),
+                Ok(Err(_)) | Err(_) => {}
+            }
+        }
+        delivered.sort();
+        assert_eq!(
+            delivered,
+            vec![
+                b"stream-one-payload".to_vec(),
+                b"stream-three-payload".to_vec()
+            ],
+            "streams 1 and 3 must be delivered around the reset stream"
+        );
+
+        // The reset was counted as survived.
+        let survived = endpoint_a.stream_read_errors_survived();
+        assert!(
+            survived >= 1,
+            "the reset stream must be counted as survived, got {survived}"
+        );
+
+        // The connection is still alive on BOTH sides.
+        assert!(
+            endpoint_a.is_connected(&endpoint_b.peer_id()).await,
+            "connection must survive a stream-scoped reset"
+        );
+        assert!(
+            endpoint_b.is_connected(&a_id).await,
+            "sender side must also see the connection alive"
+        );
+
+        // A late stream on the SAME connection still flows — the reader kept
+        // accepting instead of exiting.
+        {
+            let mut s = conn_b_to_a.open_uni().await.expect("open late stream");
+            s.write_all(b"late-stream-after-reset")
+                .await
+                .expect("write late");
+            s.finish().expect("finish late");
+        }
+        let mut got_late = false;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_secs(2), endpoint_a.recv()).await {
+                Ok(Ok((_peer, data))) => {
+                    assert_eq!(data, b"late-stream-after-reset".to_vec());
+                    got_late = true;
+                    break;
+                }
+                Ok(Err(_)) | Err(_) => {}
+            }
+        }
+        assert!(
+            got_late,
+            "the reader must still accept new streams after a survived reset"
+        );
+
+        accept_pump.abort();
+        endpoint_a.shutdown().await;
+        endpoint_b.shutdown().await;
+    }
+
+    /// #255 fix A complement: connection-scoped loss must still end the
+    /// reader (and trigger the normal disconnect path) — the classification
+    /// must not swallow real connection death.
+    #[tokio::test]
+    async fn reader_still_exits_on_connection_scoped_loss() {
+        let endpoint_a = P2pEndpoint::new(
+            P2pConfig::builder()
+                .bind_addr(SocketAddr::new(
+                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                    0,
+                ))
+                .port_mapping_enabled(false)
+                .build()
+                .expect("config should build"),
+        )
+        .await
+        .expect("endpoint_a should bind");
+
+        let endpoint_b = P2pEndpoint::new(
+            P2pConfig::builder()
+                .bind_addr(SocketAddr::new(
+                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                    0,
+                ))
+                .port_mapping_enabled(false)
+                .known_peer(localhost_addr(
+                    endpoint_a.local_addr().expect("endpoint_a addr"),
+                ))
+                .build()
+                .expect("config should build"),
+        )
+        .await
+        .expect("endpoint_b should bind");
+
+        let a_id = endpoint_a.peer_id();
+        let b_id = endpoint_b.peer_id();
+        let accept_pump = {
+            let endpoint_a = endpoint_a.clone();
+            tokio::spawn(async move { while let Some(_conn) = endpoint_a.accept().await {} })
+        };
+        let connected =
+            tokio::time::timeout(Duration::from_secs(20), endpoint_b.connect_known_peers())
+                .await
+                .expect("connect should not time out")
+                .expect("connect should succeed");
+        assert_eq!(connected, 1);
+        assert!(
+            await_connected(&endpoint_a, &b_id).await,
+            "a must admit the inbound connection"
+        );
+
+        // B tears the connection down. A's reader must observe the
+        // connection-scoped loss, exit, and clear the peer.
+        endpoint_b
+            .disconnect(&a_id)
+            .await
+            .expect("b disconnects from a");
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        while endpoint_a.is_connected(&b_id).await && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            !endpoint_a.is_connected(&b_id).await,
+            "connection-scoped loss must still tear down the peer connection"
+        );
+
+        accept_pump.abort();
+        endpoint_a.shutdown().await;
+        endpoint_b.shutdown().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fix A of the agreed #255 plan (dual-investigation consensus, see the plan comment on this issue). Reports: x0x repo `.scratch/omp-report-antquic-throughput.md` + `.scratch/claude-report-antquic-throughput.md`.

## Defect
One reset stream killed the whole connection's reader. `read_to_end`'s `Err` arm `break`ed the per-connection reader loop (`p2p_endpoint.rs`); the reader-exit supervisor then tore the connection down (generation replacement + reconnect). The common producer is the fork's deliberate **Drop⇒RESET** (`high_level/send_stream.rs:329-355`, `0xA17C0244` — diverging from upstream quinn's implicit-finish): a gossip sender whose 2.5 s write timeout drops a blocked `write_all` mid-flight resets the stream **on the peer**, and the peer destroys a perfectly healthy connection. That loop is the `reader_exited` ≈1,600/h / `generations_replaced` ≈800/h churn measured on prod (x0x#380) and a driver of the unread-assembler sawtooth (x0x#378).

## Change
- `read_to_end` errors are now classified (`read_to_end_error_is_connection_scoped`): only `ReadError::ConnectionLost` ends the reader — connection death is real death. Everything stream-local (`Reset`, `TooLong`, `MissingData`, `ClosedStream`, `IllegalOrderedRead`, `ZeroRttRejected`) **skips the stream and keeps the connection**.
- The #166 "uncancellable drain" property is untouched — classification runs after `read_to_end` resolves.
- New counter `P2pEndpoint::stream_read_errors_survived()`: every increment is one avoided connection teardown. x0x `/diagnostics/transport` should wire it alongside `orphan_connections_closed` (one-liner in the x0x snapshot builder).

## Tests
- `reader_survives_peer_reset_stream_and_keeps_connection` — real wire-level repro: three uni streams, the middle one **dropped mid-write by the sender** (genuine Drop⇒RESET, not a simulated error). Asserts streams 1+3 delivered, connection Live on both sides, `stream_read_errors_survived() >= 1`, and a late stream still accepted on the same connection.
- `reader_still_exits_on_connection_scoped_loss` — disconnect still ends the reader and clears the peer.

## Expected prod effect
`reader_exited` / `generations_replaced` collapse toward actual connection failures only; `recv_streams_with_unread` stops saw-toothing on reset-driven replacement cycles.

## Gate
fmt, clippy `-D warnings` (after fixing a pre-existing clippy-1.98 `for_kv_map` failure in `benches/relay_queue.rs` that already fails on main), `cargo check --all-targets --all-features`, unit tests **2704/2704**.

Do not merge yet.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps a P2P connection reader alive after stream-local receive failures while preserving teardown for connection loss.
- Classifies `read_to_end` errors by stream versus connection scope and records survived failures.
- Adds wire-level reset and disconnect regression tests.
- Updates the changelog and fixes a benchmark clippy warning.

<h3>Confidence Score: 4/5</h3>

The implementation appears safe to merge after addressing the non-blocking regression-test coverage gap and duplicate changelog section.

Stream-local errors retain the connection and release their stream resources as intended; the remaining concerns affect regression protection and release-note structure rather than current runtime correctness.

**Files Needing Attention:** src/p2p_endpoint.rs, CHANGELOG.md

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Correctly separates stream-local receive failures from connection loss, but the connection-loss test does not exercise the newly changed classifier branch. |
| CHANGELOG.md | Documents the fix but leaves two Unreleased headings. |
| benches/relay_queue.rs | Replaces key/value iteration with `values_mut()` to satisfy clippy without changing benchmark behavior. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Accept uni stream] --> B[read_to_end]
    B -->|Success| C[Process and deliver payload]
    B -->|Stream-scoped error| D[Increment survival counter]
    D --> A
    B -->|ConnectionLost| E[Exit reader]
    E --> F[Lifecycle cleanup]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/p2p_endpoint.rs:13335-13340
**Connection-loss branch remains untested**

This test disconnects while the reader is waiting in `accept_bi` or `accept_uni`, so it never exercises the changed `read_to_end` classifier. Hold a unidirectional read open across the disconnect so a regression that continues after `ReadError::ConnectionLost` cannot pass unnoticed and delay lifecycle cleanup.

### Issue 2
CHANGELOG.md:25-27
**Duplicate Unreleased section**

The changelog now contains two `Unreleased` headings, leaving the second one empty. This can make release tooling or maintainers select the wrong section and omit or duplicate this entry in generated release notes.

```suggestion
## [0.27.40] - 2026-08-18
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(p2p): stream-scoped read errors must..."](https://github.com/saorsa-labs/ant-quic/commit/7f18d281154fa15a0f083ba2aed5397728d76d52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56063850)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Node and peer-to-peer API](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/ant-quic/-/docs/node-and-p2p-api.md)
- Knowledge Base — [Node lifecycle and peer connections](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/ant-quic/-/docs/node-lifecycle-and-peer-connections.md)
- Knowledge Base — [Connection engine and streams](https://app.greptile.com/saorsa-labs/-/custom-context/knowledge-base/saorsa-labs/ant-quic/-/docs/connection-engine-and-streams.md)
</details>


<!-- /greptile_comment -->