### PR TITLE
chore(deps): relax unicode-width pin from =0.2.0 to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,9 +3830,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ qlog = { version = "0.13", optional = true }
 
 # Essential dependencies
 uuid = { version = "1.0", features = ["v4", "serde"] }
-unicode-width = "=0.2.0"  # Pinned to match ratatui's requirement
+unicode-width = "0.2.2"
 hex = "0.4"
 sha2 = "0.10"
 once_cell = "1.21"


### PR DESCRIPTION
## Why

ant-quic 0.27.47 pins `unicode-width = "=0.2.0"` while saorsa-transport 0.36.2 pins `=0.2.2`. Anything linking both x0x 0.40.4 and ant-core 0.8.0 cannot resolve a lockfile.

The pin's comment said it matched ratatui, but ratatui is no longer a dependency. The only in-tree consumer is `src/terminal_ui.rs` via `UnicodeWidthStr`, whose API is unchanged across 0.2.x.

## Change

`unicode-width = "0.2.2"` (caret), so both a hard `=0.2.2` pin downstream and future 0.2.x resolve. Lockfile updated 0.2.0 -> 0.2.2.

## Verification

- `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean, `cargo fmt --check` clean.
- Scratch crate depending on this branch plus `unicode-width = "=0.2.2"` resolves a lockfile (single unicode-width 0.2.2).
- Full `cargo nextest run --workspace --all-features --no-fail-fast`: 8 failures under parallel load, 7 pass in isolation. The remaining one, `test_tiebreaker_deterministic`, fails 4/4 on unmodified `master` too, so it is pre-existing and unrelated.

Intended for the next patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACs9BzCywrsupBWadQrwza


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR relaxes the exact `unicode-width` 0.2.0 pin to a caret requirement starting at 0.2.2, resolving downstream version conflicts while retaining the terminal UI API currently used.
- Updates the manifest requirement to `unicode-width = "0.2.2"`.
- Refreshes the lockfile to resolve `unicode-width` 0.2.2.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or compatibility issues identified.

The resolved unicode-width release preserves the API used by the terminal UI, remains compatible with the repository’s Rust version, and the lockfile contains no unrelated dependency changes.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Relaxes the exact unicode-width pin to a compatible 0.2.x caret range without breaking the sole in-tree API usage or repository dependency policy. |
| Cargo.lock | Updates only unicode-width from 0.2.0 to 0.2.2 and its registry checksum; unrelated advisory-listed dependencies remain unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): relax unicode-width pin fro..."](https://github.com/saorsa-labs/ant-quic/commit/c7211e9878fd1f5fc513ec0d1e720b553949aaf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59465913)</sub>

<!-- /greptile_comment -->