### PR TITLE
fix(nat): seed connection-local candidates + honest traversal counters (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **NAT traversal: connection-local candidates are now seeded (#262).** The local half of the
+  per-connection candidate-pair table was only ever populated as a side effect of
+  *broadcasting* an external address, so a node that had not (yet) advertised anything entered
+  hole punching with zero local candidates — no pair could form, and
+  `migrate_to_nat_traversal_path` could only ever fail with "No validated NAT traversal paths".
+  Now every live connection's local candidates are seeded from the endpoint's known address set
+  (QUIC-discovered reflexive addresses + the UPnP-mapped external address, both of which land in
+  the local discovery session) whenever an external address is discovered and when a hole-punch
+  session begins (`connect_orchestrated`'s HolePunching stage entry). Deduplicated, capped at 8
+  inserts per call; sends no frames.
+
+### Changed
+
+- **Traversal counters are honest (#262).** `nat_traversal_attempts` now also increments on
+  `HolePunchingStarted` (session start — locally initiated or adopted from a received
+  PUNCH_ME_NOW), not only `CoordinationRequested`. `nat_traversal_successes` now counts only
+  traversal-class establishments (hole punch / relay) and is incremented where
+  `TraversalMethod` is known, so plain direct dials stop inflating it (the live
+  attempts<successes anomaly). New `holepunched_connections` field joins
+  `direct_connections`/`relayed_connections` as the per-method success split.
+
+## [Unreleased]
+
 ## [0.27.45] - 2026-08-23
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.44"
+version = "0.27.45"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/src/candidate_discovery.rs
+++ b/src/candidate_discovery.rs
@@ -1533,6 +1533,32 @@ impl CandidateDiscoveryManager {
     }
     /// Accept a QUIC-discovered address (from OBSERVED_ADDRESS frames)
     /// This replaces the need for STUN-based server reflexive discovery
+    /// #262: the local node's QUIC-discovered / UPnP-mapped addresses, for
+    /// seeding connection-local NAT candidates at traversal-session start.
+    ///
+    /// Both external-address feeds land in the local node's own discovery
+    /// session (`accept_quic_discovered_address(local_peer_id, …)`), so this
+    /// is the single read point. Deduplicated, filtered to routable
+    /// unicast, capped at 8.
+    pub fn local_seed_addresses(&self, local_peer_id: &PeerId) -> Vec<SocketAddr> {
+        let Some(session) = self.active_sessions.get(local_peer_id) else {
+            return Vec::new();
+        };
+        let mut seen = std::collections::HashSet::new();
+        session
+            .discovered_candidates
+            .iter()
+            .map(|candidate| candidate.address)
+            .filter(|address| {
+                !address.ip().is_loopback()
+                    && !address.ip().is_unspecified()
+                    && !address.ip().is_multicast()
+            })
+            .filter(|address| seen.insert(*address))
+            .take(8)
+            .collect()
+    }
+
     pub fn accept_quic_discovered_address(
         &mut self,
         peer_id: PeerId,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -65,9 +65,13 @@ use ack_frequency::AckFrequencyState;
 pub mod port_prediction;
 pub use self::port_prediction::{PortPredictor, PortPredictorConfig};
 
+/// #262: per-call cap on local-candidate seeding (dedupe + bound).
+pub(crate) const SEED_LOCAL_CANDIDATES_CAP: usize = 8;
+
 pub(crate) mod nat_traversal;
 use nat_traversal::NatTraversalState;
 // v0.13.0: NatTraversalRole removed - all nodes are symmetric P2P nodes
+use nat_traversal::{CandidateSource, CandidateState};
 pub(crate) use nat_traversal::{CoordinationPhase, NatTraversalError};
 
 mod assembler;
@@ -5518,6 +5522,58 @@ impl Connection {
     }
 
     // === PUBLIC NAT TRAVERSAL FRAME TRANSMISSION API ===
+
+    /// Seed this connection's local NAT candidates from the endpoint's known
+    /// address set (QUIC-discovered reflexive addresses and the UPnP-mapped
+    /// external address).
+    ///
+    /// This is the #262 fix: the local half of the candidate-pair table was
+    /// previously only populated as a side effect of broadcasting an
+    /// external address, so a node that had not yet discovered a reflexive
+    /// address entered hole punching with an empty local side, no pair
+    /// could ever succeed, and `migrate_to_nat_traversal_path` was a "No
+    /// validated NAT traversal paths" dead end. Unlike
+    /// [`Self::send_nat_address_advertisement`] this sends no frames. It
+    /// deduplicates against existing candidates and caps at
+    /// `SEED_LOCAL_CANDIDATES_CAP` inserts per call.
+    pub fn seed_local_traversal_candidates(&mut self, addresses: &[SocketAddr]) -> usize {
+        let Some(nat_state) = self.nat_traversal.as_mut() else {
+            // NAT traversal not negotiated on this connection yet; nothing
+            // to seed. Later negotiation re-runs endpoint-wide seeding.
+            return 0;
+        };
+        let now = Instant::now();
+        let mut added = 0;
+        for &address in addresses {
+            let normalized = crate::shared::normalize_socket_addr(address);
+            if !is_valid_nat_advertisement_address(normalized) {
+                continue;
+            }
+            let duplicate = nat_state.local_candidates.values().any(|candidate| {
+                crate::shared::normalize_socket_addr(candidate.address) == normalized
+                    && candidate.state != CandidateState::Removed
+            });
+            if duplicate {
+                continue;
+            }
+            nat_state.add_local_candidate(
+                normalized,
+                CandidateSource::Observed { by_node: None },
+                now,
+            );
+            added += 1;
+            if added >= SEED_LOCAL_CANDIDATES_CAP {
+                break;
+            }
+        }
+        if added > 0 {
+            debug!(
+                added,
+                "Seeded local NAT traversal candidates from endpoint address set"
+            );
+        }
+        added
+    }
 
     /// Send an ADD_ADDRESS frame to advertise a candidate address to the peer
     ///

--- a/src/connection/nat_traversal.rs
+++ b/src/connection/nat_traversal.rs
@@ -3982,6 +3982,73 @@ mod tests {
     use super::*;
 
     // v0.13.0: Role parameter removed - all nodes are symmetric P2P nodes
+    /// #262: seeding local candidates (the endpoint-side fix) makes pairs
+    /// formable. Before the fix the local half was only populated as a
+    /// side effect of BROADCASTING an external address, so a node that had
+    /// not advertised anything entered hole punching with zero local
+    /// candidates — no pair could form and `migrate_to_nat_traversal_path`
+    /// could only ever fail with "No validated NAT traversal paths".
+    #[test]
+    fn seeded_local_candidates_form_pairs_with_remote_advertisement() {
+        let mut state = create_test_state();
+        let now = Instant::now();
+
+        // Endpoint-side seeding equivalent: reflexive address inserted as a
+        // local candidate (Observed source, as seed_local_traversal_candidates does).
+        state.add_local_candidate(
+            SocketAddr::from(([203, 0, 113, 7], 5483)),
+            CandidateSource::Observed { by_node: None },
+            now,
+        );
+        assert_eq!(state.local_candidates.len(), 1, "local side seeded");
+
+        // The peer advertises its own address (ADD_ADDRESS equivalent).
+        state
+            .add_remote_candidate(
+                VarInt::from_u32(1),
+                SocketAddr::from(([93, 184, 215, 123], 6000)),
+                VarInt::from_u32(100),
+                now,
+            )
+            .expect("remote candidate accepted");
+
+        assert!(
+            !state.candidate_pairs.is_empty(),
+            "a seeded local candidate + a remote advertisement must form a pair"
+        );
+    }
+
+    /// #262: the migration precondition is reachable after seeding — the
+    /// exact `get_best_succeeded_pairs()` non-empty check that used to be
+    /// dead because pairs never formed.
+    #[test]
+    fn seeded_and_succeeded_pair_satisfies_migration_precondition() {
+        let mut state = create_test_state();
+        let now = Instant::now();
+
+        state.add_local_candidate(
+            SocketAddr::from(([203, 0, 113, 7], 5483)),
+            CandidateSource::Observed { by_node: None },
+            now,
+        );
+        let remote_addr = SocketAddr::from(([93, 184, 215, 123], 6000));
+        state
+            .add_remote_candidate(VarInt::from_u32(1), remote_addr, VarInt::from_u32(100), now)
+            .expect("remote candidate accepted");
+
+        assert!(
+            state.mark_pair_succeeded(remote_addr),
+            "the formed pair must be markable succeeded"
+        );
+        let best = state.get_best_succeeded_pairs();
+        assert_eq!(
+            best.len(),
+            1,
+            "migration precondition: best pairs non-empty"
+        );
+        assert_eq!(best[0].remote_addr, remote_addr);
+    }
+
     fn create_test_state() -> NatTraversalState {
         NatTraversalState::new(
             10,                      // max_candidates

--- a/src/high_level/connection.rs
+++ b/src/high_level/connection.rs
@@ -753,6 +753,14 @@ impl Connection {
         conn.inner.send_nat_address_advertisement(address, priority)
     }
 
+    /// #262: seed local NAT traversal candidates on the underlying
+    /// connection (see the connection-level method of the same name). No
+    /// frames are sent. Returns the number of candidates inserted.
+    pub fn seed_local_traversal_candidates(&self, addresses: &[SocketAddr]) -> usize {
+        let conn = &mut *self.0.state.lock("seed_local_traversal_candidates");
+        conn.inner.seed_local_traversal_candidates(addresses)
+    }
+
     /// Queue a REMOVE_ADDRESS NAT traversal frame via the underlying connection
     pub fn send_nat_address_removal(&self, sequence: u64) -> Result<(), crate::ConnectionError> {
         let conn = &mut *self.0.state.lock("send_nat_address_removal");

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -82,6 +82,24 @@ use crate::shared::normalize_socket_addr;
 /// This helper consolidates the duplicate broadcast logic throughout the codebase.
 /// It iterates over all connections and sends the NAT address advertisement frame
 /// to each peer, logging success or failure.
+/// #262: shared seeding core for both the event handler (which has borrowed
+/// parts) and [`NatTraversalEndpoint::seed_traversal_candidates`].
+fn seed_traversal_candidates_shared(
+    connections: &dashmap::DashMap<PeerId, InnerConnection>,
+    discovery_manager: &ParkingMutex<CandidateDiscoveryManager>,
+    local_peer_id: &PeerId,
+) -> usize {
+    let addresses = discovery_manager.lock().local_seed_addresses(local_peer_id);
+    if addresses.is_empty() {
+        return 0;
+    }
+    let mut seeded = 0;
+    for entry in connections.iter() {
+        seeded += entry.value().seed_local_traversal_candidates(&addresses);
+    }
+    seeded
+}
+
 fn broadcast_address_to_peers(
     connections: &dashmap::DashMap<PeerId, InnerConnection>,
     address: SocketAddr,
@@ -3687,6 +3705,23 @@ impl NatTraversalEndpoint {
         let _ = self.add_bootstrap_node(*addr);
     }
 
+    /// #262: seed every live connection's LOCAL NAT candidates from the
+    /// endpoint's known address set (QUIC-discovered reflexive addresses and
+    /// the UPnP-mapped external address — both land in the local node's
+    /// discovery session).
+    ///
+    /// Called when an external address is discovered and when a hole-punch
+    /// session begins, so `candidate_pairs` can form on the local side even
+    /// for connections opened before the address was known. Sends no frames.
+    /// Returns the total number of candidates inserted.
+    pub fn seed_traversal_candidates(&self) -> usize {
+        seed_traversal_candidates_shared(
+            &self.connections,
+            &self.discovery_manager,
+            &self.local_peer_id,
+        )
+    }
+
     pub fn add_local_external_candidate(
         &self,
         addr: SocketAddr,
@@ -5913,6 +5948,10 @@ impl NatTraversalEndpoint {
         if !relay_setup_attempted.load(std::sync::atomic::Ordering::Relaxed) {
             broadcast_address_to_peers(connections, address, 100);
         }
+        // #262: an external address is also a LOCAL candidate for every live
+        // connection's traversal table — pairs cannot form without the
+        // local half, independent of whether we advertise it right now.
+        seed_traversal_candidates_shared(connections, &discovery_manager, &local_peer_id);
 
         Self::reconcile_relay_server_public_addresses_from_connections(connections, relay_server);
     }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1782,6 +1782,11 @@ pub struct EndpointStats {
 
     /// Direct connections (no coordinator or relay needed)
     pub direct_connections: u64,
+    /// #262: connections established via coordinated hole punching
+    /// (cumulative). Together with `direct_connections` /
+    /// `relayed_connections` this is the per-method success split of the
+    /// traversal ladder.
+    pub holepunched_connections: u64,
 
     /// Currently active direct inbound connections from peers.
     pub active_direct_incoming_connections: u64,
@@ -1825,6 +1830,7 @@ impl Default for EndpointStats {
             last_direct_local_at: None,
             last_direct_global_at: None,
             relayed_connections: 0,
+            holepunched_connections: 0,
             total_bootstrap_nodes: 0,
             connected_bootstrap_nodes: 0,
             start_time: Instant::now(),
@@ -2559,11 +2565,20 @@ async fn record_connection_established(
             match peer_conn.traversal_method {
                 TraversalMethod::Direct => {
                     s.direct_connections += 1;
+                    // #262: plain direct dials are NOT traversal successes.
+                    // The aggregate counter now counts only traversal-class
+                    // establishments (hole punch / relay), so
+                    // `nat_traversal_successes <= nat_traversal_attempts`
+                    // per class on a healthy node.
                 }
                 TraversalMethod::Relay => {
                     s.relayed_connections += 1;
+                    s.nat_traversal_successes += 1;
                 }
-                TraversalMethod::HolePunch | TraversalMethod::PortPrediction => {}
+                TraversalMethod::HolePunch | TraversalMethod::PortPrediction => {
+                    s.holepunched_connections += 1;
+                    s.nat_traversal_successes += 1;
+                }
             }
         }
 
@@ -2858,12 +2873,23 @@ async fn bridge_nat_traversal_event(
         NatTraversalEvent::CoordinationRequested { .. } => {
             stats.write().await.nat_traversal_attempts += 1;
         }
+        // #262: a punch session is also an attempt when it starts locally
+        // (the HolePunchingStarted event fires once per punching round on
+        // the initiating side and when the passive side adopts a
+        // PUNCH_ME_NOW), so attempts no longer undercount sessions that
+        // never reach a coordinator request.
+        NatTraversalEvent::HolePunchingStarted { .. } => {
+            stats.write().await.nat_traversal_attempts += 1;
+        }
         NatTraversalEvent::ConnectionEstablished {
             peer_id,
             remote_address,
             ..
         } => {
-            stats.write().await.nat_traversal_successes += 1;
+            // #262: the aggregate success counter is now incremented at the
+            // connection-store site where TraversalMethod is known, so
+            // plain direct dials stop inflating traversal successes; this
+            // arm keeps the path-status publication only.
             publish_direct_path_status(
                 direct_path_statuses,
                 event_tx,
@@ -5172,6 +5198,13 @@ impl P2pEndpoint {
                     let target = target_ipv4
                         .or(target_ipv6)
                         .ok_or(EndpointError::NoAddress)?;
+
+                    // #262: a punch session is starting — make sure the
+                    // local half of the candidate table is populated from
+                    // everything the endpoint knows (reflexive + UPnP
+                    // addresses), or no pair can ever succeed regardless of
+                    // coordination quality.
+                    let _ = self.inner.seed_traversal_candidates();
 
                     info!(
                         "Trying hole-punch to {} via {} (round {})",
@@ -11349,7 +11382,11 @@ mod tests {
         .await;
 
         let stats = stats.read().await;
-        assert_eq!(stats.nat_traversal_successes, 1);
+        // #262: the event alone no longer increments traversal successes —
+        // counting happens where TraversalMethod is known (connection
+        // store), so a bare ConnectionEstablished (e.g. a plain direct
+        // dial's event) must leave the traversal counter untouched.
+        assert_eq!(stats.nat_traversal_successes, 0);
         assert_eq!(stats.active_connections, 0);
         assert_eq!(stats.successful_connections, 0);
         drop(stats);
@@ -13179,6 +13216,104 @@ mod tests {
     }
 
     #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
+    /// #262: plain direct dials must leave the traversal counters
+    /// untouched. `nat_traversal_attempts` counts coordination/punch
+    /// session starts; `nat_traversal_successes` counts traversal-class
+    /// establishments only. A plain connect that never touches the strategy
+    /// ladder must move neither.
+    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
+    #[tokio::test]
+    async fn plain_direct_dial_leaves_traversal_counters_untouched() {
+        let endpoint_a = P2pEndpoint::new(
+            P2pConfig::builder()
+                .bind_addr(SocketAddr::new(
+                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                    0,
+                ))
+                .port_mapping_enabled(false)
+                .build()
+                .expect("config should build"),
+        )
+        .await
+        .expect("endpoint_a should bind");
+
+        let endpoint_b = P2pEndpoint::new(
+            P2pConfig::builder()
+                .bind_addr(SocketAddr::new(
+                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                    0,
+                ))
+                .port_mapping_enabled(false)
+                .build()
+                .expect("config should build"),
+        )
+        .await
+        .expect("endpoint_b should bind");
+        let a_addr = localhost_addr(endpoint_a.local_addr().expect("endpoint_a addr"));
+
+        let accept_pump = {
+            let endpoint_a = endpoint_a.clone();
+            tokio::spawn(async move { while let Some(_conn) = endpoint_a.accept().await {} })
+        };
+        let connected =
+            tokio::time::timeout(Duration::from_secs(20), endpoint_b.connect_addr(a_addr))
+                .await
+                .expect("connect should not time out")
+                .expect("connect should succeed");
+        assert_eq!(connected.peer_id, endpoint_a.peer_id());
+        assert!(
+            await_connected(&endpoint_a, &endpoint_b.peer_id()).await,
+            "a must admit the inbound connection"
+        );
+
+        let stats = endpoint_a.stats().await;
+        assert_eq!(
+            stats.nat_traversal_attempts, 0,
+            "plain direct dial: no coordination/punch session started"
+        );
+        assert_eq!(
+            stats.nat_traversal_successes, 0,
+            "plain direct dial: successes must not count (was the attempts<successes bug)"
+        );
+        assert_eq!(stats.holepunched_connections, 0);
+        assert!(
+            stats.direct_connections >= 1,
+            "sanity: the dial was counted as direct"
+        );
+
+        accept_pump.abort();
+        endpoint_a.shutdown().await;
+        endpoint_b.shutdown().await;
+    }
+
+    /// #262: a punch session start increments attempts exactly once per
+    /// HolePunchingStarted event (one round ⇒ one increment).
+    #[tokio::test]
+    async fn hole_punching_started_increments_attempts_once() {
+        let stats = Arc::new(RwLock::new(EndpointStats::default()));
+        let (event_tx, _event_rx) = broadcast::channel(64);
+        let direct_path_statuses = ParkingRwLock::new(HashMap::new());
+        let peer = crate::PeerId([9u8; 32]);
+
+        bridge_nat_traversal_event(
+            &stats,
+            &event_tx,
+            &direct_path_statuses,
+            NatTraversalEvent::HolePunchingStarted {
+                peer_id: peer,
+                targets: vec![SocketAddr::from(([198, 51, 100, 20], 5483))],
+            },
+        )
+        .await;
+
+        let snapshot = stats.read().await.clone();
+        assert_eq!(
+            snapshot.nat_traversal_attempts, 1,
+            "one punching round increments attempts exactly once"
+        );
+        assert_eq!(snapshot.nat_traversal_successes, 0);
+    }
+
     #[tokio::test]
     async fn test_mdns_auto_connect_succeeds_without_overriding_authenticated_identity() {
         let node_b = crate::Node::bind(SocketAddr::new(

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -13215,7 +13215,6 @@ mod tests {
         endpoint.shutdown().await;
     }
 
-    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
     /// #262: plain direct dials must leave the traversal counters
     /// untouched. `nat_traversal_attempts` counts coordination/punch
     /// session starts; `nat_traversal_successes` counts traversal-class
@@ -13314,6 +13313,7 @@ mod tests {
         assert_eq!(snapshot.nat_traversal_successes, 0);
     }
 
+    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
     #[tokio::test]
     async fn test_mdns_auto_connect_succeeds_without_overriding_authenticated_identity() {
         let node_b = crate::Node::bind(SocketAddr::new(


### PR DESCRIPTION
Fixes 2+3 of the #262 dual-dive verdict (companion: x0x takes fix 1 — dial-by-PeerId).

## Fix 2 — seed connection-local candidates (the dead local half)
The local half of the per-connection candidate-pair table was only ever populated as a **side effect of broadcasting** an external address (`send_nat_address_advertisement` → `add_local_candidate`). A node that had not (yet) discovered and advertised a reflexive address entered hole punching with **zero local candidates** → no `candidate_pairs` could form → `mark_pair_succeeded` never fired → `migrate_to_nat_traversal_path` could only ever fail with "No validated NAT traversal paths".

- `Connection::seed_local_traversal_candidates` — inserts the endpoint's known addresses via the existing `add_local_candidate` writer (first production caller independent of advertisement). No frames sent; deduplicated; capped at `SEED_LOCAL_CANDIDATES_CAP = 8`.
- `CandidateDiscoveryManager::local_seed_addresses` — reads the local node's own discovery session (both external feeds land there: QUIC-discovered reflexive + UPnP-mapped), filtered to routable unicast, deduped, capped.
- `NatTraversalEndpoint::seed_traversal_candidates` — fans out across all live connections. **Triggered** (a) whenever an external address is discovered, and (b) at `connect_orchestrated`'s HolePunching stage entry — so punch sessions on connections opened before discovery are covered on both the initiating and passive side (the endpoint-wide sweep at discovery time covers existing connections; stage entry covers the dial in progress).

With fix 1 (x0x dialing by PeerId) this makes the ladder's punch tier actually two-sided.

## Fix 3 — honest traversal counters
- `nat_traversal_attempts` **also** increments on `HolePunchingStarted` (session start — locally initiated or adopted from a received PUNCH_ME_NOW), not only `CoordinationRequested`. The desktop `attempts=0` observation was undercounting sessions that never reached a coordinator request.
- `nat_traversal_successes` now counts **only traversal-class** establishments (hole punch / relay), incremented where `TraversalMethod` is known (`record_connection_established`) — plain direct dials stop inflating it. This is the live `attempts < successes` anomaly resolved definitionally.
- New `holepunched_connections` field completes the per-method success split (`direct_connections` / `holepunched_connections` / `relayed_connections`) — x0x `/diagnostics/transport` picks new pub fields through automatically.

## Tests
- `seeded_local_candidates_form_pairs_with_remote_advertisement` — seed + remote ADD_ADDRESS ⇒ `candidate_pairs` non-empty.
- `seeded_and_succeeded_pair_satisfies_migration_precondition` — `mark_pair_succeeded` + `get_best_succeeded_pairs()` non-empty: the exact previously-dead migration precondition.
- `plain_direct_dial_leaves_traversal_counters_untouched` — real loopback dial: attempts=0, successes=0, `direct_connections ≥ 1`.
- `hole_punching_started_increments_attempts_once` — bridge counts one per punching round.
- Legacy bridge test updated to the new counting contract (bare `ConnectionEstablished` increments nothing).

## Gate
fmt, clippy `-D warnings`, full nextest. Remaining failures (`test_docker_config_exists`, `test_event_pipeline_uses_transport_addr`) are pre-existing on master — verified by stash; the latter passes solo (parallel-load flake).

Do not merge yet.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR seeds connection-local NAT candidates from endpoint discovery state and revises traversal telemetry to distinguish direct, hole-punched, and relayed establishments.

- Adds bounded, deduplicated local-candidate seeding across live connections.
- Triggers seeding on external-address discovery and hole-punch stage entry.
- Adds hole-punched connection statistics and changes traversal attempt/success accounting.
- Adds focused candidate-pair and telemetry tests.

<h3>Confidence Score: 4/5</h3>

The traversal-attempt double count should be fixed before merging because it makes the revised success-rate diagnostics systematically inaccurate.

A normal initiating traversal emits both newly counted event types for one session, so the implementation records two attempts despite defining the metric in terms of one attempt per round; the changelog also contains a non-blocking duplicate section.

**Files Needing Attention:** src/p2p_endpoint.rs, CHANGELOG.md

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/p2p_endpoint.rs | Revises per-method connection metrics, but counts both sequential events from one initiating traversal round as separate attempts. |
| src/nat_traversal_api.rs | Adds endpoint-wide candidate seeding and supplies the session events that expose the attempt-counter double count. |
| src/connection/mod.rs | Adds normalized, validated, deduplicated, and bounded insertion of local traversal candidates. |
| src/candidate_discovery.rs | Exposes routable, deduplicated local discovery addresses for traversal seeding. |
| src/connection/nat_traversal.rs | Adds tests showing seeded local and remote candidates can form and satisfy migration prerequisites. |
| CHANGELOG.md | Documents the NAT and telemetry changes but introduces a duplicate Unreleased section. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Session as Initiating traversal session
    participant Events as NAT event bridge
    participant Stats as EndpointStats
    participant Diagnostics as Diagnostics
    Session->>Events: CoordinationRequested
    Events->>Stats: "attempts += 1"
    Session->>Session: Synchronization to Punching
    Session->>Events: HolePunchingStarted
    Events->>Stats: "attempts += 1"
    Stats->>Diagnostics: successes / attempts
    Note over Stats,Diagnostics: One round contributes two attempts
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/p2p_endpoint.rs:2881-2883
**Traversal rounds count twice**

When an initiating traversal progresses from coordination into punching, the same session emits both `CoordinationRequested` and `HolePunchingStarted`, and both handlers increment `nat_traversal_attempts`. This records two attempts for one round and causes `hole_punch_success_rate` to under-report successful traversal.

### Issue 2
CHANGELOG.md:29
**Duplicate Unreleased changelog section**

The added entries are followed by a second `Unreleased` heading, leaving two sections with the same version label. This makes future release preparation and automated changelog parsing liable to omit or misplace entries.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(nat): seed connection-local candidat..."](https://github.com/saorsa-labs/ant-quic/commit/331df2cf5c1b8000bb4b46697abbe1546ff478b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56211514)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->