### PR TITLE
fix(cache): inbound accepts must not grant relay/coordinator capability (#262 fix 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Capability honesty: inbound accepts no longer grant relay/coordinator capability (#262 fix 4,
+  x0x#398).** `fn accept` recorded every inbound peer'''s NAT source address as global direct
+  reachability, so any desktop that dialled a bootstrap advertised `supports_relay`/
+  `supports_coordination` and poisoned helper selection for third-party hole punches. Inbound
+  evidence now caches the address as a redial candidate only
+  (`observe_inbound_peer_address`); capability derivation is fed exclusively by
+  OUTBOUND-verified connections (`side == Client`).
+
 ## [0.27.46] - 2026-08-24
 
 ### Fixed

--- a/src/bootstrap_cache/cache.rs
+++ b/src/bootstrap_cache/cache.rs
@@ -345,6 +345,42 @@ impl BootstrapCache {
     /// This is observer-scoped evidence. A peer is considered suitable for
     /// relay/bootstrap/coordinator selection only after a direct connection to
     /// one of its addresses succeeds without coordinator or relay assistance.
+    /// Record an inbound peer's source address as a redial candidate WITHOUT
+    /// granting reachability-derived capabilities (x0x#398 / #262 fix 4).
+    ///
+    /// ant-quic uses one socket for inbound and outbound, so an inbound
+    /// peer's observed source port is its listening port and is a sound
+    /// redial candidate. It is NOT evidence the peer is globally reachable:
+    /// a NATed desktop dialling out through a cone NAT shows a global source
+    /// address that only *we* (or nobody, for symmetric NATs) can reach.
+    /// Granting `supports_relay`/`supports_coordination` from inbound
+    /// evidence made every desktop that ever dialled a bootstrap advertise
+    /// as a relay/coordinator, poisoning helper selection for third-party
+    /// hole punches.
+    pub async fn observe_inbound_peer_address(&self, peer_id: PeerId, address: SocketAddr) {
+        let mut data = self.data.write().await;
+        let now = SystemTime::now();
+        let peer = data
+            .peers
+            .entry(peer_id.0)
+            .or_insert_with(|| CachedPeer::new(peer_id, vec![address], PeerSource::Connection));
+        if !peer.addresses.contains(&address) {
+            peer.addresses.push(address);
+        }
+        peer.last_seen = now;
+        peer.stats.success_count = peer.stats.success_count.saturating_add(1);
+        self.refresh_cached_peer(peer, now);
+        let count = data.peers.len();
+        drop(data);
+        let _ = self
+            .event_tx
+            .send(CacheEvent::Updated { peer_count: count });
+    }
+
+    /// Record OUTBOUND-verified direct reachability: we dialled `address` and
+    /// the connection succeeded, so the peer is genuinely reachable there.
+    /// This is the only path that feeds capability derivation
+    /// (`supports_relay` / `supports_coordination`).
     pub async fn observe_direct_reachability(&self, peer_id: PeerId, address: SocketAddr) {
         let mut data = self.data.write().await;
         let now = SystemTime::now();
@@ -876,5 +912,37 @@ mod tests {
                 .any(|entry| entry.address == addr)
         );
         assert!(peer.success_rate() > 0.0);
+    }
+    /// #262 fix 4: an INBOUND peer's source address is a redial candidate but
+    /// must not grant relay/coordinator capability — a NATed desktop dialling
+    /// out shows a global source addr that is not proof of reachability.
+    #[tokio::test]
+    async fn inbound_observation_caches_address_without_capability_grant() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cache = create_test_cache(&temp_dir).await;
+        let peer_id = PeerId([41u8; 32]);
+        let addr: SocketAddr = "203.0.113.9:41000".parse().expect("addr");
+        cache.observe_inbound_peer_address(peer_id, addr).await;
+        let peer = cache.get(&peer_id).await.expect("cached");
+        assert!(peer.addresses.contains(&addr), "redial candidate kept");
+        assert!(
+            !peer.capabilities.supports_relay && !peer.capabilities.supports_coordination,
+            "inbound evidence must not grant helper capabilities"
+        );
+    }
+
+    /// #262 fix 4 counterpart: OUTBOUND-verified reachability still grants.
+    #[tokio::test]
+    async fn outbound_observation_still_grants_capability() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cache = create_test_cache(&temp_dir).await;
+        let peer_id = PeerId([42u8; 32]);
+        let addr: SocketAddr = "203.0.113.10:41001".parse().expect("addr");
+        cache.observe_direct_reachability(peer_id, addr).await;
+        let peer = cache.get(&peer_id).await.expect("cached");
+        assert!(
+            peer.capabilities.supports_relay && peer.capabilities.supports_coordination,
+            "outbound global evidence grants helper capabilities"
+        );
     }
 }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -5988,9 +5988,21 @@ impl P2pEndpoint {
         }
 
         if let Some(socket_addr) = peer_conn.remote_addr.as_socket_addr() {
-            bootstrap_cache
-                .observe_direct_reachability(peer_conn.peer_id, socket_addr)
-                .await;
+            // #262 fix 4 (capability honesty): only OUTBOUND-verified direct
+            // connections prove the peer is reachable at this address.
+            // Inbound accepts still cache the address as a redial candidate
+            // (single-socket: source port == listening port) but must not
+            // grant relay/coordinator capability — that let every NATed
+            // desktop that dialled a bootstrap advertise as a helper.
+            if peer_conn.side == Side::Client {
+                bootstrap_cache
+                    .observe_direct_reachability(peer_conn.peer_id, socket_addr)
+                    .await;
+            } else {
+                bootstrap_cache
+                    .observe_inbound_peer_address(peer_conn.peer_id, socket_addr)
+                    .await;
+            }
         }
     }
 


