### PR TITLE
docs(testing): retire studio2 from the cross-env matrix

### DIFF
--- a/docs/testing/cross-env-matrix.md
+++ b/docs/testing/cross-env-matrix.md
@@ -19,7 +19,6 @@ Single source of truth: `scripts/lib/topology.sh`. Borrowed verbatim from
 |---|---|---|
 | L1 | this MacBook (loopback) | LAN, mDNS |
 | L2 | studio1.local | LAN, mDNS |
-| L3 | studio2.local | LAN, mDNS |
 | V_NYC | 142.93.199.50 (DigitalOcean NYC) | VPS |
 | V_SFO | 147.182.234.192 (DigitalOcean SFO) | VPS |
 | V_HEL | 65.21.157.229 (Hetzner Helsinki) | VPS |
@@ -71,9 +70,8 @@ for ip in 142.93.199.50 147.182.234.192 65.21.157.229 116.203.101.172 149.28.156
     ssh root@${ip} 'chmod +x /opt/ant-quic-test/bin/ant-quic'
 done
 
-# 3. SSH reachability to LAN studios
+# 3. SSH reachability to the LAN studio
 ssh studio1@studio1.local true
-ssh studio2@studio2.local true
 
 # 4. Sudo on this MacBook (only required for C5 forced-relay's pfctl rule)
 sudo -v

--- a/docs/testing/cross-env-matrix.md
+++ b/docs/testing/cross-env-matrix.md
@@ -28,7 +28,7 @@ Single source of truth: `scripts/lib/topology.sh`. Borrowed verbatim from
 
 Cross-LAN discovery uses `--known-peers` listing every VPS IPv4 on port
 10000. No registry, no default bootstrap. mDNS handles LAN-only
-discovery for L1/L2/L3.
+discovery for L1/L2.
 
 Preflight probes each non-L1 node via SSH; unreachable nodes are recorded
 in `LOG_DIR/skipped.txt` and excluded from later steps.


### PR DESCRIPTION
studio2 is no longer part of the lab (David, 2026-08-30). Drops the L3 row and its SSH pre-flight line; LAN nodes are this MacBook + studio1. Companion: saorsa-labs/x0x#452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wAoeWjR2y5FmCyBmC5Ym4

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the cross-environment testing guide to retire studio2 from the documented LAN inventory and SSH pre-flight steps.
- Removes the L3/studio2 host row.
- Removes studio2’s SSH reachability check and changes the heading to singular.
- Does not make the corresponding retirement in the executable topology, leaving the guide and harness inconsistent.

<h3>Confidence Score: 4/5</h3>

The documentation and executable matrix topology should be aligned before merging so the retired studio2 node is not still probed and silently skipped.

The guide removes studio2 from its inventory and prerequisites, but the sourced topology still includes L3 with studio2’s hostname and SSH target, so running the matrix does not match the documented eight-node setup.

**Files Needing Attention:** docs/testing/cross-env-matrix.md and scripts/lib/topology.sh

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/testing/cross-env-matrix.md | Removes studio2 from two documented locations, but leaves the matrix’s topology source and several remaining references configured for L3/studio2. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/testing/cross-env-matrix.md:70-71
**Executable topology still includes L3**

When an operator follows these revised prerequisites, the harness still sources a topology containing L3 at `studio2.local` and probes its SSH target, causing the retired node to be silently skipped while the guide presents an eight-node setup and omits its prerequisite.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(testing): retire studio2 from the c..."](https://github.com/saorsa-labs/ant-quic/commit/6d20f39488c1f86397a9cbb0e57f0ffc0feebabc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58367233)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->