### PR TITLE
refactor(link): overlay-neutral naming (ADR-011) + accept ADR-012..016

### DIFF
--- a/docs/adr/ADR-011-transport-scope-terminology.md
+++ b/docs/adr/ADR-011-transport-scope-terminology.md
@@ -1,0 +1,149 @@
+# ADR-011: Transport-Scope Terminology Boundary
+
+## Status
+
+Accepted (2026-08-26)
+
+## Supersedes
+
+Specific wording within [ADR-009](ADR-009-masque-relay-data-plane.md) (§ "DHT Address Propagation",
+§ Implementation Status row "ADD_ADDRESS -> DHT bridge"). ADR-009 itself remains immutable per the
+accepted-ADR immutability rule; this ADR carries forward its intent with corrected vocabulary.
+
+## Context
+
+ant-quic is a connectivity substrate: QUIC transport, NAT traversal, address discovery, and peer
+relay. It intentionally stops short of overlay semantics ([ADR-005](ADR-005-native-quic-nat-traversal.md)
+explicitly lists record storage and lookup semantics as non-goals).
+
+However, distributed-lookup vocabulary from consuming overlays has leaked into this crate. An audit
+on 2026-08-26 found:
+
+| Class | Location | Problem |
+|-------|----------|---------|
+| Code surface | `src/link_transport.rs` (lines 23, 47, 184, 218-229, 284, 296-313, 383-396, 419-454, 509, 1161, tests 1452-1617) | A hardcoded `StreamTypeFamily::Dht` (byte range 0x10-0x1F), `StreamType::DhtQuery/DhtStore/...`, and `StreamFilter::dht_only()` bake one overlay category into the public protocol-type model |
+| Comments/API docs | `src/nat_traversal_api.rs:598,1892,2404,2724`; `src/shared.rs:86`; `src/connection/mod.rs:4901`; `src/high_level/endpoint.rs:1082`; `src/p2p_endpoint.rs:1985` | Address updates described as feeding "the DHT bridge" / "the DHT routing table"; a DHT self-lookup suggested as an endpoint behaviour |
+| Accepted ADR prose | ADR-009 §Context step 3, § "DHT Address Propagation" (lines 29, 78-93) | Describes relay addresses propagating through "the DHT" as if this crate participated in a network-wide database |
+| Other docs | `docs/architecture/UNIFIED_CONNECTIVITY_PLAN.md:255`; `docs/rfcs/ant-quic-pqc-authentication.md:96` | Future-integration and PeerId rationale wording |
+| Permitted (non-goal statements) | `docs/adr/ADR-005-native-quic-nat-traversal.md:36` | Explicit prohibition context - see Decision §Permitted |
+
+The leak matters because it invites readers and contributors to assume this crate maintains or
+queries a network-wide address database. It does not. Facts observed by this crate flow only over
+live connections and out of a single typed event boundary; persistence and network-wide propagation
+of those facts belong entirely to the consuming overlay.
+
+## Decision
+
+### 1. Vocabulary boundary
+
+The term "DHT" (and equivalents such as "distributed hash table", "Kademlia", "routing table",
+"DHT entry") is prohibited in all ant-quic artifacts - documentation, ADR prose, code identifiers,
+log messages, and comments - **except** in non-goal statements.
+
+**Permitted**: a single scope statement asserting that this crate does not provide distributed
+record-storage/lookup semantics. Renaming that statement to avoid the word entirely obscures the
+boundary it enforces, so one explicit prohibition per document is allowed where needed.
+
+**Required replacements** elsewhere:
+
+| Instead of | Use |
+|------------|-----|
+| "ADD_ADDRESS → DHT bridge" | "peer-address notification (an event consumed by overlays)" |
+| "update the DHT routing table" | "update their own address book" (consumer responsibility) |
+| "propagate through the DHT" | "advertise on live connections; consumers persist/forward as they see fit" |
+| "address resolved from the DHT" | "any address the initiator learned via any means" |
+| `StreamTypeFamily::Dht`, `StreamType::DhtXxx`, `StreamFilter::dht_only()` | See Decision 2 |
+
+### 2. Generalize the protocol-type model
+
+Rename the DHT-specific stream-type family to an overlay-neutral name (for example
+`StreamTypeFamily::OverlayService`), keeping the existing numeric allocation (0x10-0x1F) unchanged so
+deployed peers negotiating these type codes remain compatible. Registered variants and filters are
+renamed on the same principle (`query/store` become overlay-neutral operation names). One overlay
+category must never be named in the shared abstraction ([ADR-001](ADR-001-link-transport-abstraction.md)).
+
+### 3. Event-boundary contract
+
+Normative statement for the whole crate: ant-quic learns addresses only from connections it holds;
+it exposes them only through endpoint events and query APIs scoped to known peers; it performs no
+further distribution. What consumes, stores, indexes, or re-advertises those addresses is entirely
+the overlay's concern. Event-channel names and doc comments are updated accordingly (the channel at
+`nat_traversal_api.rs:598` becomes a consumer-neutral "address notification sink").
+
+## Consequences
+
+### Positive
+
+- Contributors stop assuming hidden network-wide state exists in this crate.
+- The public type model stays honest: one transport, many overlays, no favourites.
+- Cross-repo contracts clarify cleanly: saorsa-core consumes events; ant-quic emits them.
+
+### Negative
+
+- Mechanical rename touches ~35 sites across 8 source files plus 3 docs; churn with no behaviour change.
+- Test names/identifiers referencing the old family need coordinated rename to keep greps honest.
+
+## Alternatives Considered
+
+1. **Keep DHT naming as legacy alias, add neutral names alongside**
+   - Rejected: aliases preserve exactly the vocabulary this ADR removes; greps stay polluted.
+2. **Edit ADR-009 in place to fix wording**
+   - Rejected: accepted ADRs are immutable (see [ADR-010](ADR-010-ble-transport-opt-in.md)); supersession is the mechanism.
+3. **Ban even non-goal statements containing the term**
+   - Rejected: hiding the scoping sentence makes the boundary harder to teach; one disciplined exception is clearer.
+
+## Remediation Inventory
+
+- Rename sweep: `src/link_transport.rs`, `src/link_transport_impl.rs:1606`, `src/nat_traversal_api.rs`,
+  `src/shared.rs:86`, `src/connection/mod.rs:4901`, `src/high_level/endpoint.rs:1082`,
+  `src/p2p_endpoint.rs:1985`
+- Doc sweep: `docs/architecture/UNIFIED_CONNECTIVITY_PLAN.md:255`,
+  `docs/rfcs/ant-quic-pqc-authentication.md:96` (rationale reworded to "compact identifier suitable
+  for any consumer-side addressing layer")
+- ADR-009 is left byte-for-byte untouched (immutable per the governance gate); the supersession is
+  recorded here only (§Supersedes, §References)
+- Research doc sweep: `docs/research/CONSTRAINED_TRANSPORTS.md` (`RoutingTable` -> `RouteTable`,
+  "routing table" -> "route table")
+
+### Migration (breaking public API - next release must be a minor bump, 0.28.0)
+
+The rename sweep changes public identifiers. Downstream crates must update:
+
+| Before | After |
+|--------|-------|
+| `StreamTypeFamily::Dht` | `StreamTypeFamily::OverlayService` |
+| `StreamType::DhtQuery` / `DhtStore` / `DhtWitness` / `DhtReplication` | `StreamType::ServiceQuery` / `ServiceStore` / `ServiceWitness` / `ServiceReplication` |
+| `StreamType::is_dht()` | `StreamType::is_overlay_service()` |
+| `StreamTypeFamily::dht_only()` | `StreamTypeFamily::overlay_service_only()` |
+| `StreamTypeFamily::dht_types()` | `StreamTypeFamily::service_types()` |
+
+Wire bytes (0x10-0x1F) are unchanged, so peers on either side of the rename interoperate.
+`StreamType` derives serde and unit variants serialize by name, so any downstream code that
+serde-encodes `StreamType` (ant-quic itself never does - the wire path is the raw first byte)
+will see `"DhtQuery"` become `"ServiceQuery"`; treat such encodings as version-scoped.
+
+## Validation
+
+- `src/link_transport.rs::tests::test_stream_type_from_byte` and `test_protocol_id_from_string` pin
+  the frozen wire bytes (0x10-0x1F -> `ServiceQuery`/`ServiceStore`/`ServiceWitness`/`ServiceReplication`);
+  a rename that shifts a byte value fails them.
+- `python3 scripts/adr-governance.py --base origin/master` passes: ADR-009 unchanged, this ADR frozen
+  at acceptance.
+- Vocabulary gate (run before merging any PR): a case-insensitive grep for `\bdht\b`, "distributed
+  hash table", "kademlia", "routing table" over `src/ tests/ examples/ benches/ docs/ README.md
+  CHANGELOG.md` returns hits only in ADR-005 (non-goal), ADR-009 (frozen original), and this ADR.
+- Downstream compile check: saorsa-core / x0x build against the 0.28.0 release using the migration
+  table above with no remaining `Dht*` identifiers.
+- Revisit trigger: a new stream-type family is added, or a consumer needs a term this ADR prohibits
+  for a genuine transport-scope concept - supersede with a new ADR rather than editing this one.
+
+## References
+
+- [ADR-001](ADR-001-link-transport-abstraction.md) - LinkTransport abstraction this boundary protects
+- [ADR-004](ADR-004-symmetric-p2p-architecture.md) - symmetric architecture motivating role-free vocabulary
+- [ADR-009](ADR-009-masque-relay-data-plane.md) - superseded wording origin
+
+## Notes for AI-assisted work
+
+Drafted with AI assistance; reviewed and accepted by the project owner on 2026-08-26. Accepted ADRs are
+immutable: create a new superseding ADR rather than editing this one.

--- a/docs/adr/ADR-012-standards-basis-refresh.md
+++ b/docs/adr/ADR-012-standards-basis-refresh.md
@@ -1,0 +1,120 @@
+# ADR-012: Standards Basis Refresh
+
+## Status
+
+Accepted (2026-08-26)
+
+## Supersedes
+
+The "Standards Basis" section of [ADR-005](ADR-005-native-quic-nat-traversal.md) and the
+specification references of [ADR-006](ADR-006-masque-relay-fallback.md). Those ADRs remain immutable;
+this ADR carries their intent with corrected standards status.
+
+## Context
+
+ADR-005 and ADR-006 were written against draft revisions whose status has since changed materially
+(verified 2026-08-26):
+
+| Document | Status at ADR time | Verified status now | Wire impact |
+|----------|-------------------|---------------------|-------------|
+| `draft-seemann-quic-nat-traversal` | "Based on IETF drafts (not yet RFCs)" | **Expired at -02 (March 2024)**; individual submission, no successor of same name | None on our wire - frames are defined by us |
+| `draft-ietf-quic-address-discovery` | Cited as `-00` (expired as an I-D March 2025) | **Active WG document at `-01`, dated 2026-08-15**; OBSERVED_ADDRESS codepoints 0x9f81a6/a7 and transport parameter 0x9f81a176 unchanged; IANA registration still TODO | Codepoints we already use match current WG text |
+| `draft-ietf-masque-connect-udp-listen` | Cited as `-10` | **At `-16` (2026-08-24), passed IESG evaluation, sitting in the RFC Editor queue** for Proposed Standard publication | Must diff -10 → -16 before declaring conformance |
+
+Separately, two related documents define our ecosystem's direction:
+
+- [`draft-bruynooghe-n0-quic-nat-traversal-00`](https://datatracker.ietf.org/doc/draft-bruynooghe-n0-quic-nat-traversal/)
+  (n0-computer / iroh) explicitly builds on the expired Seemann draft - evidence the QUIC-native
+  hole-punching approach has independent traction.
+- [`draft-seemann-masque-connect-udp-rendezvous-00`](https://datatracker.ietf.org/doc/draft-seemann-masque-connect-udp-rendezvous/)
+  formalizes relay-mediated rendezvous for CONNECT-UDP listeners - closely matching the proactive-relay
+  model of [ADR-009](ADR-009-masque-relay-data-plane.md).
+
+Risk being addressed: ADR prose currently implies living standards work where none exists, while real
+standards movement (address discovery WG item, listen RFC-in-queue) is under-credited.
+
+## Decision
+
+1. **Our specifications become normative; drafts become citations.**
+   The authoritative wire definition for ant-quic's NAT traversal frames, transport parameters, and
+   MASQUE relay capsules is maintained in this repository (`docs/rfcs/ant-quic-nat-traversal.md`,
+   to be authored if absent). External drafts are cited as inspiration and provenance only. An expired
+   individual submission cannot be a conformance target; a self-hosted spec can.
+
+2. **Wire-compatibility freeze via negotiation, not silent drift.**
+   Deployed peers already speak the codepoints listed above. If a future RFC assigns different
+   codepoints or semantics, differences are resolved through transport-parameter/capsule negotiation
+   under our own spec versioning - never by silently adopting upstream changes that would break
+   deployed peers.
+
+3. **Point-in-time conformance table.**
+   - Address discovery: align conformance claims with `draft-ietf-quic-address-discovery-01`
+     (codepoints verified identical); revisit when its IANA registration completes.
+   - MASQUE relay: perform a documented diff of listen-draft -10 → -16 before any claim of protocol
+     conformance; since the draft is effectively RFC-bound, plan for re-citing it by RFC number once
+     published.
+
+4. **Quarterly upstream check.**
+   A maintainer task reviews: n0 NAT traversal draft evolution, address-discovery revisions,
+   connect-udp-listen RFC publication, and rendezvous-draft developments. Outcomes are recorded as
+   GitHub issues, not ADR edits.
+
+## Consequences
+
+### Positive
+
+- Honest standards posture: nothing claims conformity to dead text.
+- Our own spec becomes the single source reviewers implement against; expired drafts stop rotating
+  out from under documentation.
+- Positions us to interoperate with iroh-family implementations later if desired (they negotiate,
+  so no commitment today).
+
+### Negative
+
+- One-time effort to author `docs/rfcs/ant-quic-nat-traversal.md` and perform the -10 → -16 diff.
+- Ongoing quarterly review chore (small; issue-driven).
+
+## Alternatives Considered
+
+1. **Adopt `draft-bruynooghe-n0-quic-nat-traversal` as our wire format now**
+   - Rejected: it is also an unadopted `-00`; swapping one live custom dialect for another gains
+     nothing except external alignment, and forces a migration on deployed peers.
+2. **Wait for RFC status before touching references**
+   - Rejected: citation staleness is itself misleading today; address-discovery is early-stage but
+     active, and listen-draft is days-to-months from an RFC number, not years.
+3. **Fork and resurrect the Seemann draft under saorsa stewardship**
+   - Rejected: republishing someone else's draft without author intent adds governance burden for
+     zero interop gain while the n0 draft already serves as public continuation.
+
+## Validation
+
+- `scripts/adr-governance.py` (run in CI by `.github/workflows/adr-governance.yml`) rejects edits to
+  Accepted ADR-005/006, so the corrected standards status can only live here or in a successor ADR -
+  never in a silent rewrite of the superseded sections.
+- Wire codepoints that must not drift are pinned by existing tests:
+  `src/transport_parameters.rs::test_nat_traversal_parameter_id` (0x3d7e9f0bca12fea6),
+  `src/transport_parameters.rs::test_address_discovery_parameter_id` (0x9f81a176), and the
+  frame-type constants asserted in `tests/nat_traversal_frame_tests.rs` and
+  `tests/frame_encoding_tests.rs` (0x3d7e90-94). An upstream-driven codepoint change fails these
+  until negotiation under our own spec versioning exists (Decision 2).
+- Implementing PR for Decision 1 must add `docs/rfcs/ant-quic-nat-traversal.md` (absent as of
+  2026-08-26; `docs/rfcs/` holds only the expired `draft-seemann-quic-nat-traversal-02.txt` and
+  `draft-ietf-quic-address-discovery-00.txt`) and repoint the "Reference Specifications" sections of
+  `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` at it.
+- Implementing PR for Decision 3 must add the listen-draft -10 -> -16 diff as a dated document under
+  `docs/` before any repository text claims MASQUE CONNECT-UDP conformance.
+- Revisit trigger: `draft-ietf-masque-connect-udp-listen` is published as an RFC, or
+  `draft-ietf-quic-address-discovery` completes IANA registration - either warrants a superseding
+  ADR re-citing by final number and re-verifying codepoints.
+
+## References
+
+- [Seemann draft history (expired)](https://datatracker.ietf.org/doc/draft-seemann-quic-nat-traversal/history/)
+- [address-discovery datatracker (-01)](https://datatracker.ietf.org/doc/draft-ietf-quic-address-discovery/)
+- [connect-udp-listen datatracker (-16, RFC Ed queue)](https://datatracker.ietf.org/doc/draft-ietf-masque-connect-udp-listen/)
+- [n0-computer NAT traversal draft](https://datatracker.ietf.org/doc/draft-bruynooghe-n0-quic-nat-traversal/)
+- [UDP Rendezvous over HTTP](https://datatracker.ietf.org/doc/draft-seemann-masque-connect-udp-rendezvous/)
+
+## Notes for AI-assisted work
+
+Drafted with AI assistance; reviewed and accepted by the project owner on 2026-08-26. Accepted ADRs are immutable: create a new superseding ADR rather than editing this one.

--- a/docs/adr/ADR-013-measured-connectivity-metrics.md
+++ b/docs/adr/ADR-013-measured-connectivity-metrics.md
@@ -1,0 +1,133 @@
+# ADR-013: Measured Connectivity Metrics Replace Asserted Success Rates
+
+## Status
+
+Accepted (2026-08-26)
+
+## Supersedes
+
+All quantitative connectivity-success claims in accepted ADRs:
+
+- [ADR-005](ADR-005-native-quic-nat-traversal.md) § Layered Connectivity Strategy ("~20%", "High*")
+- [ADR-006](ADR-006-masque-relay-fallback.md) § Layered Connectivity Strategy ("~100%")
+- [ADR-008](ADR-008-universal-connectivity-architecture.md) § Connectivity Matrix ("95%+", "100%")
+
+Those tables remain in their immutable originals; this ADR replaces them as the source of truth for
+expectations and requires instrumentation instead of assertion.
+
+## Context
+
+The percentage columns in ADR-005/006/008 were illustrative estimates at decision time. They have
+two problems: they are not measurable from any artifact of this project, and they now conflict with
+published measurements:
+
+- Tailscale reports direct-connection success "well north of 90%" from internal fleet metrics
+  ([nat-traversal-improvements-pt-1](https://tailscale.com/blog/nat-traversal-improvements-pt-1)).
+- The first large-scale measurement of fully decentralized NAT traversal (DCUtR/libp2p;
+  Trautwein et al., [arXiv:2510.27500](https://arxiv.org/abs/2510.27500)) found **70% ± 7.1%
+  conditional hole-punch success**, attributing residual failure primarily to endpoint-dependent
+  mapping and CGNAT - exactly the environments ant-quic targets hardest.
+- iroh publicly cites ~90% direct-hole-punch success with encrypted relays as guaranteed fallback
+  ([iroh docs](https://docs.iroh.computer/concepts/nat-traversal)).
+- rust-libp2p operator reports range 60-90% depending on deployment
+  ([rust-libp2p discussion #5910](https://github.com/libp2p/rust-libp2p/discussions/5910)).
+
+A layered system can still reach near-total coverage via relay fallback, but the *distribution*
+across layers is an empirical property of the deployed population, unknowable from design docs.
+
+## Decision
+
+### 1. Qualitative tiers only, in prose
+
+Documentation describes establishment tiers qualitatively:
+
+| Tier | Meaning (no percentages) |
+|------|--------------------------|
+| Direct | Existing reachability or router-assisted mapping made it work |
+| Punched | Coordinated traversal through observed-only-NAT pairs succeeded |
+| Relayed | Fallback guaranteed path; expected residual after punch failure |
+
+Success *rates* belong to telemetry dashboards, never static ADR tables.
+
+### 2. Required exported metrics
+
+Promote the existing monitoring list ([ADR-008] § Monitoring Metrics) into concrete instrumented
+counters/histograms shipped by default:
+
+- `connection_establishment_total{method=direct|punched|relay}` (source of truth for tier ratios)
+- `holepunch_attempt_total{outcome=succeeded|failed|timeout}` per round number
+- `path_pair_probe_total{pair_rank}` (feeds [ADR-015](ADR-015-paced-candidate-spray-punching.md))
+- `time_to_establish_seconds{method}` histogram
+- `relay_upgrade_total{from=relay,to=direct}` and `relay_session_bytes_total`
+- `symmetric_nat_detection_total{detected=yes|no}`
+- `port_mapping_result{protocol=upnp_igd,outcome=mapped|failed|unsupported}` (extensible to PCP/NAT-PMP)
+- Amplification/pacing counters from [ADR-015]
+
+### 3. Internal SLOs set after a data window
+
+Numeric engineering targets (e.g., minimum punched-tier share, maximum relay-tier share) are set
+after ~30 days of multi-environment telemetry, tracked as issues with links to dashboard snapshots.
+External studies may be cited in docs with links; unsourced constants may not.
+
+### 4. Tuning gated on measurement
+
+Future changes to punch-round count, spray width ([ADR-015](ADR-015-paced-candidate-spray-punching.md)),
+or relay-forwarding mode ([ADR-016](ADR-016-hybrid-relay-data-plane.md)) must cite these metrics
+before/after, making layer distribution a governed KPI rather than folklore.
+
+## Consequences
+
+### Positive
+
+- Expectations track reality as the deployed population shifts (CGNAT growth, IPv6 growth).
+- Argues for engineering investment with numbers when the punched tier lags.
+- Removes maintenance burden of perpetually-outdated estimates.
+
+### Negative
+
+- Instrumentation work ships ahead of numeric comfort; dashboards need a home.
+- Docs lose reassuring-sounding certainty until data exists - intended consequence.
+
+## Alternatives Considered
+
+1. **Keep percentages, add "measured" caveats to each table**
+   - Rejected: leaves unverifiable numbers in accepted text and invites cargo-culting them into
+     user-facing material.
+2. **Copy the libp2p/Tailscale figures into our docs as expectations**
+   - Rejected: different population (browser-free symmetric Rust nodes, mandatory relaying) makes
+     transplanting their distributions its own form of assertion.
+
+## Validation
+
+- None of the Decision 2 metric names (`connection_establishment_total`, `holepunch_attempt_total`,
+  `path_pair_probe_total`, `time_to_establish_seconds`, `relay_upgrade_total`,
+  `symmetric_nat_detection_total`, `port_mapping_result`) exist in `src/` as of 2026-08-26. The
+  implementing PR must add each as an exported counter/histogram plus a unit test per metric that
+  drives the corresponding code path (a relayed connect, a timed-out punch round, ...) and asserts
+  the labelled increment.
+- `connection_establishment_total{method}` must be derived from the same events that already feed
+  `EndpointStats`; `src/p2p_endpoint.rs::test_direct_plus_relayed_equals_active_connections_under_churn`
+  and `test_record_connection_established_direct_to_relay_decrements_direct` pin that accounting
+  and must keep passing.
+- `tests/connection_success_rates.rs::observed_address_frames_drive_connection_success_rate_inputs`
+  is the only test computing a success *rate*; it compares two simulated runs against each other
+  rather than against a fixed percentage - the pattern any new rate assertion must follow.
+- Reviewers reject new ADR or `docs/architecture/` text that states a connectivity-success
+  percentage without a link to a dashboard snapshot or an external study; the figures in this ADR's
+  Context and in ADR-015's Consequences are cited external measurements, not ant-quic claims.
+- Revisit trigger: the ~30-day multi-environment telemetry window (Decision 3) closes and numeric
+  SLOs are proposed - those go into a new ADR citing dashboard snapshots, not into this one.
+
+## References
+
+- [Tailscale: improving NAT traversal](https://tailscale.com/blog/nat-traversal-improvements-pt-1)
+- [arXiv:2510.27500 - Large-scale decentralized NAT traversal measurement](https://arxiv.org/abs/2510.27500)
+- [arXiv:2604.12484 - DCUtR IPFS case study](https://arxiv.org/html/2604.12484v1)
+- [rust-libp2p discussion #5910](https://github.com/libp2p/rust-libp2p/discussions/5910)
+- [iroh NAT traversal concepts](https://docs.iroh.computer/concepts/nat-traversal)
+- Related: [ADR-008](ADR-008-universal-connectivity-architecture.md) § Monitoring Metrics (superseded list),
+  [ADR-015](ADR-015-paced-candidate-spray-punching.md), [ADR-016](ADR-016-hybrid-relay-data-plane.md)
+
+## Notes for AI-assisted work
+
+Drafted with AI assistance; reviewed and accepted by the project owner on 2026-08-26. Accepted ADRs are immutable: create a new superseding ADR rather than editing this one.

--- a/docs/adr/ADR-014-relay-resource-governance.md
+++ b/docs/adr/ADR-014-relay-resource-governance.md
@@ -1,0 +1,130 @@
+# ADR-014: Enforced Relay Resource Governance
+
+## Status
+
+Accepted (2026-08-26)
+
+## Amends / Supersedes
+
+- [ADR-002](ADR-002-epsilon-greedy-bootstrap-cache.md) § Mandatory Relay/Coordinator Participation
+  (budget promise)
+- [ADR-006](ADR-006-masque-relay-fallback.md) § Every Peer is a Relay ("no opt-out... resource
+  budgets prevent abuse")
+
+The mandatory-participation decision stands. This ADR makes its precondition explicit and testable:
+**open relaying without enforced budgets must not ship**.
+
+## Context
+
+ADR-002/006 justify mandatory relay participation through "predictable resource budgets". An audit
+on 2026-08-26 found the promise only partially implemented:
+
+| Mechanism | State |
+|-----------|-------|
+| Per-session bandwidth limit | ✅ Enforced - `BandwidthTracker` in `src/masque/relay_session.rs` (default 1 MiB/s) rejects over-budget bytes with `BandwidthExceeded` |
+| Global bandwidth limit | ❌ **Declared, never referenced** - `MasqueServerConfig::global_bandwidth_limit` (`src/masque/relay_server.rs:61-73`) has no enforcement site |
+| Per-peer fairness quota (ADR-002 table) | ❌ Not implemented at the MASQUE layer; legacy `TokenBucket` exists in `src/relay/rate_limiter.rs` but is unwired from the MASQUE path |
+| Concurrent relay count cap | ⚠️ Present as config surface only; no admission control counts active relay sessions per source peer |
+
+This is the sharpest edge in the design: every node accepting arbitrary peers' traffic under a
+"mandatory, no opt-out" mandate, while aggregate load-shaping exists mostly on paper. Comparable
+systems treat this carefully by construction - libp2p's Circuit Relay v2 gates forwarding behind
+explicit resource-controlled reservations, and iroh relays are operated services. ant-quic's bet is
+different (symmetry), so its budgets must be real.
+
+Budgets keyed to IP address are also wrong for our threat model: CGNAT and mobile networks share
+thousands of users per address, while attackers rotate addresses freely. Identity-keyed accounting
+matches how we authenticate everything else ([ADR-003](ADR-003-pure-post-quantum-cryptography.md)).
+
+## Decision
+
+1. **Global budget enforcement (ship-blocker).**
+   `global_bandwidth_limit` becomes an admission gate enforced in the relay accept path: bytes are
+   counted through the same tracker family as sessions; when exhausted, new relay sessions receive a
+   structured refuse capsule signalling backoff, and existing sessions continue until their own
+   session budget or grace expires. Config value of 0 keeps semantics "unlimited" *only* in builds
+   explicitly compiled with a development feature - shipped defaults always enforce a finite limit.
+
+2. **Identity-keyed fair share.**
+   Per-source-peer quotas key on the authenticated ML-DSA-65 endpoint identity, not network address.
+   Defaults land at, or below, ADR-002's budget table; no requirement that HostKey ever be consulted
+   on the wire (see [ADR-007](ADR-007-local-only-hostkey.md)).
+
+3. **Concurrency admission control.**
+   Active relay sessions counted per source peer and globally; new sessions refused above caps with
+   the same structured-refuse mechanism.
+
+4. **Legacy limiter consolidation.**
+   The unwired `src/relay/rate_limiter.rs` token bucket either gets adopted as the global-limiter
+   implementation or deleted during the legacy deprecation already planned in [ADR-006]; a second,
+   divergent limiting vocabulary may not survive alongside it.
+
+5. **Honesty clause.**
+   If any mechanism above ships incomplete, user-facing docs must describe relay participation as
+   best-effort rather than claiming bounded guarantees. The claimed invariant and the enforced
+   invariant must be the same invariant.
+
+## Consequences
+
+### Positive
+
+- Mandatory symmetric relaying becomes defensible to run: abuse is structurally capped, not policed.
+- Budget telemetry integrates with [ADR-013](ADR-013-measured-connectivity-metrics.md) counters
+  (refusals by reason become observable).
+- Removes an easy DoS story against participating nodes before it is discovered in production.
+
+### Negative
+
+- Relay accept-path gains hot-path accounting cost (tracked-bytes increments; negligible vs
+  forwarding itself).
+- Behaviour changes for operators who relied on unlimited implicit budgets across upgrades.
+- One-time engineering effort across server config, session admission, and tests.
+
+## Alternatives Considered
+
+1. **Make relaying opt-in instead**
+   - Rejected for now: ADR-004/006 argue symmetry maximizes traversal reliability; abandoning that
+     trade-off belongs to those ADRs' owners. This ADR instead removes the argument against symmetry.
+2. **Enforce via QUIC flow-control credits only**
+   - Rejected: stream-flow credits cap per-stream pressure but not aggregate cross-peer fairness,
+     and refuse-on-new-session needs application-visible signalling anyway.
+3. **Trust process-level cgroups/systemd budgets set by operators**
+   - Rejected: out-of-process configuration cannot express per-peer identity fairness and disappears
+     in library embedding contexts entirely.
+
+## Validation
+
+- Session budget (already enforced): `src/masque/relay_session.rs::test_rate_limit_allows_within_limit`
+  and `test_rate_limit_rejects_over_limit` pin `BandwidthTracker` rejection of over-budget bytes.
+- Decision 1 acceptance: the implementing PR must add a test in `src/masque/relay_server.rs` that sets
+  `MasqueServerConfig::global_bandwidth_limit` low, drives sessions past it, and asserts new sessions
+  receive the structured refuse capsule while existing sessions keep forwarding. It must also revise
+  `src/masque/relay_session.rs::test_rate_limit_zero_means_unlimited` so 0-means-unlimited is
+  asserted only under the development feature and shipped defaults are finite.
+- Decision 2/3 acceptance: a test with two distinct ML-DSA-65 identities behind one `SocketAddr` must
+  show independent quotas (identity-keyed, not address-keyed), and a per-source-peer concurrency cap
+  test must extend the existing `src/masque/relay_server.rs::test_session_limit` /
+  `tests/masque_integration_tests.rs::test_relay_server_session_limit` pattern to the per-peer
+  dimension.
+- Decision 4 acceptance: after the implementing PR exactly one of these holds -
+  `src/relay/rate_limiter.rs` is referenced from the MASQUE accept path, or the file and its
+  `pub use rate_limiter::{RateLimiter, TokenBucket}` export in `src/relay/mod.rs` are removed.
+- Decision 5 (honesty clause): until every item above lands, README and `docs/architecture/` text
+  describing relay participation as bounded must carry a best-effort caveat;
+  `tests/release_hygiene.rs` is the established home if a doc-invariant test is added.
+- Revisit trigger: ADR-004/006 owners revisit mandatory relaying (opt-in), or ADR-013 budget
+  telemetry shows refusals dominating legitimate relay traffic in production.
+
+## References
+
+- Audit sources: `src/masque/relay_session.rs` (enforced session budget),
+  `src/masque/relay_server.rs:61-73` (dead global config), `src/relay/rate_limiter.rs` (unwired bucket)
+- [libp2p Circuit Relay v2 reservations](https://github.com/libp2p/specs/blob/master/relay/circuit-v2.md)
+- [iroh relay concept](https://docs.iroh.computer/concepts/nat-traversal)
+- Related: [ADR-002](ADR-002-epsilon-greedy-bootstrap-cache.md),
+  [ADR-006](ADR-006-masque-relay-fallback.md),
+  [ADR-013](ADR-013-measured-connectivity-metrics.md)
+
+## Notes for AI-assisted work
+
+Drafted with AI assistance; reviewed and accepted by the project owner on 2026-08-26. Accepted ADRs are immutable: create a new superseding ADR rather than editing this one.

--- a/docs/adr/ADR-015-paced-candidate-spray-punching.md
+++ b/docs/adr/ADR-015-paced-candidate-spray-punching.md
@@ -1,0 +1,131 @@
+# ADR-015: Paced Candidate-Spray Punching
+
+## Status
+
+Accepted (2026-08-26)
+
+## Amends
+
+[ADR-005](ADR-005-native-quic-nat-traversal.md) § How It Works step 4 ("Hole Punching") and its
+"Symmetric NAT Handling" section, at implementation level. ADR-005 remains immutable.
+
+## Context
+
+Current punching probes **one candidate pair per round**: coordination queues a single punch target
+(`send_coordination_request`, `src/connection/mod.rs:1304-1340`) and each punching phase emits one
+PATH_CHALLENGE to `targets[0]` (`src/connection/mod.rs:1359-1366`), across up to 3 rounds
+(`max_holepunch_rounds: 3`, `src/connection_strategy.rs:186`) with adaptive jitter and RTT-scaled
+grace periods in `src/connection/nat_traversal.rs`.
+
+Contemporary systems probe candidate pairs concurrently within an attempt, because a single probe
+turns any single loss, late NAT mapping, or mispredicted port into a whole wasted round:
+
+- Tailscale's DISCO sprays endpoints and picks winners continuously
+  ([how NAT traversal works](https://tailscale.com/blog/how-nat-traversal-works)).
+- DCUtR retries coordinated punches three times, measurably improving aggregate success
+  ([large-scale measurement, arXiv:2510.27500](https://arxiv.org/abs/2510.27500));
+  operator-reported success varies 60-90%
+  ([rust-libp2p #5910](https://github.com/libp2p/rust-libp2p/discussions/5910)).
+- Port-prediction approaches improve odds further by trying several predicted ports near a sequence
+  (classic birthday-style spraying; see libp2p symmetric-NAT discussion).
+
+The existing machinery already produces ranked multi-candidate pairs - including linear-delta
+predicted candidates (`src/connection/port_prediction.rs`) and family-filtered pairing - they simply
+are not exercised concurrently per round.
+
+## Decision
+
+Per coordination round, replace singleton probing with a **paced spray across the top-N viable pairs**:
+
+1. **N (spray width)**: default 8 pairs per round, configurable. Ordering follows the existing pair
+   ranking (family filter → priority class → predicted candidates included at their current
+   low-priority tier). N=1 reproduces today's behaviour; both limits bound memory/bandwidth on
+   constrained hosts.
+2. **Pacing**: inter-probe spacing of at least `max(20 ms, min_rtt/10)` within a round, plus the
+   existing start-jitter. Spraying must never violate RFC 9000 anti-amplification rules: probes to an
+   unvalidated address count against the 3× received-byte allowance like any other egress.
+3. **Validation unchanged**: all probes carry token-keyed PATH_CHALLENGE data padded to 1200 bytes;
+   promotion stays keyed by challenge token (survives rebinding), and the existing
+   beats-current-path logic selects the winner. First valid PATH_RESPONSE wins; outstanding probes
+   of that round are cancelled.
+4. **Round count unchanged**: default 3 rounds; a sprayed round subsumes most retry patterns that
+   multiple rounds previously approximated, but the round ceiling is retained as backstop.
+5. **Unauthenticated trigger safety**: a PUNCH_ME_NOW causes bounded work (≤N paced probes per
+   round); hostile coordinators cannot inflate probe volume beyond that without acting on an
+   authenticated connection, which carries its own rate limits.
+6. **Instrumentation**: per-rank probe outcome counters ship per
+   [ADR-013](ADR-013-measured-connectivity-metrics.md) (`path_pair_probe_total{pair_rank}`), so
+   future width tuning is evidence-based.
+
+Rollout behind a config knob defaulting to the spray enabled after soak testing in the
+network-namespace symmetric-NAT harness used for [ADR-009] validation
+(`MASQUERADE --random-fully` namespaces); knob allows instant regression to N=1.
+
+## Consequences
+
+### Positive
+
+- Rescues rounds previously lost to a single dropped/mispredicted probe; expected largest gain in
+  port-restricted × port-restricted and port-restricted × predicted-port combinations.
+- Cheap relative to payoff: ranking, validation, and promotion paths already exist.
+- Per-rank telemetry turns punch tuning into a measurement exercise.
+
+### Negative
+
+- Marginally higher burst egress per round (bounded by pacing + amplification cap).
+- More states in validation bookkeeping (per-round outstanding-probe sets) - contained churn in
+  `nat_traversal.rs`.
+- Symmetric×symmetric remains improbable (~15-30% even with prediction per classic studies); spray
+  narrows the gap, relay fallback still owns that cell. Expectations handled by
+  [ADR-013](ADR-013-measured-connectivity-metrics.md).
+
+## Alternatives Considered
+
+1. **More rounds instead of wider rounds**
+   - Rejected: rounds already scale latency linearly (60 s default coordination timeout); width buys
+     coverage inside the same wall-clock budget, which matters for interactive connect() UX.
+2. **Birthday-style wide port-range scanning against symmetric NATs (dozens-hundreds of probes)**
+   - Rejected as default: egress/amplification cost and firewall-tripping behaviour outweigh
+     marginal wins against random-per-destination mappings; narrow linear-delta predictions capture
+     most predictable cases affordably.
+3. **Always N = all pairs**
+   - Rejected: unbounded work triggered by unauthenticated coordination frames violates the
+     bounded-trigger-cost rule (Decision 5).
+
+## Validation
+
+- Baseline behaviour this ADR builds on is pinned by `src/connection_strategy.rs::test_holepunch_rounds`
+  (3-round ceiling, unchanged by Decision 4) and the ranked-candidate/prediction tests in
+  `src/connection/port_prediction.rs` (`test_linear_prediction_increment`,
+  `wrapping_delta_predictions_are_supported`, ...) that supply the pairs the spray consumes.
+- Implementing PR must add unit tests in `src/connection/nat_traversal.rs` asserting: (a) a round
+  emits at most N PATH_CHALLENGEs, to distinct top-ranked pairs; (b) N=1 reproduces today's
+  single-probe emission; (c) inter-probe spacing is at least `max(20 ms, min_rtt/10)`; (d) the
+  first valid PATH_RESPONSE cancels the round's outstanding probes.
+- Anti-amplification (Decision 2): a test must show probes to an unvalidated address are withheld
+  once the 3x received-byte allowance is exhausted, exercising the existing
+  `validate_amplification_limits` / `is_amplification_suspicious` checks in
+  `src/connection/nat_traversal.rs` rather than a new accounting path.
+- Bounded trigger (Decision 5): a test must show a flood of PUNCH_ME_NOW frames from an
+  unauthenticated coordinator yields no more than N paced probes per round.
+- `path_pair_probe_total{pair_rank}` must ship with the feature per ADR-013, and the default-flip PR
+  must cite before/after values from the symmetric-NAT namespace harness referenced by ADR-009.
+- Revisit trigger: ADR-013 telemetry shows the punched-tier share unchanged after the default flip,
+  or egress/amplification counters rise materially - either reopens spray width or pacing in a new
+  ADR.
+
+## References
+
+- Current scheduling: `src/connection/nat_traversal.rs` (grace/jitter/retry math),
+  `src/connection/mod.rs:1342-1426` (challenge emission/validation)
+- Candidates & prediction: `src/port_prediction` usage via
+  `src/connection/nat_traversal.rs:1940-2004`
+- External evidence: [Tailscale NAT traversal](https://tailscale.com/blog/how-nat-traversal-works),
+  [arXiv:2510.27500](https://arxiv.org/abs/2510.27500),
+  [rust-libp2p #5910](https://github.com/libp2p/rust-libp2p/discussions/5910)
+- Related: [ADR-005](ADR-005-native-quic-nat-traversal.md),
+  [ADR-013](ADR-013-measured-connectivity-metrics.md)
+
+## Notes for AI-assisted work
+
+Drafted with AI assistance; reviewed and accepted by the project owner on 2026-08-26. Accepted ADRs are immutable: create a new superseding ADR rather than editing this one.

--- a/docs/adr/ADR-016-hybrid-relay-data-plane.md
+++ b/docs/adr/ADR-016-hybrid-relay-data-plane.md
@@ -1,0 +1,122 @@
+# ADR-016: Hybrid Datagram/Stream Relay Data Plane
+
+## Status
+
+Accepted (2026-08-26)
+
+## Supersedes (conditionally)
+
+[ADR-009](ADR-009-masque-relay-data-plane.md) § Decision 2 ("Stream-Based Forwarding") - superseded
+for regular-packet forwarding once this ADR's gate passes. ADR-009's stream lane, secondary-endpoint
+design, proactive-setup model, and address-propagation decision all remain in force.
+
+## Context
+
+ADR-009 chose a single reliable ordered QUIC stream with `[4-byte length][packet]` framing for the
+relay hop because QUIC-datagram payloads (~1120 B practical budget after tunnel overhead) cannot
+carry 1200 B QUIC Initial packets. That rationale is sound **only for oversized packets**; it
+concedes more than necessary for everything else:
+
+- Post-handshake short-header packets mostly fit the datagram budget, yet travel over the reliable
+  ordered stream today.
+- Consequences of stream-only carriage:
+  - **Head-of-line blocking**: one lost tunnel segment stalls every relayed flow until
+    retransmission, though the end-to-end QUIC connections are loss-tolerant by design.
+  - **Reliability stacking**: inner QUIC retransmits loss the stream already repaired - wasted
+    bandwidth and artificial latency inflation that behaves unlike the UDP path it emulates.
+  - **Congestion coupling**: single-stream dynamics degrade throughput under loss for bulk flows,
+    the classic TCP-over-TCP failure mode TURN-style proxies avoid by forwarding unreliably.
+
+A hybrid keeps ADR-009's true invariant (Initial packets must survive intact) while restoring
+UDP-like semantics for regular traffic.
+
+## Decision
+
+Two-lane relay forwarding, selected per packet:
+
+1. **Datagram lane (default)**: packets with on-wire size ≤ `P_max` carry as QUIC DATAGRAM frames on
+   the existing relay session. Unordered, unreliable - exactly UDP semantics across the hop.
+2. **Stream lane**: anything larger than `P_max` - always including full Initial packets - uses the
+   current length-prefixed stream framing unchanged. Reliability here is required precisely because
+   these packets have no retransmission story if lost.
+3. **Session-negotiated `P_max`**: computed from the negotiated session limits minus measured outer
+   overhead (outer headers + varint lengths), refined empirically at session establishment;
+   never guessed below the 1200 B + margin needed for Initial-carriage decisions.
+4. **Single congestion controller, honest accounting**: both lanes share the session's QUIC CC -
+   correct, since the hop genuinely is one bottleneck. Tuning items recorded as follow-ups: ACK
+   frequency tuning for the datagram-heavy profile and scheduler notes for mixed lanes.
+5. **Gate before default-flip**:
+   - Config `relay_forward_mode = stream | hybrid`, shipping default `stream`.
+   - Land hybrid implementation behind the flag; soak in the network-namespace harness used by
+     [ADR-009] (`MASQUERADE --random-fully`) plus targeted loss-injection tests comparing p95 RTT
+     inflation, retransmission ratios, and Initial-delivery reliability between modes.
+   - Flip default to `hybrid` only when benchmarks show parity on Initial delivery and improvement
+     on loss-path metrics, citing [ADR-013](ADR-013-measured-connectivity-metrics.md) counters.
+6. **Compatibility**: during transition both modes may coexist; mode is per-session so peers on
+   older code remain served via the stream lane without protocol rupture.
+
+## Consequences
+
+### Positive
+
+- Removes head-of-line blocking for the common case; relay-hop behaviour converges toward the TURN
+  semantics it replaces while staying purely peer-operated.
+- Restores accurate loss signal to inner QUIC connections (their CC sees real loss instead of
+  artificially-ordered delivery).
+- Keeps ADR-009's correctness guarantee where it actually matters.
+
+### Negative
+
+- Two lanes = two code paths to test; cancellation/cleanup edge cases grew when reliability work
+  touched the socket layer before, and now apply to lane switching too.
+- Lossy hops will drop relayed payloads loudly rather than hiding damage under ordering - a
+  semantic change applications should not notice but tests must.
+- Benchmark infrastructure burden sits ahead of any user-visible benefit until defaults flip.
+
+## Alternatives Considered
+
+1. **Keep stream-only until direct migration almost always succeeds anyway**
+   - Rejected: symmetric-NAT nodes persist (CGNAT growth per arXiv studies), so the relay path is a
+     permanent tier, not a transitional hack.
+2. **Mandate oversized packets be fragmented across multiple datagrams**
+   - Rejected: reinvents fragmentation under our own error modes while the stream lane already does
+     the job for the rare case; two mechanisms for the same packet class would be worse than one.
+3. **Wait for the listen-draft RFC and use its proxy semantics wholesale**
+   - Deferred, not rejected: [ADR-012](ADR-012-standards-basis-refresh.md) tracks publication; the
+     custom data plane then either aligns or gets encapsulated behind it.
+
+## Validation
+
+- Stream-lane behaviour that must stay intact is covered by `tests/masque_integration_tests.rs`
+  (`test_e2e_relay_scenario`, `test_e2e_migration_scenario`, `test_compressed_datagram_roundtrip`)
+  and `src/masque/relay_server.rs::test_handle_client_datagram_records_bytes_and_datagram_count`;
+  these must pass unchanged with `relay_forward_mode = stream`.
+- Implementing PR must add the `relay_forward_mode` config surface (`stream | hybrid`, shipped default
+  `stream`) with a test asserting that default, plus lane-selection unit tests in
+  `src/masque/relay_socket.rs`: packets at or below `P_max` take the datagram lane, packets above
+  `P_max` and every Initial take the length-prefixed stream lane, and `P_max` is never computed
+  below 1200 B plus margin.
+- Loss-injection tests comparing `stream` and `hybrid` on p95 RTT inflation, retransmission ratio,
+  and Initial-delivery reliability must exist before the default flips;
+  `tests/compat_datagram_drop_tests.rs` shows the existing pattern for forcing datagram loss.
+- Compatibility (Decision 6): a test must show a `hybrid`-capable peer serving a `stream`-only peer
+  over the stream lane without session failure.
+- Default-flip PR must cite ADR-013 counters (`relay_session_bytes_total`,
+  `time_to_establish_seconds{method=relay}`) before/after from the namespace harness used for
+  ADR-009.
+- Revisit trigger: `draft-ietf-masque-connect-udp-listen` is published as an RFC (tracked by
+  ADR-012) - evaluate whether its proxy semantics subsume the custom hybrid data plane.
+
+## References
+
+- Superseded design rationale: [ADR-009](ADR-009-masque-relay-data-plane.md) § Alternatives 1 & 2
+- Implementation sites: `src/masque/relay_socket.rs` (framing), `src/masque/relay_server.rs`
+  (forwarding pump), `src/masque/migration.rs` (escape-to-direct)
+- Semantics reference: RFC 9297 (HTTP Datagrams), RFC 9298 (CONNECT-UDP), RFC 9000 §8 (amplification)
+- Related: [ADR-006](ADR-006-masque-relay-fallback.md),
+  [ADR-013](ADR-013-measured-connectivity-metrics.md),
+  [ADR-015](ADR-015-paced-candidate-spray-punching.md)
+
+## Notes for AI-assisted work
+
+Drafted with AI assistance; reviewed and accepted by the project owner on 2026-08-26. Accepted ADRs are immutable: create a new superseding ADR rather than editing this one.

--- a/docs/architecture/UNIFIED_CONNECTIVITY_PLAN.md
+++ b/docs/architecture/UNIFIED_CONNECTIVITY_PLAN.md
@@ -252,7 +252,7 @@ Initial provider set:
 1. static known peers
 2. optional mDNS
 3. existing bootstrap/discovery flows
-4. future registry/gossip/DHT integrations
+4. future registry/gossip integrations by consuming overlays
 
 All providers feed the same internal peer directory.
 

--- a/docs/research/CONSTRAINED_TRANSPORTS.md
+++ b/docs/research/CONSTRAINED_TRANSPORTS.md
@@ -967,10 +967,10 @@ impl ProgressiveHandshake {
 
 ## 7. Network Layer and Routing
 
-### 7.1 Routing Table Design
+### 7.1 Route Table Design
 
 ```rust
-pub struct RoutingTable {
+pub struct RouteTable {
     /// Known routes to peers
     routes: HashMap<PeerId, Route>,
     
@@ -1007,7 +1007,7 @@ pub struct RouteMetrics {
 ### 7.2 Route Selection
 
 ```rust
-impl RoutingTable {
+impl RouteTable {
     pub fn select_route(&self, dest: &PeerId, requirements: &RouteRequirements) -> Option<SelectedRoute> {
         let route = self.routes.get(dest)?;
         
@@ -1115,8 +1115,8 @@ pub struct GatewayNode {
     /// Protocol engines per transport class
     engines: HashMap<TransportType, Arc<dyn ProtocolEngine>>,
     
-    /// Unified routing table
-    routing: Arc<RwLock<RoutingTable>>,
+    /// Unified route table
+    routing: Arc<RwLock<RouteTable>>,
     
     /// Message relay queue
     relay_queue: mpsc::Sender<RelayRequest>,
@@ -1576,7 +1576,7 @@ impl Message {
 ### Phase 5: Network Layer (5-6 weeks)
 
 **Goals**:
-- Routing table design
+- Route table design
 - Route announcements
 - Gateway logic
 - Multi-transport peer discovery

--- a/docs/rfcs/ant-quic-pqc-authentication.md
+++ b/docs/rfcs/ant-quic-pqc-authentication.md
@@ -93,8 +93,8 @@ The PeerId is derived by hashing the ML-DSA-65 public key:
 ML-DSA-65 Public Key: 1952 bytes → SHA-256 → PeerId (32 bytes)
 ```
 
-**Rationale:** This provides a compact 32-byte identifier suitable for DHT
-routing and peer addressing while maintaining a single quantum-resistant key
+**Rationale:** This provides a compact 32-byte identifier suitable for any
+consumer-side addressing layer while maintaining a single quantum-resistant key
 pair for both identity and authentication. The SHA-256 hash provides:
 - Uniform 32-byte identifiers regardless of public key size
 - Collision resistance (2^128 security level)

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4898,7 +4898,7 @@ impl Connection {
                     normalized_addr, add_address.sequence, add_address.priority
                 );
 
-                // Notify the endpoint so the DHT routing table can be updated
+                // Notify the endpoint so consumer address books can be updated
                 self.endpoint_events.push_back(
                     crate::shared::EndpointEventInner::PeerAddressAdvertised {
                         peer_addr: self.path.remote,

--- a/src/high_level/endpoint.rs
+++ b/src/high_level/endpoint.rs
@@ -1079,7 +1079,7 @@ impl State {
         }
 
         // Forward peer address updates from ADD_ADDRESS frames to the
-        // NatTraversalEndpoint so it can update the DHT routing table.
+        // NatTraversalEndpoint so consuming overlays can update their own address books.
         let address_updates: Vec<(SocketAddr, SocketAddr)> =
             self.inner.drain_peer_address_updates().collect();
         for (peer_addr, advertised_addr) in address_updates {

--- a/src/link_transport.rs
+++ b/src/link_transport.rs
@@ -19,8 +19,8 @@
 //!
 //! ```text
 //! ┌─────────────────────────────────────────────────────────────────┐
-//! │                      saorsa-core (overlay)                       │
-//! │  DHT routing │ Record storage │ Greedy routing │ Naming         │
+//! │                      saorsa-core (overlay)                      │
+//! │ Overlay routing │ Record storage │ Greedy routing │ Naming      │
 //! └─────────────────────────────────────────────────────────────────┘
 //!                              │
 //!                              ▼
@@ -44,11 +44,11 @@
 //! use futures_util::StreamExt;
 //!
 //! // Define your overlay's protocol identifier
-//! const DHT_PROTOCOL: ProtocolId = ProtocolId::from_static(b"saorsa-dht/1.0.0");
+//! const OVERLAY_SERVICE_PROTOCOL: ProtocolId = ProtocolId::from_static(b"saorsa-overlay/1.0.0");
 //!
 //! async fn run_overlay<T: LinkTransport>(transport: Arc<T>) -> anyhow::Result<()> {
 //!     // Register our protocol so peers know we support it
-//!     transport.register_protocol(DHT_PROTOCOL);
+//!     transport.register_protocol(OVERLAY_SERVICE_PROTOCOL);
 //!
 //!     // Subscribe to transport events for connection lifecycle
 //!     let mut events = transport.subscribe();
@@ -69,7 +69,7 @@
 //!     // Accept incoming connections in a background task
 //!     let transport_clone = transport.clone();
 //!     tokio::spawn(async move {
-//!         let mut incoming = transport_clone.accept(DHT_PROTOCOL);
+//!         let mut incoming = transport_clone.accept(OVERLAY_SERVICE_PROTOCOL);
 //!         while let Some(result) = incoming.next().await {
 //!             match result {
 //!                 Ok(conn) => {
@@ -84,7 +84,7 @@
 //!     // Dial a peer using their PeerId (NAT traversal handled automatically)
 //!     let peers = transport.peer_table();
 //!     if let Some((peer_id, caps)) = peers.first() {
-//!         match transport.dial(*peer_id, DHT_PROTOCOL).await {
+//!         match transport.dial(*peer_id, OVERLAY_SERVICE_PROTOCOL).await {
 //!             Ok(conn) => {
 //!                 // Open a bidirectional stream for request/response
 //!                 let (mut send, mut recv) = conn.open_bi().await?;
@@ -181,7 +181,7 @@ use crate::transport::TransportAddr;
 /// | Range | Protocol Family | Types |
 /// |-------|-----------------|-------|
 /// | 0x00-0x0F | Gossip | Membership, PubSub, Bulk |
-/// | 0x10-0x1F | DHT | Query, Store, Witness, Replication |
+/// | 0x10-0x1F | Overlay services | Query, Store, Witness, Replication |
 /// | 0x20-0x2F | WebRTC | Signal, Media, Data |
 /// | 0xF0-0xFF | Reserved | Future use |
 ///
@@ -192,7 +192,7 @@ use crate::transport::TransportAddr;
 ///
 /// // Check if a byte is a valid stream type
 /// let stream_type = StreamType::from_byte(0x10);
-/// assert_eq!(stream_type, Some(StreamType::DhtQuery));
+/// assert_eq!(stream_type, Some(StreamType::ServiceQuery));
 ///
 /// // Get all gossip types
 /// for st in StreamType::gossip_types() {
@@ -215,19 +215,19 @@ pub enum StreamType {
     GossipBulk = 0x02,
 
     // =========================================================================
-    // DHT Protocols (0x10-0x1F)
+    // Overlay service protocols (0x10-0x1F)
     // =========================================================================
-    /// DHT query operations (GET, FIND_NODE, FIND_VALUE).
-    DhtQuery = 0x10,
+    /// Query operations for overlay services (GET, FIND_NODE, FIND_VALUE).
+    ServiceQuery = 0x10,
 
-    /// DHT store operations (PUT, STORE).
-    DhtStore = 0x11,
+    /// Store operations for overlay services (PUT, STORE).
+    ServiceStore = 0x11,
 
-    /// DHT witness operations (Byzantine fault tolerance).
-    DhtWitness = 0x12,
+    /// Witness operations for overlay services (Byzantine fault tolerance).
+    ServiceWitness = 0x12,
 
-    /// DHT replication operations (background repair).
-    DhtReplication = 0x13,
+    /// Replication operations for overlay services (background repair).
+    ServiceReplication = 0x13,
 
     // =========================================================================
     // WebRTC Protocols (0x20-0x2F)
@@ -258,10 +258,10 @@ impl StreamType {
             0x00 => Some(Self::Membership),
             0x01 => Some(Self::PubSub),
             0x02 => Some(Self::GossipBulk),
-            0x10 => Some(Self::DhtQuery),
-            0x11 => Some(Self::DhtStore),
-            0x12 => Some(Self::DhtWitness),
-            0x13 => Some(Self::DhtReplication),
+            0x10 => Some(Self::ServiceQuery),
+            0x11 => Some(Self::ServiceStore),
+            0x12 => Some(Self::ServiceWitness),
+            0x13 => Some(Self::ServiceReplication),
             0x20 => Some(Self::WebRtcSignal),
             0x21 => Some(Self::WebRtcMedia),
             0x22 => Some(Self::WebRtcData),
@@ -281,7 +281,7 @@ impl StreamType {
     pub const fn family(self) -> StreamTypeFamily {
         match self as u8 {
             0x00..=0x0F => StreamTypeFamily::Gossip,
-            0x10..=0x1F => StreamTypeFamily::Dht,
+            0x10..=0x1F => StreamTypeFamily::OverlayService,
             0x20..=0x2F => StreamTypeFamily::WebRtc,
             _ => StreamTypeFamily::Reserved,
         }
@@ -293,10 +293,10 @@ impl StreamType {
         matches!(self.family(), StreamTypeFamily::Gossip)
     }
 
-    /// Check if this is a DHT protocol type.
+    /// Check if this is an overlay service type.
     #[inline]
-    pub const fn is_dht(self) -> bool {
-        matches!(self.family(), StreamTypeFamily::Dht)
+    pub const fn is_overlay_service(self) -> bool {
+        matches!(self.family(), StreamTypeFamily::OverlayService)
     }
 
     /// Check if this is a WebRTC protocol type.
@@ -310,13 +310,13 @@ impl StreamType {
         &[Self::Membership, Self::PubSub, Self::GossipBulk]
     }
 
-    /// Get all DHT stream types.
-    pub const fn dht_types() -> &'static [StreamType] {
+    /// Get all overlay service stream types.
+    pub const fn service_types() -> &'static [StreamType] {
         &[
-            Self::DhtQuery,
-            Self::DhtStore,
-            Self::DhtWitness,
-            Self::DhtReplication,
+            Self::ServiceQuery,
+            Self::ServiceStore,
+            Self::ServiceWitness,
+            Self::ServiceReplication,
         ]
     }
 
@@ -331,10 +331,10 @@ impl StreamType {
             Self::Membership,
             Self::PubSub,
             Self::GossipBulk,
-            Self::DhtQuery,
-            Self::DhtStore,
-            Self::DhtWitness,
-            Self::DhtReplication,
+            Self::ServiceQuery,
+            Self::ServiceStore,
+            Self::ServiceWitness,
+            Self::ServiceReplication,
             Self::WebRtcSignal,
             Self::WebRtcMedia,
             Self::WebRtcData,
@@ -349,10 +349,10 @@ impl fmt::Display for StreamType {
             Self::Membership => write!(f, "Membership"),
             Self::PubSub => write!(f, "PubSub"),
             Self::GossipBulk => write!(f, "GossipBulk"),
-            Self::DhtQuery => write!(f, "DhtQuery"),
-            Self::DhtStore => write!(f, "DhtStore"),
-            Self::DhtWitness => write!(f, "DhtWitness"),
-            Self::DhtReplication => write!(f, "DhtReplication"),
+            Self::ServiceQuery => write!(f, "ServiceQuery"),
+            Self::ServiceStore => write!(f, "ServiceStore"),
+            Self::ServiceWitness => write!(f, "ServiceWitness"),
+            Self::ServiceReplication => write!(f, "ServiceReplication"),
             Self::WebRtcSignal => write!(f, "WebRtcSignal"),
             Self::WebRtcMedia => write!(f, "WebRtcMedia"),
             Self::WebRtcData => write!(f, "WebRtcData"),
@@ -380,8 +380,8 @@ impl TryFrom<u8> for StreamType {
 pub enum StreamTypeFamily {
     /// Gossip protocols (0x00-0x0F).
     Gossip,
-    /// DHT protocols (0x10-0x1F).
-    Dht,
+    /// Overlay service protocols (0x10-0x1F).
+    OverlayService,
     /// WebRTC protocols (0x20-0x2F).
     WebRtc,
     /// Reserved (0xF0-0xFF).
@@ -393,7 +393,7 @@ impl StreamTypeFamily {
     pub const fn byte_range(self) -> (u8, u8) {
         match self {
             Self::Gossip => (0x00, 0x0F),
-            Self::Dht => (0x10, 0x1F),
+            Self::OverlayService => (0x10, 0x1F),
             Self::WebRtc => (0x20, 0x2F),
             Self::Reserved => (0xF0, 0xFF),
         }
@@ -416,14 +416,14 @@ impl StreamTypeFamily {
 /// ```rust
 /// use ant_quic::link_transport::{StreamFilter, StreamType};
 ///
-/// // Accept only DHT streams
+/// // Accept only overlay service streams
 /// let filter = StreamFilter::new()
-///     .with_types(StreamType::dht_types());
+///     .with_types(StreamType::service_types());
 ///
-/// // Accept gossip and DHT
+/// // Accept gossip and overlay services
 /// let filter = StreamFilter::new()
 ///     .with_type(StreamType::Membership)
-///     .with_type(StreamType::DhtQuery);
+///     .with_type(StreamType::ServiceQuery);
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct StreamFilter {
@@ -451,9 +451,9 @@ impl StreamFilter {
         Self::new().with_types(StreamType::gossip_types())
     }
 
-    /// Create a filter for DHT streams only.
-    pub fn dht_only() -> Self {
-        Self::new().with_types(StreamType::dht_types())
+    /// Create a filter for overlay service streams only.
+    pub fn overlay_service_only() -> Self {
+        Self::new().with_types(StreamType::service_types())
     }
 
     /// Create a filter for WebRTC streams only.
@@ -506,7 +506,7 @@ impl StreamFilter {
 /// use ant_quic::link_transport::ProtocolId;
 ///
 /// // From a static string (padded/truncated to 16 bytes)
-/// const DHT: ProtocolId = ProtocolId::from_static(b"saorsa-dht/1.0.0");
+/// const OVERLAY_PROTOCOL: ProtocolId = ProtocolId::from_static(b"saorsa-overlay/1.0.0");
 ///
 /// // From bytes
 /// let proto = ProtocolId::new([0x73, 0x61, 0x6f, 0x72, 0x73, 0x61, 0x2d, 0x64,
@@ -1118,7 +1118,7 @@ pub trait LinkConn: Send + Sync {
     ///
     /// # Example
     /// ```rust,ignore
-    /// let (mut send, mut recv) = conn.open_bi_typed(StreamType::DhtQuery).await?;
+    /// let (mut send, mut recv) = conn.open_bi_typed(StreamType::ServiceQuery).await?;
     /// send.write_all(b"query request").await?;
     /// send.finish()?;
     /// let response = recv.read_to_end(4096).await?;
@@ -1154,11 +1154,11 @@ pub trait LinkConn: Send + Sync {
     ///
     /// # Example
     /// ```rust,ignore
-    /// let filter = StreamFilter::dht_only();
+    /// let filter = StreamFilter::overlay_service_only();
     /// let mut incoming = conn.accept_bi_typed(filter);
     /// while let Some(result) = incoming.next().await {
     ///     let (stream_type, send, recv) = result?;
-    ///     // Handle DHT request/response
+    ///     // Handle overlay-service request/response
     /// }
     /// ```
     fn accept_bi_typed(
@@ -1449,8 +1449,8 @@ mod tests {
 
     #[test]
     fn test_protocol_id_from_string() {
-        let proto = ProtocolId::from("saorsa-dht/1.0");
-        assert_eq!(&proto.0[..14], b"saorsa-dht/1.0");
+        let proto = ProtocolId::from("saorsa-overlay");
+        assert_eq!(&proto.0[..14], b"saorsa-overlay");
         assert_eq!(proto.0[14], 0);
         assert_eq!(proto.0[15], 0);
     }
@@ -1513,12 +1513,12 @@ mod tests {
     #[test]
     fn test_capabilities_supports_protocol() {
         let mut caps = Capabilities::default();
-        let dht = ProtocolId::from("dht/1.0");
+        let overlay_proto = ProtocolId::from("overlay/1.0");
         let gossip = ProtocolId::from("gossip/1.0");
 
-        caps.protocols.push(dht);
+        caps.protocols.push(overlay_proto);
 
-        assert!(caps.supports_protocol(&dht));
+        assert!(caps.supports_protocol(&overlay_proto));
         assert!(!caps.supports_protocol(&gossip));
     }
 
@@ -1531,10 +1531,10 @@ mod tests {
         assert_eq!(StreamType::Membership.as_byte(), 0x00);
         assert_eq!(StreamType::PubSub.as_byte(), 0x01);
         assert_eq!(StreamType::GossipBulk.as_byte(), 0x02);
-        assert_eq!(StreamType::DhtQuery.as_byte(), 0x10);
-        assert_eq!(StreamType::DhtStore.as_byte(), 0x11);
-        assert_eq!(StreamType::DhtWitness.as_byte(), 0x12);
-        assert_eq!(StreamType::DhtReplication.as_byte(), 0x13);
+        assert_eq!(StreamType::ServiceQuery.as_byte(), 0x10);
+        assert_eq!(StreamType::ServiceStore.as_byte(), 0x11);
+        assert_eq!(StreamType::ServiceWitness.as_byte(), 0x12);
+        assert_eq!(StreamType::ServiceReplication.as_byte(), 0x13);
         assert_eq!(StreamType::WebRtcSignal.as_byte(), 0x20);
         assert_eq!(StreamType::WebRtcMedia.as_byte(), 0x21);
         assert_eq!(StreamType::WebRtcData.as_byte(), 0x22);
@@ -1544,7 +1544,7 @@ mod tests {
     #[test]
     fn test_stream_type_from_byte() {
         assert_eq!(StreamType::from_byte(0x00), Some(StreamType::Membership));
-        assert_eq!(StreamType::from_byte(0x10), Some(StreamType::DhtQuery));
+        assert_eq!(StreamType::from_byte(0x10), Some(StreamType::ServiceQuery));
         assert_eq!(StreamType::from_byte(0x20), Some(StreamType::WebRtcSignal));
         assert_eq!(StreamType::from_byte(0xF0), Some(StreamType::Reserved));
         assert_eq!(StreamType::from_byte(0x99), None); // Unassigned
@@ -1557,10 +1557,10 @@ mod tests {
         assert!(StreamType::PubSub.is_gossip());
         assert!(StreamType::GossipBulk.is_gossip());
 
-        assert!(StreamType::DhtQuery.is_dht());
-        assert!(StreamType::DhtStore.is_dht());
-        assert!(StreamType::DhtWitness.is_dht());
-        assert!(StreamType::DhtReplication.is_dht());
+        assert!(StreamType::ServiceQuery.is_overlay_service());
+        assert!(StreamType::ServiceStore.is_overlay_service());
+        assert!(StreamType::ServiceWitness.is_overlay_service());
+        assert!(StreamType::ServiceReplication.is_overlay_service());
 
         assert!(StreamType::WebRtcSignal.is_webrtc());
         assert!(StreamType::WebRtcMedia.is_webrtc());
@@ -1573,9 +1573,9 @@ mod tests {
         assert!(StreamTypeFamily::Gossip.contains(0x0F));
         assert!(!StreamTypeFamily::Gossip.contains(0x10));
 
-        assert!(StreamTypeFamily::Dht.contains(0x10));
-        assert!(StreamTypeFamily::Dht.contains(0x1F));
-        assert!(!StreamTypeFamily::Dht.contains(0x20));
+        assert!(StreamTypeFamily::OverlayService.contains(0x10));
+        assert!(StreamTypeFamily::OverlayService.contains(0x1F));
+        assert!(!StreamTypeFamily::OverlayService.contains(0x20));
 
         assert!(StreamTypeFamily::WebRtc.contains(0x20));
         assert!(StreamTypeFamily::WebRtc.contains(0x2F));
@@ -1586,10 +1586,10 @@ mod tests {
     fn test_stream_filter_accepts() {
         let filter = StreamFilter::new()
             .with_type(StreamType::Membership)
-            .with_type(StreamType::DhtQuery);
+            .with_type(StreamType::ServiceQuery);
 
         assert!(filter.accepts(StreamType::Membership));
-        assert!(filter.accepts(StreamType::DhtQuery));
+        assert!(filter.accepts(StreamType::ServiceQuery));
         assert!(!filter.accepts(StreamType::PubSub));
         assert!(!filter.accepts(StreamType::WebRtcMedia));
     }
@@ -1599,7 +1599,7 @@ mod tests {
         let filter = StreamFilter::new();
         assert!(filter.accepts_all());
         assert!(filter.accepts(StreamType::Membership));
-        assert!(filter.accepts(StreamType::DhtQuery));
+        assert!(filter.accepts(StreamType::ServiceQuery));
         assert!(filter.accepts(StreamType::WebRtcMedia));
     }
 
@@ -1609,23 +1609,23 @@ mod tests {
         assert!(gossip.accepts(StreamType::Membership));
         assert!(gossip.accepts(StreamType::PubSub));
         assert!(gossip.accepts(StreamType::GossipBulk));
-        assert!(!gossip.accepts(StreamType::DhtQuery));
+        assert!(!gossip.accepts(StreamType::ServiceQuery));
 
-        let dht = StreamFilter::dht_only();
-        assert!(dht.accepts(StreamType::DhtQuery));
-        assert!(dht.accepts(StreamType::DhtStore));
-        assert!(!dht.accepts(StreamType::Membership));
+        let service_filter = StreamFilter::overlay_service_only();
+        assert!(service_filter.accepts(StreamType::ServiceQuery));
+        assert!(service_filter.accepts(StreamType::ServiceStore));
+        assert!(!service_filter.accepts(StreamType::Membership));
 
         let webrtc = StreamFilter::webrtc_only();
         assert!(webrtc.accepts(StreamType::WebRtcSignal));
         assert!(webrtc.accepts(StreamType::WebRtcMedia));
-        assert!(!webrtc.accepts(StreamType::DhtQuery));
+        assert!(!webrtc.accepts(StreamType::ServiceQuery));
     }
 
     #[test]
     fn test_stream_type_display() {
         assert_eq!(format!("{}", StreamType::Membership), "Membership");
-        assert_eq!(format!("{}", StreamType::DhtQuery), "DhtQuery");
+        assert_eq!(format!("{}", StreamType::ServiceQuery), "ServiceQuery");
         assert_eq!(format!("{}", StreamType::WebRtcMedia), "WebRtcMedia");
     }
 
@@ -1691,11 +1691,11 @@ mod tests {
 
         #[tokio::test]
         async fn test_handler_returns_response() {
-            let handler = TestHandler::new(vec![StreamType::DhtQuery]);
+            let handler = TestHandler::new(vec![StreamType::ServiceQuery]);
             let peer = PeerId::from([0u8; 32]);
 
             let result = handler
-                .handle_stream(peer, StreamType::DhtQuery, Bytes::from_static(b"test"))
+                .handle_stream(peer, StreamType::ServiceQuery, Bytes::from_static(b"test"))
                 .await;
 
             assert!(result.is_ok());
@@ -1755,8 +1755,8 @@ mod tests {
 
         #[test]
         fn test_boxed_handler() {
-            let handler: BoxedHandler = TestHandler::new(vec![StreamType::DhtStore]).boxed();
-            assert_eq!(handler.stream_types(), &[StreamType::DhtStore]);
+            let handler: BoxedHandler = TestHandler::new(vec![StreamType::ServiceStore]).boxed();
+            assert_eq!(handler.stream_types(), &[StreamType::ServiceStore]);
             assert_eq!(handler.name(), "TestHandler");
         }
 
@@ -1803,9 +1803,9 @@ mod tests {
 
         #[test]
         fn test_no_handler_error() {
-            let err = LinkError::NoHandler(StreamType::DhtQuery);
+            let err = LinkError::NoHandler(StreamType::ServiceQuery);
             let msg = err.to_string();
-            assert!(msg.contains("DhtQuery"), "Error message: {}", msg);
+            assert!(msg.contains("ServiceQuery"), "Error message: {}", msg);
         }
 
         #[test]

--- a/src/link_transport_impl.rs
+++ b/src/link_transport_impl.rs
@@ -1026,7 +1026,7 @@ use crate::link_transport::BoxedHandler;
 /// let transport = SharedTransport::new(quic_transport);
 ///
 /// transport.register_handler(my_gossip_handler.boxed()).await?;
-/// transport.register_handler(my_dht_handler.boxed()).await?;
+/// transport.register_handler(my_service_handler.boxed()).await?;
 ///
 /// transport.run().await?;
 /// ```
@@ -1603,7 +1603,7 @@ mod tests {
         assert_eq!(alpn_to_protocol_id(None), ProtocolId::DEFAULT);
 
         // Raw 16-byte form round-trips exactly.
-        let proto = ProtocolId::from("saorsa-dht/1.0.0");
+        let proto = ProtocolId::from("saorsa-overlay/1.0.0");
         assert_eq!(alpn_to_protocol_id(Some(proto.as_bytes())), proto);
 
         // UTF-8 string form maps like ProtocolId::from.
@@ -1813,7 +1813,7 @@ mod tests {
 
             assert!(transport.has_handler(StreamType::Membership).await);
             assert!(transport.has_handler(StreamType::PubSub).await);
-            assert!(!transport.has_handler(StreamType::DhtQuery).await);
+            assert!(!transport.has_handler(StreamType::ServiceQuery).await);
         }
 
         #[tokio::test]
@@ -1862,7 +1862,7 @@ mod tests {
             });
 
             let handler1 = MockHandler::new(vec![StreamType::Membership, StreamType::PubSub]);
-            let handler2 = MockHandler::new(vec![StreamType::DhtQuery]);
+            let handler2 = MockHandler::new(vec![StreamType::ServiceQuery]);
 
             transport.register_handler(handler1.boxed()).await.unwrap();
             transport.register_handler(handler2.boxed()).await.unwrap();
@@ -1870,7 +1870,7 @@ mod tests {
             let filter = transport.build_stream_filter().await;
             assert!(filter.accepts(StreamType::Membership));
             assert!(filter.accepts(StreamType::PubSub));
-            assert!(filter.accepts(StreamType::DhtQuery));
+            assert!(filter.accepts(StreamType::ServiceQuery));
             assert!(!filter.accepts(StreamType::WebRtcSignal));
         }
 
@@ -1880,13 +1880,13 @@ mod tests {
                 local: PeerId::from([1u8; 32]),
             });
 
-            let handler = MockHandler::new(vec![StreamType::Membership, StreamType::DhtQuery]);
+            let handler = MockHandler::new(vec![StreamType::Membership, StreamType::ServiceQuery]);
             transport.register_handler(handler.boxed()).await.unwrap();
 
             let types = transport.registered_types().await;
             assert_eq!(types.len(), 2);
             assert!(types.contains(&StreamType::Membership));
-            assert!(types.contains(&StreamType::DhtQuery));
+            assert!(types.contains(&StreamType::ServiceQuery));
         }
 
         #[tokio::test]
@@ -1894,11 +1894,11 @@ mod tests {
             let transport = SharedTransport::new(MockTransport {
                 local: PeerId::from([1u8; 32]),
             });
-            let handler = MockHandler::new(vec![StreamType::DhtStore]);
+            let handler = MockHandler::new(vec![StreamType::ServiceStore]);
 
             transport.register_handler(handler.boxed()).await.unwrap();
 
-            let h = transport.get_handler(StreamType::DhtStore).await;
+            let h = transport.get_handler(StreamType::ServiceStore).await;
             assert!(h.is_some());
             assert_eq!(h.unwrap().name(), "MockHandler");
 

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -595,7 +595,7 @@ pub struct NatTraversalEndpoint {
     /// Transport registry for multi-transport support
     /// When present, allows using transport-provided sockets instead of creating new ones
     transport_registry: Option<Arc<TransportRegistry>>,
-    /// Channel for receiving peer address updates (ADD_ADDRESS → DHT bridge)
+    /// Channel for receiving peer address updates (ADD_ADDRESS → consumer notification)
     #[allow(dead_code)] // Used when full symmetric NAT relay is wired
     pub(crate) peer_address_update_rx:
         TokioMutex<mpsc::UnboundedReceiver<(SocketAddr, SocketAddr)>>,
@@ -1539,7 +1539,7 @@ pub enum NatTraversalEvent {
     },
     /// A connected peer advertised a new reachable address (ADD_ADDRESS frame).
     ///
-    /// The upper layer should update its routing table so that future lookups
+    /// The upper layer should update its address book so that future lookups
     /// for this peer return the advertised address.
     PeerAddressUpdated {
         /// The connected peer that sent the advertisement
@@ -1889,7 +1889,7 @@ impl NatTraversalEndpoint {
         // Create channel for forwarding constrained engine events to P2pEndpoint
         let (constrained_event_tx, constrained_event_rx) = mpsc::unbounded_channel();
 
-        // Channel for peer address updates (ADD_ADDRESS → DHT bridge)
+        // Channel for peer address updates (ADD_ADDRESS → consumer notification)
         let (peer_addr_tx, peer_addr_rx) = mpsc::unbounded_channel();
         inner_endpoint.set_peer_address_update_tx(peer_addr_tx);
 
@@ -2401,7 +2401,7 @@ impl NatTraversalEndpoint {
         // Create channel for forwarding constrained engine events to P2pEndpoint
         let (constrained_event_tx, constrained_event_rx) = mpsc::unbounded_channel();
 
-        // Channel for peer address updates (ADD_ADDRESS → DHT bridge)
+        // Channel for peer address updates (ADD_ADDRESS → consumer notification)
         let (peer_addr_tx, peer_addr_rx) = mpsc::unbounded_channel();
         inner_endpoint.set_peer_address_update_tx(peer_addr_tx);
 
@@ -2721,7 +2721,7 @@ impl NatTraversalEndpoint {
 
     /// Check if a peer with the given ID has an active connection,
     /// returning its actual socket address if found. This is essential
-    /// for symmetric NAT where the peer's address in the DHT differs
+    /// for symmetric NAT where the address known to consumers differs
     /// from the connection's actual address.
     #[allow(dead_code)] // Used by try_hole_punch peer ID fallback path
     pub(crate) fn find_connection_by_peer_id(&self, peer_id: &[u8; 32]) -> Option<SocketAddr> {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -1982,7 +1982,7 @@ pub enum P2pEvent {
     /// This node established a MASQUE relay and is advertising a relay address.
     ///
     /// Emitted once when the relay becomes active. Upper layers should use this
-    /// to trigger a DHT self-lookup so that more peers learn the relay address.
+    /// to advertise the relay address through whatever discovery mechanism the overlay runs.
     RelayEstablished {
         /// The relay's public address (relay_IP:PORT)
         relay_addr: SocketAddr,

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -83,7 +83,7 @@ pub(crate) enum EndpointEventInner {
     #[allow(dead_code)]
     NatCandidateValidated { address: SocketAddr, challenge: u64 },
     /// A peer advertised a new reachable address via ADD_ADDRESS.
-    /// The endpoint should propagate this so the DHT routing table is updated.
+    /// The endpoint should propagate this so consuming overlays can update their own address books.
     PeerAddressAdvertised {
         /// The peer's current connection address
         peer_addr: SocketAddr,


### PR DESCRIPTION
## Summary
- **ADR-011 accepted**: transport-scope terminology boundary. `StreamTypeFamily::Dht` → `OverlayService`, `Dht{Query,Store,Witness,Replication}` → `Service{…}`, `is_dht()`/`dht_only()`/`dht_types()` → `is_overlay_service()`/`overlay_service_only()`/`service_types()`. **Wire bytes 0x10–0x1F unchanged** (pinned by `test_stream_type_from_byte`), so 0.27.x peers interoperate.
- **ADR-012..016 accepted** (owner sign-off 2026-08-26) with governance-required `## Validation` sections: standards-basis refresh, measured connectivity metrics, relay resource governance, paced candidate-spray punching, hybrid relay data plane.
- Consumer-neutral wording sweep across seven source modules and the architecture/RFC/research docs.
- ADR-009 left byte-for-byte untouched (immutable); supersession recorded in ADR-011.

**BREAKING (public API)** — next release is **0.28.0**; migration table in ADR-011.

## Review
Independent review via `omp` (GLM-5.3) → "merge after fixes"; all 8 findings addressed in this branch (broken `test_protocol_id_from_string`, quotemeta-corrupted rustdoc row, residual prohibited terms, ASCII-art alignment, migration/serde notes).

## Verification
- `cargo fmt --check` · `clippy --workspace --all-features --all-targets -D warnings` (+ panic/unwrap/expect denies) · `cargo check --workspace --all-targets` · doctests 25/25
- `cargo nextest run --workspace --all-features --no-fail-fast`: 3391/3392 — the one red is `test_tiebreaker_deterministic`, a pre-existing ~50% flake (3/8 on clean `origin/master`, 4/8 here; file untouched)
- `scripts/adr-governance.py --base origin/master`: passed (16 discovered, 6 validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adopts six ADRs covering transport-neutral terminology and future connectivity work, and renames the public overlay-service stream types without changing their wire bytes.
- Renames the 0x10–0x1F stream family, variants, predicates, filters, tests, and examples to overlay-neutral identifiers.
- Updates NAT traversal and endpoint documentation to describe consumer-owned address propagation.
- Adds ADRs for standards ownership, measured connectivity, relay governance, paced punching, and hybrid relay forwarding.
- Sweeps architecture, research, and authentication documentation for consumer-neutral terminology.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after correcting the non-blocking raw-byte ProtocolId documentation example.

The executable rename preserves stream discriminants and updates in-repository mappings and callers consistently; the only accepted issue is a misleading public rustdoc byte array.

**Files Needing Attention:** src/link_transport.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/link_transport.rs | Renames the public stream-type API while preserving discriminants and coordinated mappings; one raw-byte rustdoc example still encodes the old protocol name. |
| src/link_transport_impl.rs | Updates typed-stream implementation tests and examples consistently with the renamed service variants. |
| src/nat_traversal_api.rs | Changes comments and public event documentation to clarify that address persistence belongs to consuming overlays. |
| docs/adr/ADR-011-transport-scope-terminology.md | Defines the overlay-neutral naming boundary, public migration table, and unchanged wire-byte contract. |
| docs/adr/ADR-012-standards-basis-refresh.md | Establishes a repository-owned future NAT traversal specification while explicitly deferring its creation and guide repointing. |
| docs/adr/ADR-014-relay-resource-governance.md | Records future requirements for global, per-identity, and concurrency relay budgets without changing runtime behavior. |
| docs/adr/ADR-015-paced-candidate-spray-punching.md | Specifies a future paced multi-candidate punching design with bounded work and anti-amplification requirements. |
| docs/adr/ADR-016-hybrid-relay-data-plane.md | Specifies a future negotiated stream/datagram relay design gated behind configuration and validation. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Overlay consumer] -->|ServiceQuery / ServiceStore| B[LinkTransport typed streams]
    B -->|Wire bytes 0x10–0x13 unchanged| C[QUIC connection]
    C --> D[Remote peer]
    C -->|Address events| E[Consumer address book]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/link_transport.rs`, line 511-513 ([link](https://github.com/saorsa-labs/ant-quic/blob/2b6c80beb5b42771369073cbc78488e5bd9fa927/src/link_transport.rs#L511-L513)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Align raw protocol bytes**

   The string example uses `saorsa-overlay/1.0.0`, but the adjacent byte array still encodes the old `saorsa-dht/1.0.0` identifier. Copying the raw form therefore produces a different protocol ID from the one documented immediately above it.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/link_transport.rs
   Line: 511-513

   Comment:
   **Align raw protocol bytes**

   The string example uses `saorsa-overlay/1.0.0`, but the adjacent byte array still encodes the old `saorsa-dht/1.0.0` identifier. Copying the raw form therefore produces a different protocol ID from the one documented immediately above it.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/link_transport.rs:511-513
**Align raw protocol bytes**

The string example uses `saorsa-overlay/1.0.0`, but the adjacent byte array still encodes the old `saorsa-dht/1.0.0` identifier. Copying the raw form therefore produces a different protocol ID from the one documented immediately above it.

```suggestion
/// // From bytes
/// let proto = ProtocolId::new([0x73, 0x61, 0x6f, 0x72, 0x73, 0x61, 0x2d, 0x6f,
///                              0x76, 0x65, 0x72, 0x6c, 0x61, 0x79, 0x2f, 0x31]);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(link): adopt overlay-neutral pr..."](https://github.com/saorsa-labs/ant-quic/commit/2b6c80beb5b42771369073cbc78488e5bd9fa927) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57225054)</sub>

<!-- /greptile_comment -->