### PR TITLE
fix(pqc): stop relying on IP fragmentation for handshake datagrams — RFC 9000 §14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **RFC 9000 §14 compliance: PQC handshakes no longer rely on IP fragmentation (#270, x0x#505).**
+  Three cooperating defects made PQC-negotiating endpoints emit 4096-byte UDP datagrams during
+  the handshake (and on post-handshake path validation), which fails outright on networks that
+  drop non-initial IP fragments (Oracle Cloud: `IpReasmReqds == IpReasmFails` at 16260/16260,
+  24/24 bootstraps unreachable): `PqcState::min_initial_size()` returned a 4096-byte floor that
+  padded Initials past the path MTU; `PacketBuilder::pad_to` could raise a packet's minimum
+  past the enclosing datagram's capacity; and PQC detection in CRYPTO bytes reset
+  `MtuDiscovery` to 4096 mid-handshake without any probe. Padding is now hard-capped at the
+  datagram builder's capacity, the PQC floor is clamped to the current validated PLPMTU
+  (1200 until DPLPMTUD probes confirm more), off-path PATH_RESPONSE and PATH_CHALLENGE
+  datagrams pad to the RFC-specified 1200-byte minimum, and PQC detection no longer raises the
+  path MTU. PQ handshake volume continues to flow as multiple ≤MTU datagrams of split CRYPTO
+  frames; the server's first flight was ~95% padding, not key material. Regression tests drive
+  a full PQC handshake through the low-level state machines and assert every transmit fits
+  1200 bytes (fails on the pre-fix code with three 4096-byte datagrams).
+
+
+
 ## [0.27.48] - 2026-09-02
 
 ### Changed

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -837,7 +837,7 @@ impl Connection {
                 // Finish current packet
                 if let Some(mut builder) = builder_storage.take() {
                     if pad_datagram {
-                        let min_size = self.pqc_state.min_initial_size();
+                        let min_size = self.pqc_state.min_initial_size(self.path.current_mtu());
                         builder.pad_to(min_size);
                     }
 
@@ -1092,10 +1092,11 @@ impl Connection {
                     ) {
                         return None;
                     }
-                    buf.write(token);
                     self.stats.frame_tx.path_response += 1;
-                    let min_size = self.pqc_state.min_initial_size();
-                    builder.pad_to(min_size);
+                    // RFC 9000 §8.2.2: an off-path PATH_RESPONSE must be padded to at least the
+                    // smallest allowed maximum datagram size — not the larger PQC handshake floor,
+                    // which previously fragmented these datagrams post-handshake (ant-quic#270).
+                    builder.pad_to(MIN_INITIAL_SIZE);
                     builder.finish_and_track(
                         now,
                         self,
@@ -1177,11 +1178,10 @@ impl Connection {
             // Don't increment space_idx.
             // We stay in the current space and check if there is more data to send.
         }
-
         // Finish the last packet
         if let Some(mut builder) = builder_storage {
             if pad_datagram {
-                let min_size = self.pqc_state.min_initial_size();
+                let min_size = self.pqc_state.min_initial_size(self.path.current_mtu());
                 builder.pad_to(min_size);
             }
 
@@ -1375,7 +1375,7 @@ impl Connection {
             "PATH_CHALLENGE queued without 1-RTT keys"
         );
 
-        buf.reserve(self.pqc_state.min_initial_size() as usize);
+        buf.reserve(usize::from(MIN_INITIAL_SIZE));
         let buf_capacity = buf.capacity();
 
         let mut builder = PacketBuilder::new(
@@ -1403,9 +1403,10 @@ impl Connection {
         buf.write(challenge);
         self.stats.frame_tx.path_challenge += 1;
 
-        let min_size = self.pqc_state.min_initial_size();
-        builder.pad_to(min_size);
-        builder.finish_and_track(now, self, None, buf);
+        // RFC 9000 §8.2.1: a PATH_CHALLENGE sent to a peer address must be padded to at least the
+        // smallest allowed maximum datagram size — not the larger PQC handshake floor
+        // (ant-quic#270).
+        builder.pad_to(MIN_INITIAL_SIZE);
 
         // Mark coordination as validating after packet is built
         if let Some(nat_traversal) = &mut self.nat_traversal {
@@ -1471,7 +1472,7 @@ impl Connection {
             "PATH_CHALLENGE queued without 1-RTT keys"
         );
 
-        buf.reserve(self.pqc_state.min_initial_size() as usize);
+        buf.reserve(usize::from(MIN_INITIAL_SIZE));
         let buf_capacity = buf.capacity();
 
         // Use current connection ID for NAT traversal PATH_CHALLENGE
@@ -1500,9 +1501,9 @@ impl Connection {
         buf.write(challenge);
         self.stats.frame_tx.path_challenge += 1;
 
-        // PATH_CHALLENGE frames must be padded to at least 1200 bytes
-        let min_size = self.pqc_state.min_initial_size();
-        builder.pad_to(min_size);
+        // PATH_CHALLENGE frames must be padded to at least the smallest allowed maximum
+        // datagram size (RFC 9000 §8.2.1), not the larger PQC handshake floor (ant-quic#270)
+        builder.pad_to(MIN_INITIAL_SIZE);
 
         builder.finish_and_track(now, self, None, buf);
 
@@ -1535,7 +1536,7 @@ impl Connection {
             SpaceId::Data,
             "PATH_CHALLENGE queued without 1-RTT keys"
         );
-        buf.reserve(self.pqc_state.min_initial_size() as usize);
+        buf.reserve(usize::from(MIN_INITIAL_SIZE));
 
         let buf_capacity = buf.capacity();
 
@@ -1569,8 +1570,7 @@ impl Connection {
         // to at least the smallest allowed maximum datagram size of 1200 bytes,
         // unless the anti-amplification limit for the path does not permit
         // sending a datagram of this size
-        let min_size = self.pqc_state.min_initial_size();
-        builder.pad_to(min_size);
+        builder.pad_to(MIN_INITIAL_SIZE);
 
         builder.finish(self, buf);
         self.stats.udp_tx.on_sent(1, buf.len());
@@ -2720,14 +2720,10 @@ impl Connection {
         // Detect PQC usage from CRYPTO frame data before processing
         self.pqc_state.detect_pqc_from_crypto(&crypto.data, space);
 
-        // Check if we should trigger MTU discovery for PQC
-        if self.pqc_state.should_trigger_mtu_discovery() {
-            // Request larger MTU for PQC handshakes
-            self.path
-                .mtud
-                .reset(self.pqc_state.min_initial_size(), self.config.min_mtu);
-            trace!("Triggered MTU discovery for PQC handshake");
-        }
+        // PQC negotiation must NOT raise `path.current_mtu()` here: an unvalidated 4096-byte
+        // MTU made handshake datagrams rely on IP fragmentation, which fails on
+        // fragment-filtering networks (RFC 9000 §14, ant-quic#270). Larger datagrams are only
+        // authorized by DPLPMTUD probes after the handshake completes.
 
         let space = &mut self.spaces[space];
         let max = end.saturating_sub(space.crypto_stream.bytes_read());
@@ -2791,7 +2787,7 @@ impl Connection {
                 let frames = self.pqc_state.packet_handler.fragment_crypto_data(
                     &outgoing,
                     offset,
-                    self.pqc_state.min_initial_size() as usize,
+                    usize::from(self.pqc_state.min_initial_size(self.path.current_mtu())),
                 );
                 for frame in frames {
                     self.spaces[space].pending.crypto.push_back(frame);
@@ -6525,11 +6521,18 @@ impl PqcState {
         }
     }
 
-    /// Get the minimum initial packet size based on PQC state
-    fn min_initial_size(&self) -> u16 {
+    /// Get the minimum Initial datagram size based on PQC state
+    ///
+    /// RFC 9000 §14: datagrams must not exceed the smallest maximum datagram size the path is
+    /// known to support until a larger PLPMTU has been validated by DPLPMTUD probes (which only
+    /// run after the handshake). The PQC handshake's desire for larger uniform datagrams is
+    /// therefore capped at the current validated path MTU; PQ handshake volume flows as multiple
+    /// ≤MTU datagrams of split CRYPTO frames (ant-quic#270).
+    fn min_initial_size(&self, path_mtu: u16) -> u16 {
         if self.enabled && self.using_pqc {
-            // Use larger initial packet size for PQC handshakes
-            std::cmp::max(self.handshake_mtu, 4096)
+            let floor = Ord::max(self.handshake_mtu, MIN_INITIAL_SIZE);
+            let ceiling = Ord::max(path_mtu, MIN_INITIAL_SIZE);
+            Ord::min(floor, ceiling)
         } else {
             MIN_INITIAL_SIZE
         }
@@ -6558,11 +6561,6 @@ impl PqcState {
             // Update handshake MTU based on PQC detection
             self.handshake_mtu = self.packet_handler.get_min_packet_size(space);
         }
-    }
-
-    /// Check if MTU discovery should be triggered for PQC
-    fn should_trigger_mtu_discovery(&mut self) -> bool {
-        self.packet_handler.should_trigger_mtu_discovery()
     }
 
     /// Get PQC-aware MTU configuration
@@ -7098,6 +7096,10 @@ impl Connection {
         self.peer_params.ack_receive_v2
     }
 }
+
+#[cfg(test)]
+#[path = "pqc_mtu_regression_tests.rs"]
+mod pqc_mtu_regression_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1092,6 +1092,7 @@ impl Connection {
                     ) {
                         return None;
                     }
+                    buf.write(token);
                     self.stats.frame_tx.path_response += 1;
                     // RFC 9000 §8.2.2: an off-path PATH_RESPONSE must be padded to at least the
                     // smallest allowed maximum datagram size — not the larger PQC handshake floor,
@@ -1407,6 +1408,7 @@ impl Connection {
         // smallest allowed maximum datagram size — not the larger PQC handshake floor
         // (ant-quic#270).
         builder.pad_to(MIN_INITIAL_SIZE);
+        builder.finish_and_track(now, self, None, buf);
 
         // Mark coordination as validating after packet is built
         if let Some(nat_traversal) = &mut self.nat_traversal {

--- a/src/connection/packet_builder.rs
+++ b/src/connection/packet_builder.rs
@@ -184,14 +184,21 @@ impl PacketBuilder {
 
     /// Append the minimum amount of padding to the packet such that, after encryption, the
     /// enclosing datagram will occupy at least `min_size` bytes
+    ///
+    /// The padding is capped at this packet's remaining capacity in the enclosing datagram
+    /// (`max_size`), so a datagram can never grow past the buffer allocated for it. Callers
+    /// historically requested PQC handshake padding larger than the path MTU, which silently
+    /// relied on IP fragmentation and failed on fragment-filtering networks (RFC 9000 §14,
+    /// ant-quic#270).
     pub(super) fn pad_to(&mut self, min_size: u16) {
         // The datagram might already have a larger minimum size than the caller is requesting, if
         // e.g. we're coalescing packets and have populated more than `min_size` bytes with packets
         // already.
-        self.min_size = Ord::max(
+        let target = Ord::max(
             self.min_size,
             self.datagram_start + (min_size as usize) - self.tag_len,
         );
+        self.min_size = Ord::min(target, self.max_size);
     }
 
     pub(super) fn finish_and_track(

--- a/src/connection/pqc_mtu_regression_tests.rs
+++ b/src/connection/pqc_mtu_regression_tests.rs
@@ -1,0 +1,403 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/gpl-3.0.html>
+//
+// Full details available at https://saorsalabs.com/licenses
+
+//! Regression tests for ant-quic#270 (x0x#505): PQC handshakes must not rely on IP
+//! fragmentation.
+//!
+//! Before the fix, three cooperating defects made PQC-negotiating endpoints emit
+//! 4096-byte UDP datagrams during (and after) the handshake:
+//!
+//! 1. `PqcState::min_initial_size()` returned `max(handshake_mtu, 4096)` whenever the peer
+//!    advertised ML-KEM/ML-DSA, and every padding-required datagram was padded to it.
+//! 2. `PacketBuilder::pad_to` raised the packet minimum past the builder's datagram
+//!    capacity without a cap, and `finish()` blindly grew and encrypted the buffer.
+//! 3. `read_crypto` reset `MtuDiscovery` to 4096 mid-handshake whenever PQC was detected in
+//!    CRYPTO bytes, raising `path.current_mtu()` without any probe.
+//!
+//! On paths that drop non-initial IP fragments (e.g. Oracle Cloud) the handshake never
+//! completed. RFC 9000 §14 requires datagrams to fit 1200 bytes until a larger PLPMTU is
+//! validated by DPLPMTUD probes, which only run after the handshake.
+//!
+//! These tests drive a full client↔server handshake through the low-level state machines
+//! (no sockets — loopback MTUs would hide the defect) and assert the invariant at the
+//! `Transmit` boundary.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
+
+use bytes::BytesMut;
+
+use crate::{
+    ClientConfig, Connection, ConnectionHandle, EndpointConfig, Event, ServerConfig,
+    TransportConfig,
+    crypto::{
+        pqc::PqcConfig,
+        rustls::{QuicClientConfig, QuicServerConfig, configured_provider_with_pqc},
+    },
+    endpoint::{DatagramEvent, Endpoint},
+};
+
+/// Smallest allowed maximum datagram size (RFC 9000 §14); the crate's `MIN_INITIAL_SIZE`.
+const MIN_INITIAL_SIZE: usize = 1200;
+
+const SERVER_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4433);
+
+#[derive(Debug)]
+struct SkipServerVerification;
+
+impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+        ]
+    }
+}
+
+fn generate_test_cert() -> (
+    rustls::pki_types::CertificateDer<'static>,
+    rustls::pki_types::PrivateKeyDer<'static>,
+) {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    let cert_der = cert.cert.into();
+    let key_der = rustls::pki_types::PrivateKeyDer::Pkcs8(cert.signing_key.serialize_der().into());
+    (cert_der, key_der)
+}
+
+fn server_config() -> Arc<ServerConfig> {
+    let (cert, key) = generate_test_cert();
+    let provider = configured_provider_with_pqc(Some(&PqcConfig::default()));
+
+    let mut server_crypto = rustls::ServerConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], key)
+        .unwrap();
+    server_crypto.alpn_protocols = vec![b"test".to_vec()];
+
+    let mut config =
+        ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(server_crypto).unwrap()));
+    // Default transport: initial MTU 1200, PQC algorithms advertised (ML-KEM-768/ML-DSA-65).
+    config.transport_config(Arc::new(TransportConfig::default()));
+    Arc::new(config)
+}
+
+fn client_config() -> ClientConfig {
+    let provider = configured_provider_with_pqc(Some(&PqcConfig::default()));
+    let mut client_crypto = rustls::ClientConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS13])
+        .unwrap()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(SkipServerVerification))
+        .with_no_client_auth();
+    client_crypto.alpn_protocols = vec![b"test".to_vec()];
+
+    let mut config =
+        ClientConfig::new(Arc::new(QuicClientConfig::try_from(client_crypto).unwrap()));
+    config.transport_config(Arc::new(TransportConfig::default()));
+    config
+}
+
+struct Peer {
+    endpoint: Endpoint,
+    conn: Option<Connection>,
+    handle: Option<ConnectionHandle>,
+    connected: bool,
+}
+
+/// Feed one datagram into `peer`'s endpoint and route everything it produces.
+fn ingress(now: crate::Instant, data: BytesMut, from_addr: SocketAddr, peer: &mut Peer) {
+    let mut scratch = Vec::new();
+    match peer
+        .endpoint
+        .handle(now, from_addr, None, None, data, &mut scratch)
+    {
+        Some(DatagramEvent::ConnectionEvent(_, event)) => {
+            if let Some(conn) = peer.conn.as_mut() {
+                conn.handle_event(event);
+            }
+        }
+        Some(DatagramEvent::NewConnection(incoming)) => {
+            let (handle, conn) = peer
+                .endpoint
+                .accept(incoming, now, &mut scratch, None)
+                .expect("accept first client Initial");
+            peer.handle = Some(handle);
+            peer.conn = Some(conn);
+        }
+        Some(DatagramEvent::Response(_)) | None => {}
+    }
+}
+
+/// Poll `peer`'s connection for transmits and events, delivering each datagram to `other`.
+/// Returns whether anything happened. Records every transmitted datagram size.
+fn pump(now: crate::Instant, peer: &mut Peer, other: &mut Peer, sizes: &mut Vec<usize>) -> bool {
+    let mut progress = false;
+
+    // Connection → endpoint events (identifier retirement, drain, …)
+    let handle = peer.handle.unwrap();
+    while let Some(event) = peer.conn.as_mut().unwrap().poll_endpoint_events() {
+        if let Some(response) = peer.endpoint.handle_event(handle, event) {
+            if let Some(conn) = peer.conn.as_mut() {
+                conn.handle_event(response);
+            }
+        }
+        progress = true;
+    }
+
+    // Application events
+    while let Some(event) = peer.conn.as_mut().unwrap().poll() {
+        if matches!(event, Event::Connected) {
+            peer.connected = true;
+        }
+        progress = true;
+    }
+
+    // Transmits → deliver to the other side
+    {
+        let conn = peer.conn.as_mut().unwrap();
+        let mut buf = Vec::with_capacity(65_536);
+        while let Some(transmit) = conn.poll_transmit(now, 1, &mut buf) {
+            sizes.push(transmit.size);
+            let datagram = BytesMut::from(&buf[..transmit.size]);
+            ingress(now, datagram, transmit.destination, other);
+            buf.clear();
+            progress = true;
+        }
+    }
+
+    progress
+}
+
+/// Drive the pair until both report `Connected` or the round budget is exhausted, advancing
+/// the simulated clock by 25 ms whenever a round makes no progress (loss/PTO timers).
+fn drive_to_connected(client: &mut Peer, server: &mut Peer) -> Vec<usize> {
+    let mut now = crate::Instant::now();
+    let mut sizes = Vec::new();
+    for _ in 0..400 {
+        let mut progress = false;
+        progress |= pump(now, client, server, &mut sizes);
+        progress |= pump(now, server, client, &mut sizes);
+        if client.connected && server.connected {
+            return sizes;
+        }
+        if !progress {
+            now += crate::Duration::from_millis(25);
+            for peer in [&mut *client, &mut *server] {
+                if let Some(conn) = peer.conn.as_mut() {
+                    if conn.poll_timeout().is_some_and(|deadline| deadline <= now) {
+                        conn.handle_timeout(now);
+                    }
+                }
+            }
+        }
+    }
+    sizes
+}
+
+fn make_peer_pair() -> (Peer, Peer) {
+    let server = Peer {
+        // allow_mtud = false: no DPLPMTUD probes may authorize >1200-byte datagrams, which
+        // is exactly the environment a fragment-filtering path presents pre-validation.
+        endpoint: Endpoint::new(
+            Arc::new(EndpointConfig::default()),
+            Some(server_config()),
+            false,
+            None,
+        ),
+        conn: None,
+        handle: None,
+        connected: false,
+    };
+    let mut client = Peer {
+        endpoint: Endpoint::new(Arc::new(EndpointConfig::default()), None, false, None),
+        conn: None,
+        handle: None,
+        connected: false,
+    };
+    let (handle, conn) = client
+        .endpoint
+        .connect(
+            crate::Instant::now(),
+            client_config(),
+            SERVER_ADDR,
+            "localhost",
+        )
+        .expect("initiate client connection");
+    client.handle = Some(handle);
+    client.conn = Some(conn);
+    (client, server)
+}
+
+/// The core regression: a full PQC handshake over a 1200-byte path. Before the fix the
+/// server padded its first ack-eliciting Initial to 4096 bytes and the client's subsequent
+/// Handshake flights went out up to 4096 bytes after `MtuDiscovery` was reset mid-flight.
+#[test]
+fn pqc_handshake_datagrams_stay_within_1200_bytes() {
+    let (mut client, mut server) = make_peer_pair();
+    let sizes = drive_to_connected(&mut client, &mut server);
+
+    assert!(
+        client.connected && server.connected,
+        "PQC handshake must complete over a 1200-byte path; got {} datagrams",
+        sizes.len()
+    );
+    assert!(
+        sizes.len() > 4,
+        "expected a multi-flight PQC handshake, saw only {} datagrams",
+        sizes.len()
+    );
+
+    // RFC 9000 §14: nothing above the smallest allowed maximum datagram size before
+    // PLPMTU validation. This is the assertion that fails on the pre-fix code with
+    // 4096-byte padded Initials.
+    let offenders: Vec<usize> = sizes
+        .iter()
+        .copied()
+        .filter(|&size| size > MIN_INITIAL_SIZE)
+        .collect();
+    assert_eq!(
+        offenders,
+        Vec::<usize>::new(),
+        "datagrams exceeded 1200 bytes during PQC handshake"
+    );
+
+    // RFC 9000 §14.1: the client's first Initial datagram must be padded to at least 1200.
+    assert_eq!(
+        sizes.first(),
+        Some(&MIN_INITIAL_SIZE),
+        "client's first Initial must be padded to exactly 1200 bytes"
+    );
+
+    // PQC negotiation must not have raised the unvalidated path MTU on either side.
+    assert_eq!(
+        client.conn.as_ref().unwrap().current_mtu(),
+        MIN_INITIAL_SIZE as u16
+    );
+    assert_eq!(
+        server.conn.as_ref().unwrap().current_mtu(),
+        MIN_INITIAL_SIZE as u16
+    );
+}
+
+/// `PqcState::min_initial_size` clamps the PQC floor to the current validated PLPMTU.
+#[test]
+fn pqc_min_initial_size_is_clamped_to_path_mtu() {
+    use crate::MIN_INITIAL_SIZE;
+    use crate::transport_parameters::{PqcAlgorithms, TransportParameters};
+
+    use super::PqcState;
+
+    let mut state = PqcState::new();
+    let mut params = TransportParameters::default();
+    params.pqc_algorithms = Some(PqcAlgorithms {
+        ml_kem_768: true,
+        ml_dsa_65: true,
+    });
+    state.update_from_peer_params(&params);
+    assert!(state.enabled && state.using_pqc && state.handshake_mtu == 4096);
+
+    // During the handshake the path MTU is the unvalidated 1200-byte default.
+    assert_eq!(state.min_initial_size(MIN_INITIAL_SIZE), MIN_INITIAL_SIZE);
+    // Only a validated larger PLPMTU admits larger PQC padding.
+    assert_eq!(state.min_initial_size(1500), 1500);
+    assert_eq!(state.min_initial_size(4096), 4096);
+    // A path MTU below the RFC floor still yields the floor, never less.
+    assert_eq!(state.min_initial_size(576), MIN_INITIAL_SIZE);
+
+    // Without PQC the answer is always the RFC minimum.
+    let plain = PqcState::new();
+    assert_eq!(plain.min_initial_size(1500), MIN_INITIAL_SIZE);
+}
+
+/// `PacketBuilder::pad_to` must never raise a packet's minimum past the datagram capacity,
+/// whatever the caller requests. This is the backstop that makes every other policy bug
+/// harmless.
+#[test]
+fn packet_builder_pad_to_is_capped_at_datagram_capacity() {
+    use super::packet_builder::PacketBuilder;
+
+    // Build a real builder through the production constructor over a 1200-byte datagram
+    // buffer, mirroring `poll_transmit`'s single-datagram path.
+    let (mut client, _server) = make_peer_pair();
+    let conn = client.conn.as_mut().unwrap();
+    let mut buf = Vec::with_capacity(MIN_INITIAL_SIZE);
+    let buf_capacity = MIN_INITIAL_SIZE;
+    let mut builder = PacketBuilder::new(
+        crate::Instant::now(),
+        crate::packet::SpaceId::Initial,
+        conn.rem_cids.active(),
+        &mut buf,
+        buf_capacity,
+        0,
+        true,
+        conn,
+    )
+    .expect("build Initial packet");
+
+    // The pre-fix bug: request the PQC 4096-byte floor.
+    builder.pad_to(4096);
+    assert!(
+        builder.min_size <= builder.max_size,
+        "pad_to must not raise min_size past max_size ({} > {})",
+        builder.min_size,
+        builder.max_size
+    );
+
+    let (len, _padded) = builder.finish(conn, &mut buf);
+    assert!(
+        buf.len() <= buf_capacity,
+        "encrypted datagram {} exceeds buffer capacity {buf_capacity}",
+        buf.len()
+    );
+    assert_eq!(len, buf.len());
+    // And it is a compliant Initial: padded to exactly 1200 bytes.
+    assert_eq!(buf.len(), MIN_INITIAL_SIZE);
+    // Sanity: the padded datagram starts with an Initial long header (both header bits set).
+    assert_eq!(buf[0] & 0xc0, 0xc0);
+}

--- a/src/connection/pqc_mtu_regression_tests.rs
+++ b/src/connection/pqc_mtu_regression_tests.rs
@@ -26,8 +26,6 @@
 //! (no sockets — loopback MTUs would hide the defect) and assert the invariant at the
 //! `Transmit` boundary.
 
-#![allow(clippy::unwrap_used, clippy::expect_used)]
-
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
@@ -216,7 +214,7 @@ fn pump(now: crate::Instant, peer: &mut Peer, other: &mut Peer, sizes: &mut Vec<
 
 /// Drive the pair until both report `Connected` or the round budget is exhausted, advancing
 /// the simulated clock by 25 ms whenever a round makes no progress (loss/PTO timers).
-fn drive_to_connected(client: &mut Peer, server: &mut Peer) -> Vec<usize> {
+fn drive_to_connected(client: &mut Peer, server: &mut Peer) -> (Vec<usize>, crate::Instant) {
     let mut now = crate::Instant::now();
     let mut sizes = Vec::new();
     for _ in 0..400 {
@@ -224,7 +222,7 @@ fn drive_to_connected(client: &mut Peer, server: &mut Peer) -> Vec<usize> {
         progress |= pump(now, client, server, &mut sizes);
         progress |= pump(now, server, client, &mut sizes);
         if client.connected && server.connected {
-            return sizes;
+            return (sizes, now);
         }
         if !progress {
             now += crate::Duration::from_millis(25);
@@ -237,7 +235,7 @@ fn drive_to_connected(client: &mut Peer, server: &mut Peer) -> Vec<usize> {
             }
         }
     }
-    sizes
+    (sizes, now)
 }
 
 fn make_peer_pair() -> (Peer, Peer) {
@@ -280,7 +278,7 @@ fn make_peer_pair() -> (Peer, Peer) {
 #[test]
 fn pqc_handshake_datagrams_stay_within_1200_bytes() {
     let (mut client, mut server) = make_peer_pair();
-    let sizes = drive_to_connected(&mut client, &mut server);
+    let (sizes, _) = drive_to_connected(&mut client, &mut server);
 
     assert!(
         client.connected && server.connected,
@@ -400,4 +398,107 @@ fn packet_builder_pad_to_is_capped_at_datagram_capacity() {
     assert_eq!(buf.len(), MIN_INITIAL_SIZE);
     // Sanity: the padded datagram starts with an Initial long header (both header bits set).
     assert_eq!(buf[0] & 0xc0, 0xc0);
+}
+
+/// Off-path responses must preserve the challenge, not let zero padding become its payload.
+#[test]
+fn off_path_response_echoes_token_and_validates_peer_path() {
+    let (mut client, mut server) = make_peer_pair();
+    let (_, now) = drive_to_connected(&mut client, &mut server);
+    assert!(client.connected && server.connected);
+    let candidate = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4444);
+    let token = 0x0123_4567_89ab_cdef;
+
+    let client_conn = client.conn.as_mut().unwrap();
+    client_conn.nat_traversal = None;
+    assert_ne!(candidate, client_conn.path.remote);
+    client_conn.path_responses = super::paths::PathResponses::default();
+    client_conn.path_responses.push(0, token, candidate);
+    let mut buf = Vec::with_capacity(65_536);
+    let transmit = client_conn.poll_transmit(now, 1, &mut buf).unwrap();
+    assert_eq!(transmit.destination, candidate);
+    assert_eq!(transmit.size, MIN_INITIAL_SIZE);
+    assert_eq!(transmit.segment_size, None);
+
+    // Feed the actual encrypted datagram through the peer's endpoint and connection.
+    // Its outstanding nonzero token is the oracle, independent of sender-side counters.
+    let server_conn = server.conn.as_mut().unwrap();
+    server_conn.path.challenge = Some(token);
+    server_conn.path.validated = false;
+    let source = server_conn.path.remote;
+    ingress(
+        now,
+        BytesMut::from(&buf[..transmit.size]),
+        source,
+        &mut server,
+    );
+    let server_conn = server.conn.as_ref().unwrap();
+    assert_eq!(
+        server_conn.path.challenge, None,
+        "peer must accept echoed token"
+    );
+    assert!(server_conn.path.validated);
+}
+
+/// A coordinated punch must be a finished, authenticated packet before it is returned.
+#[test]
+fn coordinated_path_challenge_is_padded_and_decoded_by_peer() {
+    use super::nat_traversal::{CoordinationPhase, NatTraversalState, PunchTarget};
+
+    let (mut client, mut server) = make_peer_pair();
+    let (_, now) = drive_to_connected(&mut client, &mut server);
+    assert!(client.connected && server.connected);
+    let token = 0xfedc_ba98_7654_3210;
+    let client_conn = client.conn.as_mut().unwrap();
+    let destination = client_conn.path.remote;
+    let mut nat = NatTraversalState::new(4, crate::Duration::from_secs(10));
+    nat.prime_passive_coordination_target(
+        crate::VarInt::from_u32(1),
+        PunchTarget {
+            remote_addr: destination,
+            remote_sequence: crate::VarInt::from_u32(1),
+            challenge: token,
+        },
+        now,
+    )
+    .unwrap();
+    assert_eq!(
+        nat.get_coordination_phase(),
+        Some(CoordinationPhase::Preparing)
+    );
+    client_conn.nat_traversal = Some(nat);
+    let now = now + crate::Duration::from_millis(500);
+    let mut buf = Vec::with_capacity(65_536);
+    let transmit = client_conn.poll_transmit(now, 1, &mut buf).unwrap();
+    assert_eq!(transmit.destination, destination);
+    assert_eq!(transmit.segment_size, None);
+    assert_eq!(
+        client_conn
+            .nat_traversal
+            .as_ref()
+            .unwrap()
+            .get_coordination_phase(),
+        Some(CoordinationPhase::Validating)
+    );
+
+    let server_conn = server.conn.as_mut().unwrap();
+    server_conn.path_responses = super::paths::PathResponses::default();
+    let source = server_conn.path.remote;
+    ingress(
+        now,
+        BytesMut::from(&buf[..transmit.size]),
+        source,
+        &mut server,
+    );
+    assert_eq!(
+        server
+            .conn
+            .as_mut()
+            .unwrap()
+            .path_responses
+            .pop_on_path(source),
+        Some(token),
+        "peer must authenticate and decode the coordinated challenge"
+    );
+    assert_eq!(transmit.size, MIN_INITIAL_SIZE);
 }

--- a/src/crypto/pqc/packet_handler.rs
+++ b/src/crypto/pqc/packet_handler.rs
@@ -45,8 +45,6 @@ pub struct PqcPacketHandler {
     pqc_detected: bool,
     /// Current estimated handshake size
     estimated_handshake_size: u32,
-    /// Whether we've initiated MTU discovery for PQC
-    mtu_discovery_triggered: bool,
 }
 
 impl PqcPacketHandler {
@@ -57,7 +55,6 @@ impl PqcPacketHandler {
         Self {
             pqc_detected: false,
             estimated_handshake_size: 0,
-            mtu_discovery_triggered: false,
         }
     }
 
@@ -112,16 +109,6 @@ impl PqcPacketHandler {
     fn pqc_handshake_size() -> u32 {
         // PQC handshake with ML-KEM-768 hybrid key exchange
         16384
-    }
-
-    /// Check if MTU discovery should be triggered for PQC
-    pub fn should_trigger_mtu_discovery(&mut self) -> bool {
-        if self.pqc_detected && !self.mtu_discovery_triggered {
-            self.mtu_discovery_triggered = true;
-            true
-        } else {
-            false
-        }
     }
 
     /// Get recommended MTU configuration for PQC
@@ -239,7 +226,6 @@ impl PqcPacketHandler {
     pub fn reset(&mut self) {
         self.pqc_detected = false;
         self.estimated_handshake_size = 0;
-        self.mtu_discovery_triggered = false;
     }
 }
 
@@ -273,22 +259,6 @@ mod tests {
         let handler = PqcPacketHandler::new();
         assert!(!handler.pqc_detected);
         assert_eq!(handler.estimated_handshake_size, 0);
-        assert!(!handler.mtu_discovery_triggered);
-    }
-
-    #[test]
-    fn test_mtu_discovery_trigger() {
-        let mut handler = PqcPacketHandler::new();
-
-        // Should not trigger without PQC detection
-        assert!(!handler.should_trigger_mtu_discovery());
-
-        // Simulate PQC detection
-        handler.pqc_detected = true;
-        assert!(handler.should_trigger_mtu_discovery());
-
-        // Should not trigger again
-        assert!(!handler.should_trigger_mtu_discovery());
     }
 
     #[test]
@@ -388,13 +358,11 @@ mod tests {
         let mut handler = PqcPacketHandler::new();
         handler.pqc_detected = true;
         handler.estimated_handshake_size = 16384;
-        handler.mtu_discovery_triggered = true;
 
         handler.reset();
 
         assert!(!handler.pqc_detected);
         assert_eq!(handler.estimated_handshake_size, 0);
-        assert!(!handler.mtu_discovery_triggered);
     }
 
     #[test]

--- a/tests/pqc_packet_handling.rs
+++ b/tests/pqc_packet_handling.rs
@@ -65,7 +65,9 @@ fn test_packet_handler_keeps_standard_limits_before_pqc_detection() {
 
     assert!(!handler.detect_pqc_handshake(&[], SpaceId::Initial));
     assert!(!handler.detect_pqc_handshake(&[1, 0, 0, 16], SpaceId::Data));
-    assert!(!handler.should_trigger_mtu_discovery());
+
+    // ant-quic#270: PQC detection no longer raises the path MTU mid-handshake; MTUD probes
+    // are the only mechanism that may authorize datagrams above 1200 bytes.
 
     assert_eq!(handler.get_min_packet_size(SpaceId::Initial), 1200);
     assert_eq!(
@@ -83,8 +85,8 @@ fn test_packet_handler_detects_pqc_handshake_and_adjusts_packet_limits() {
     let client_hello = synthetic_pqc_client_hello();
 
     assert!(handler.detect_pqc_handshake(&client_hello, SpaceId::Initial));
-    assert!(handler.should_trigger_mtu_discovery());
-    assert!(!handler.should_trigger_mtu_discovery());
+
+    // ant-quic#270: detection adjusts frame sizing only; it must never raise the path MTU.
 
     assert_eq!(handler.get_min_packet_size(SpaceId::Initial), PQC_MIN_MTU);
     assert_eq!(handler.get_min_packet_size(SpaceId::Handshake), 1500);
@@ -112,7 +114,6 @@ fn test_packet_handler_detects_pqc_handshake_and_adjusts_packet_limits() {
 
     handler.reset();
     assert_eq!(handler.get_min_packet_size(SpaceId::Initial), 1200);
-    assert!(!handler.should_trigger_mtu_discovery());
 }
 
 #[test]


### PR DESCRIPTION
PQC handshake and path-validation padding could produce 4096-byte UDP datagrams before the path supported that size. This change caps padding at the packet builder capacity, keeps the initial path MTU at 1200 until probing confirms more, and uses the 1200-byte minimum for path validation. PQ handshake data continues across multiple CRYPTO datagrams. This addresses the source defect behind #270 and x0x#505; deployment on the reporter’s fragment-filtering OCI path remains unverified.

Off-path PATH_RESPONSE packets retain their challenge token. Coordinated PATH_CHALLENGE packets are finalized, padded and encrypted before transmission and the transition to Validating. The redundant lint allowance in the new test module was removed.

Validation on `fbecc771ebe80098b7c379af3f61af5129937162`:

- Author and independent root runs passed the four ordered gates: fmt; all-feature/all-target clippy with warnings denied; production lib/bin clippy with panic/unwrap/expect denied; workspace/all-target check.
- Five focused in-memory packet tests passed. They cover handshake datagram size, the padding cap, the PQC minimum, nonzero response-token validation at the receiving peer, and authenticated challenge decoding at the receiving peer.
- Removing only the response-token write makes its receiving-peer regression fail; removing only challenge finalization makes the other regression fail. Both repairs were restored before final gates.
- The new path tests exercise actual poll_transmit and endpoint/connection ingress, without live sockets. They do not establish full broker-mediated NAT traversal, deployed RPK authentication, x0x consumer acceptance or OCI connectivity.

Fresh CI must pass on this updated head before merge. Earlier full-suite/CI results and any review of `45d891de` do not establish acceptance of this head.

Fixes #270
Refs saorsa-labs/x0x#505


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR limits PQC handshake and path-validation padding to the available datagram/path capacity and removes the mid-handshake MTU reset. The primary MTU corrections are accompanied by focused regression coverage, but two accidental omissions break path validation:
- Off-path PATH_RESPONSE packets no longer contain the challenge token.
- Coordinated PATH_CHALLENGE packets are returned without padding, encryption, or transmission tracking.
- The new regression module also introduces a blanket lint allowance contrary to repository guidance.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until off-path responses include their token, coordinated challenges are finalized, and the repository lint-suppression requirement is satisfied.

Two changed path-validation branches now emit invalid packets: one omits the PATH_RESPONSE token, while the other returns a PATH_CHALLENGE without invoking the padding and encryption finalizer. These failures block path migration and coordinated NAT traversal.

**Files Needing Attention:** src/connection/mod.rs, src/connection/pqc_mtu_regression_tests.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/connection/mod.rs | Correctly removes unvalidated PQC MTU inflation, but accidentally omits the off-path response token and coordinated challenge finalization. |
| src/connection/packet_builder.rs | Safely caps requested padding at the packet's plaintext capacity while preserving space for encryption overhead. |
| src/connection/pqc_mtu_regression_tests.rs | Adds strong low-level handshake MTU regression coverage but introduces a disallowed blanket lint suppression and does not cover the two affected path-validation branches. |
| src/crypto/pqc/packet_handler.rs | Removes obsolete state and behavior that previously triggered an unvalidated MTU increase. |
| tests/pqc_packet_handling.rs | Updates packet-handler expectations to reflect that PQC detection no longer triggers MTU discovery. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Receive PATH_CHALLENGE on another path] --> B[Build off-path PATH_RESPONSE]
  B --> C{Echo challenge token?}
  C -->|Current change: no| D[Padding supplies zero payload]
  D --> E[Peer rejects response and path validation fails]

  F[Coordination enters Punching] --> G[Build coordinated PATH_CHALLENGE]
  G --> H{Finalize builder?}
  H -->|Current change: no| I[Return unpadded and unencrypted bytes]
  I --> J[Coordination advances to Validating]
  J --> K[No valid response arrives; hole punching stalls]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/connection/mod.rs:1095
**PATH_RESPONSE Omits Token**

When replying to a PATH_CHALLENGE received on another path, this branch encodes the PATH_RESPONSE frame type but does not write the received challenge token. The following padding supplies zero bytes instead, so the peer receives the wrong response and cannot complete path validation. Write `token` before padding and finalizing the packet.

```suggestion
                    buf.write(token);
                    self.stats.frame_tx.path_response += 1;
```

### Issue 2
src/connection/mod.rs:1409
**Challenge Packet Is Unfinished**

During coordinated hole punching, this builder is not finalized before its `Transmit` is returned. `pad_to` only records the target size; `finish_and_track` performs the actual padding and encryption. The code then advances coordination to `Validating`, but the peer cannot process the unfinished PATH_CHALLENGE, so coordinated NAT traversal stalls.

### Issue 3
src/connection/pqc_mtu_regression_tests.rs:29
**Blanket Lint Suppression Added**

This new module-wide `allow` suppresses `unwrap_used` and `expect_used` warnings without an existing surrounding allowance. That violates the repository directive not to silence warnings with `#[allow(...)]` unless the surrounding code already does. This repository requirement must be satisfied before merging.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pqc): stop relying on IP fragmentati..."](https://github.com/saorsa-labs/ant-quic/commit/45d891deb87a8167c6f8feb585cf556badb157b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60724630)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/saorsa-labs/ant-quic/blob/master/AGENTS.md))

<!-- /greptile_comment -->