### PR DESCRIPTION
x0x#398 fix 4. Inbound accepts recorded the peer's NAT source addr as global direct reachability → every NATed desktop that dialled a bootstrap advertised as relay/coordinator, poisoning helper selection. Now: inbound = redial candidate only (`observe_inbound_peer_address`); capability grants come exclusively from outbound-verified (`side == Client`) direct connections. 2 intent tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates inbound peer-address observations from outbound-verified direct reachability so inbound accepts remain redial candidates without granting relay or coordinator capability.
- Adds a cache operation that records inbound addresses without deriving helper capabilities.
- Routes direct connections according to client/server side before persisting reachability evidence.
- Adds intent tests covering inbound non-promotion and outbound capability grants.
- Documents the capability-honesty fix in the changelog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with inbound and outbound reachability evidence now separated consistently.

The changed endpoint path retains inbound addresses for future dialing while reserving relay and coordinator capability derivation for successful outbound direct connections, and no concrete regression remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/bootstrap_cache/cache.rs | Adds distinct inbound-address observation semantics and tests contrasting inbound candidates with outbound-verified capability evidence. |
| src/p2p_endpoint.rs | Splits persistence for direct connections by initiator side while preserving existing exclusions for synthetic identities and assisted traversal methods. |
| CHANGELOG.md | Documents why inbound accepts must not be treated as proof of globally reachable helper capability. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Peer
    participant Endpoint
    participant Cache
    participant Selection as Helper Selection
    alt Inbound accepted connection
        Peer->>Endpoint: Connect to local endpoint
        Endpoint->>Cache: observe_inbound_peer_address(peer, source)
        Cache-->>Cache: Store redial candidate only
        Cache-->>Selection: No new relay/coordinator capability
    else Outbound direct connection
        Endpoint->>Peer: Dial peer address
        Peer-->>Endpoint: Direct connection succeeds
        Endpoint->>Cache: observe_direct_reachability(peer, address)
        Cache-->>Cache: Record verified direct evidence
        Cache-->>Selection: Relay/coordinator capability eligible
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(cache): inbound accepts must not gra..."](https://github.com/saorsa-labs/ant-quic/commit/0cf02d143a625c31e92046c03a5401d0bc674d96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56312422)</sub>

<!-- /greptile_comment -->