### PR TITLE
feat(node): preserve receive connection generations for x0x #517

### DIFF
--- a/src/bounded_pending_buffer.rs
+++ b/src/bounded_pending_buffer.rs
@@ -19,6 +19,7 @@ use crate::nat_traversal_api::PeerId;
 #[derive(Debug)]
 struct PendingEntry {
     data: Vec<u8>,
+    generation: u64,
     created_at: Instant,
 }
 
@@ -70,6 +71,20 @@ impl BoundedPendingBuffer {
 
     /// Push data for a peer, dropping oldest if limits exceeded
     pub fn push(&mut self, peer_id: &PeerId, data: Vec<u8>) -> Result<(), PendingBufferError> {
+        self.push_with_generation(
+            peer_id,
+            crate::nat_traversal_api::UNAUTHENTICATED_GENERATION,
+            data,
+        )
+    }
+
+    /// Buffer provenance at insertion, before any authentication or reconnect can finish.
+    pub(crate) fn push_with_generation(
+        &mut self,
+        peer_id: &PeerId,
+        generation: u64,
+        data: Vec<u8>,
+    ) -> Result<(), PendingBufferError> {
         let data_len = data.len();
 
         // Reject single messages larger than limit
@@ -97,6 +112,7 @@ impl BoundedPendingBuffer {
         // Add new entry
         peer_data.entries.push_back(PendingEntry {
             data,
+            generation,
             created_at: Instant::now(),
         });
         peer_data.total_bytes += data_len;
@@ -106,6 +122,10 @@ impl BoundedPendingBuffer {
 
     /// Pop the oldest pending data for a peer
     pub fn pop(&mut self, peer_id: &PeerId) -> Option<Vec<u8>> {
+        self.pop_with_generation(peer_id).map(|(_, data)| data)
+    }
+
+    fn pop_with_generation(&mut self, peer_id: &PeerId) -> Option<(u64, Vec<u8>)> {
         let peer_data = self.data.get_mut(peer_id)?;
         let entry = peer_data.entries.pop_front()?;
         peer_data.total_bytes = peer_data.total_bytes.saturating_sub(entry.data.len());
@@ -115,7 +135,7 @@ impl BoundedPendingBuffer {
             self.data.remove(peer_id);
         }
 
-        Some(entry.data)
+        Some((entry.generation, entry.data))
     }
 
     /// Pop oldest data from any peer (returns peer_id and data)
@@ -124,6 +144,13 @@ impl BoundedPendingBuffer {
         let peer_id = *self.data.keys().next()?;
         let data = self.pop(&peer_id)?;
         Some((peer_id, data))
+    }
+
+    /// Pop data without losing the connection generation captured at insertion.
+    pub(crate) fn pop_any_with_generation(&mut self) -> Option<(PeerId, u64, Vec<u8>)> {
+        let peer_id = *self.data.keys().next()?;
+        let (generation, data) = self.pop_with_generation(&peer_id)?;
+        Some((peer_id, generation, data))
     }
 
     /// Peek at the oldest entry without removing

--- a/src/diagnostics/gso.rs
+++ b/src/diagnostics/gso.rs
@@ -37,8 +37,8 @@
 //!
 //! ant-quic's [`crate::high_level::runtime::UdpSender`] trait defaults
 //! `max_transmit_segments()` to `1`, and the in-tree implementations
-//! ([`crate::high_level::runtime::tokio::TokioRuntime`]'s `UdpSocket` and
-//! [`crate::high_level::runtime::dual_stack::DualStackSocket`]) both use
+//! ([`crate::high_level::TokioRuntime`]'s `UdpSocket` and
+//! `crate::high_level::runtime::dual_stack::DualStackSocket`) both use
 //! `try_send_to(transmit.contents, destination)` rather than
 //! `quinn_udp::UdpSocketState::send`. As a consequence:
 //!

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -11,7 +11,7 @@
 //! the higher-level [`crate::p2p_endpoint::P2pEndpoint`] and [`crate::Node`]
 //! re-export via accessor methods. The counters are intentionally global
 //! rather than per-endpoint: every concrete UDP send path in ant-quic ends
-//! up funnelled through the same low-level [`crate::high_level::connection`]
+//! up funnelled through the same low-level `crate::high_level::connection`
 //! `drive_transmit` loop, and the actual GSO bundling (when enabled) is a
 //! kernel-side concern rather than an endpoint-scoped one. Surfacing them
 //! globally keeps the instrumentation hook one-line at the call site and

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -35,6 +35,21 @@ use crate::transport::TransportRegistry;
 
 use crate::SHUTDOWN_DRAIN_TIMEOUT;
 
+/// Reserved receive provenance for data without a proven live connection.
+pub(crate) const UNAUTHENTICATED_GENERATION: u64 = u64::MAX;
+
+// Shared by every endpoint in this process, including endpoints created after shutdown.
+static CONNECTION_GENERATIONS: std::sync::LazyLock<Arc<AtomicU64>> =
+    std::sync::LazyLock::new(|| Arc::new(AtomicU64::new(1)));
+
+fn allocate_connection_generation(counter: &AtomicU64) -> Option<u64> {
+    counter
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |next| {
+            (next < UNAUTHENTICATED_GENERATION).then(|| next + 1)
+        })
+        .ok()
+}
+
 /// Creates a bind address that allows the OS to select a random available port
 ///
 /// This provides protocol obfuscation by preventing port fingerprinting, which improves
@@ -805,6 +820,7 @@ pub struct PeerId(pub [u8; 32]);
 pub(crate) struct IncomingAckBidiStream {
     pub(crate) peer_id: PeerId,
     pub(crate) conn_stable_id: usize,
+    pub(crate) generation: u64,
     pub(crate) send: InnerSendStream,
     pub(crate) recv: InnerRecvStream,
     pub(crate) prefix: Vec<u8>,
@@ -1915,7 +1931,7 @@ impl NatTraversalEndpoint {
             connection_lifecycle: Arc::new(ParkingRwLock::new(HashMap::new())),
             reader_liveness_probe: ParkingRwLock::new(None),
             orphan_connections_closed: std::sync::atomic::AtomicU64::new(0),
-            next_connection_generation: Arc::new(AtomicU64::new(1)),
+            next_connection_generation: Arc::clone(&CONNECTION_GENERATIONS),
             local_peer_id: Self::generate_local_peer_id(),
             timeout_config: config.timeouts.clone(),
             emitted_established_events: emitted_established_events.clone(),
@@ -2427,7 +2443,7 @@ impl NatTraversalEndpoint {
             connection_lifecycle: Arc::new(ParkingRwLock::new(HashMap::new())),
             reader_liveness_probe: ParkingRwLock::new(None),
             orphan_connections_closed: std::sync::atomic::AtomicU64::new(0),
-            next_connection_generation: Arc::new(AtomicU64::new(1)),
+            next_connection_generation: Arc::clone(&CONNECTION_GENERATIONS),
             local_peer_id: Self::generate_local_peer_id(),
             timeout_config: config.timeouts.clone(),
             emitted_established_events: emitted_established_events.clone(),
@@ -5467,6 +5483,7 @@ impl NatTraversalEndpoint {
                                     tokio::spawn(async move {
                                         Self::handle_relay_requests(
                                             peer_id,
+                                            generation,
                                             conn_clone,
                                             server_clone,
                                             ack_bidi_stream_tx,
@@ -5663,6 +5680,7 @@ impl NatTraversalEndpoint {
 
     async fn handle_relay_requests(
         peer_id: PeerId,
+        generation: u64,
         connection: InnerConnection,
         relay_server: Arc<MasqueRelayServer>,
         ack_bidi_stream_tx: Arc<
@@ -5692,6 +5710,7 @@ impl NatTraversalEndpoint {
                         if prefix.as_slice() == &ACK_BIDI_REQUEST_MAGIC[..] {
                             let stream = IncomingAckBidiStream {
                                 peer_id,
+                                generation,
                                 conn_stable_id,
                                 send: send_stream,
                                 recv: recv_stream,
@@ -6958,7 +6977,14 @@ impl NatTraversalEndpoint {
         peer_id: PeerId,
         connection: InnerConnection,
     ) -> ConnectionRegistrationOutcome {
-        let generation = next_connection_generation.fetch_add(1, Ordering::Relaxed);
+        let Some(generation) = allocate_connection_generation(next_connection_generation) else {
+            // Exhaustion is terminal for allocation: never wrap or issue the stale sentinel.
+            connection.close(VarInt::from_u32(0), b"connection generation exhausted");
+            tracing::error!("connection generation namespace exhausted");
+            return ConnectionRegistrationOutcome::Rejected {
+                winner_generation: UNAUTHENTICATED_GENERATION,
+            };
+        };
         let tracked = TrackedConnection {
             connection: connection.clone(),
             generation,
@@ -7069,6 +7095,19 @@ impl NatTraversalEndpoint {
             })
     }
 
+    pub(crate) fn current_connection_generation(&self, peer_id: &PeerId) -> Option<u64> {
+        self.connection_lifecycle
+            .read()
+            .get(peer_id)?
+            .iter()
+            .filter(|entry| {
+                matches!(entry.state, ConnectionLifecycleState::Live)
+                    && entry.connection.close_reason().is_none()
+            })
+            .map(|entry| entry.generation)
+            .max()
+    }
+
     pub(crate) fn connection_snapshot_by_stable_id(
         &self,
         peer_id: &PeerId,
@@ -7077,7 +7116,14 @@ impl NatTraversalEndpoint {
         self.connection_lifecycle
             .read()
             .get(peer_id)
-            .and_then(|entries| entries.iter().find(|entry| entry.stable_id() == stable_id))
+            .and_then(|entries| {
+                // Retired registrations can share a reused underlying stable_id.
+                // Reader setup must bind to the newest registration of that handle.
+                entries
+                    .iter()
+                    .filter(|entry| entry.stable_id() == stable_id)
+                    .max_by_key(|entry| entry.generation)
+            })
             .map(|entry| ConnectionLifecycleSnapshot {
                 generation: entry.generation,
                 stable_id: entry.stable_id(),
@@ -13463,6 +13509,76 @@ mod tests {
             .expect("loopback handshake must not hang")
             .expect("loopback handshake must succeed");
         (server, client, conn)
+    }
+
+    #[test]
+    fn receive_generation_allocation_is_monotonic_and_never_wraps() {
+        let counter = AtomicU64::new(1);
+        assert_eq!(allocate_connection_generation(&counter), Some(1));
+        assert_eq!(allocate_connection_generation(&counter), Some(2));
+        let exhausted = AtomicU64::new(u64::MAX - 1);
+        assert_eq!(
+            allocate_connection_generation(&exhausted),
+            Some(u64::MAX - 1)
+        );
+        assert_eq!(allocate_connection_generation(&exhausted), None);
+        assert_eq!(allocate_connection_generation(&exhausted), None);
+        assert_eq!(exhausted.load(Ordering::Relaxed), u64::MAX);
+    }
+
+    #[tokio::test]
+    async fn receive_generation_reused_stable_id_uses_new_registration() {
+        let (_server, client, connection) = loopback_quic_connection().await;
+        let peer = PeerId([0x51; 32]);
+        let register = || {
+            NatTraversalEndpoint::register_connection_lifecycle_parts(
+                client.local_peer_id,
+                &client.connections,
+                &client.connection_lifecycle,
+                &client.next_connection_generation,
+                &client.emitted_established_events,
+                peer,
+                connection.clone(),
+            )
+        };
+        let first = register();
+        let ConnectionRegistrationOutcome::Live {
+            generation: old, ..
+        } = first
+        else {
+            assert!(matches!(first, ConnectionRegistrationOutcome::Live { .. }));
+            return;
+        };
+        // Model allocator pointer/stable_id reuse after retirement without relying
+        // on a platform allocator to recycle a real connection allocation.
+        client.connection_lifecycle.write().get_mut(&peer).unwrap()[0].state =
+            ConnectionLifecycleState::Closed {
+                reason: ConnectionCloseReason::LocallyClosed,
+                closed_at_unix_ms: now_unix_ms(),
+            };
+        let replacement = register();
+        assert!(matches!(
+            replacement,
+            ConnectionRegistrationOutcome::Live { .. }
+        ));
+        let ConnectionRegistrationOutcome::Live {
+            generation: new, ..
+        } = replacement
+        else {
+            return;
+        };
+        assert!(new > old);
+        assert_eq!(
+            client
+                .connection_snapshot_by_stable_id(&peer, connection.stable_id())
+                .map(|snapshot| snapshot.generation),
+            Some(new)
+        );
+        assert_eq!(client.current_connection_generation(&peer), Some(new));
+        assert!(Arc::ptr_eq(
+            &client.next_connection_generation,
+            &CONNECTION_GENERATIONS
+        ));
     }
 
     /// Seed a single tracked generation for `peer_id` directly into the

--- a/src/node.rs
+++ b/src/node.rs
@@ -722,7 +722,7 @@ impl Node {
             .map_err(NodeError::Endpoint)
     }
 
-    /// Same as [`send_with_receive_ack`] but the caller supplies the ACK-v2
+    /// Same as [`Self::send_with_receive_ack`] but the caller supplies the ACK-v2
     /// request id. Repeated calls with the same `(peer_id, request_id, data)`
     /// are duplicate-safe at the receiver — the second arrival is replayed
     /// from the receiver-side ACK dedupe cache and the payload is not
@@ -788,6 +788,26 @@ impl Node {
     /// Receive data from any peer
     pub async fn recv(&self) -> Result<(PeerId, Vec<u8>), NodeError> {
         self.inner.recv().await.map_err(NodeError::Endpoint)
+    }
+
+    /// Receive data with the process-local generation of the connection that read it.
+    ///
+    /// Shares a queue with [`Self::recv`]. A reconnect does not change the stamp
+    /// on queued bytes. `u64::MAX` denotes stale pre-authentication data or data
+    /// without proven QUIC lifecycle provenance and must not authorize a session.
+    pub async fn recv_with_generation(&self) -> Result<(PeerId, u64, Vec<u8>), NodeError> {
+        self.inner
+            .recv_with_generation()
+            .await
+            .map_err(NodeError::Endpoint)
+    }
+
+    /// Generation of the currently live, open QUIC connection for `peer`, if any.
+    ///
+    /// Generations share the namespace returned by [`Self::recv_with_generation`].
+    /// This snapshot must not be used to stamp previously received data.
+    pub fn current_connection_generation(&self, peer: &PeerId) -> Option<u64> {
+        self.inner.current_connection_generation(peer)
     }
 
     // === Application byte-streams ============================================

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -87,6 +87,7 @@ use crate::crypto::raw_public_keys::key_utils::{
 use crate::happy_eyeballs::{self, HappyEyeballsConfig};
 use crate::mdns::{MdnsPeerRecord, MdnsRuntimeEvent, MdnsSnapshot, spawn_mdns_runtime};
 pub use crate::nat_traversal_api::TraversalPhase;
+use crate::nat_traversal_api::UNAUTHENTICATED_GENERATION;
 use crate::nat_traversal_api::{
     ConstrainedEventWithAddr, IncomingAckBidiStream, NatTraversalEndpoint, NatTraversalError,
     NatTraversalEvent, PeerId, TraversalFailureReason,
@@ -827,10 +828,10 @@ pub struct P2pEndpoint {
     direct_path_statuses: Arc<ParkingRwLock<HashMap<PeerId, DirectPathStatus>>>,
 
     /// Channel sender for data received from QUIC reader tasks and constrained poller
-    data_tx: mpsc::Sender<(PeerId, Vec<u8>)>,
+    data_tx: mpsc::Sender<(PeerId, u64, Vec<u8>)>,
 
     /// Channel receiver for data received from QUIC reader tasks and constrained poller
-    data_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(PeerId, Vec<u8>)>>>,
+    data_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(PeerId, u64, Vec<u8>)>>>,
 
     /// Configured `data_tx` capacity (preserved for diagnostics; the
     /// `mpsc::Sender` only exposes remaining free slots).
@@ -3338,6 +3339,7 @@ impl P2pEndpoint {
                             let Some(IncomingAckBidiStream {
                                 peer_id,
                                 conn_stable_id,
+                                generation,
                                 send,
                                 recv,
                                 prefix,
@@ -3356,6 +3358,7 @@ impl P2pEndpoint {
                                 &event_tx,
                                 peer_id,
                                 conn_stable_id,
+                                generation,
                                 send,
                                 recv,
                                 prefix,
@@ -6225,7 +6228,7 @@ impl P2pEndpoint {
         ack_request_dedupe: &Arc<AckRequestDedupeCache>,
         connected_peers: &Arc<RwLock<HashMap<PeerId, PeerConnection>>>,
         peer_activity: &Arc<RwLock<HashMap<PeerId, PeerActivityRecord>>>,
-        data_tx: &mpsc::Sender<(PeerId, Vec<u8>)>,
+        data_tx: &mpsc::Sender<(PeerId, u64, Vec<u8>)>,
         data_tx_diagnostics: &DataChannelDiagnostics,
         data_tx_capacity: usize,
         event_tx: &broadcast::Sender<P2pEvent>,
@@ -6238,6 +6241,7 @@ impl P2pEndpoint {
         connection: &crate::high_level::Connection,
         peer_id: PeerId,
         conn_stable_id: usize,
+        generation: u64,
         mut send: crate::high_level::SendStream,
         mut recv: crate::high_level::RecvStream,
         max_read_bytes: usize,
@@ -6287,6 +6291,7 @@ impl P2pEndpoint {
                 &event_tx,
                 peer_id,
                 conn_stable_id,
+                generation,
                 send,
                 recv,
                 prefix,
@@ -6363,12 +6368,13 @@ impl P2pEndpoint {
         ack_request_dedupe: &AckRequestDedupeCache,
         connected_peers: &Arc<RwLock<HashMap<PeerId, PeerConnection>>>,
         peer_activity: &Arc<RwLock<HashMap<PeerId, PeerActivityRecord>>>,
-        data_tx: &mpsc::Sender<(PeerId, Vec<u8>)>,
+        data_tx: &mpsc::Sender<(PeerId, u64, Vec<u8>)>,
         data_tx_diagnostics: &DataChannelDiagnostics,
         data_tx_capacity: usize,
         event_tx: &broadcast::Sender<P2pEvent>,
         peer_id: PeerId,
         conn_stable_id: usize,
+        generation: u64,
         send: crate::high_level::SendStream,
         mut recv: crate::high_level::RecvStream,
         prefix: Vec<u8>,
@@ -6492,6 +6498,7 @@ impl P2pEndpoint {
             data_tx_diagnostics,
             data_tx_capacity,
             peer_id,
+            generation,
             payload.to_vec(),
         )
         .await;
@@ -6585,10 +6592,11 @@ impl P2pEndpoint {
     }
 
     async fn admit_ack_requested_payload(
-        data_tx: &mpsc::Sender<(PeerId, Vec<u8>)>,
+        data_tx: &mpsc::Sender<(PeerId, u64, Vec<u8>)>,
         data_tx_diagnostics: &DataChannelDiagnostics,
         data_tx_capacity: usize,
         peer_id: PeerId,
+        generation: u64,
         payload: Vec<u8>,
     ) -> Result<(), ReceiveRejectReason> {
         // Sample channel pressure pre-reserve so high-water events are
@@ -6596,7 +6604,7 @@ impl P2pEndpoint {
         data_tx_diagnostics.observe_capacity(data_tx.capacity(), data_tx_capacity);
         match timeout(ACK_RECEIVE_ADMISSION_TIMEOUT, data_tx.reserve()).await {
             Ok(Ok(permit)) => {
-                permit.send((peer_id, payload));
+                permit.send((peer_id, generation, payload));
                 Ok(())
             }
             Ok(Err(_closed)) => Err(ReceiveRejectReason::ConsumerGone),
@@ -7151,7 +7159,7 @@ impl P2pEndpoint {
     ///
     /// Generates a fresh request id and delegates to
     /// [`P2pEndpoint::send_with_receive_ack_with_request_id`]. Callers that need
-    /// to issue more than one [`send_with_receive_ack`] for the same logical
+    /// to issue more than one [`Self::send_with_receive_ack`] for the same logical
     /// payload — e.g. application-level request hedging — should use the
     /// `_with_request_id` variant directly and supply the same id to every call
     /// so the receiver dedupes the duplicates instead of delivering them twice.
@@ -7167,10 +7175,10 @@ impl P2pEndpoint {
             .await
     }
 
-    /// Same contract as [`send_with_receive_ack`] but the caller supplies the
+    /// Same contract as [`Self::send_with_receive_ack`] but the caller supplies the
     /// ACK-v2 request id. Two calls with the same `(peer_id, request_id, data)`
     /// are duplicate-safe at the receiver: the second arrival is replayed from
-    /// the receiver-side [`AckRequestDedupeCache`], the cached ACK is returned
+    /// the receiver-side `AckRequestDedupeCache`, the cached ACK is returned
     /// on the wire, and the payload is **not** redelivered to `recv()`.
     ///
     /// Intended for application-level request hedging (x0x X0X-0066): the caller
@@ -7894,6 +7902,19 @@ impl P2pEndpoint {
     ///
     /// Returns `EndpointError::ShuttingDown` if the endpoint is shutting down.
     pub async fn recv(&self) -> Result<(PeerId, Vec<u8>), EndpointError> {
+        self.recv_with_generation()
+            .await
+            .map(|(peer, _, data)| (peer, data))
+    }
+
+    /// Receive data with the process-local generation captured by its connection reader.
+    ///
+    /// Shares a queue with [`Self::recv`]; each message is consumed exactly once.
+    /// `u64::MAX` means stale pre-authentication data or unproven provenance (including
+    /// constrained transports). It is never allocated to a tracked QUIC connection.
+    /// A queued generation can be older than [`Self::current_connection_generation`].
+    /// Returns [`EndpointError::ShuttingDown`] when the endpoint shuts down.
+    pub async fn recv_with_generation(&self) -> Result<(PeerId, u64, Vec<u8>), EndpointError> {
         if self.shutdown.is_cancelled() {
             return Err(EndpointError::ShuttingDown);
         }
@@ -7903,7 +7924,15 @@ impl P2pEndpoint {
             let mut pending = self.pending_data.write().await;
             pending.cleanup_expired();
 
-            if let Some((peer_id, data)) = pending.pop_any() {
+            if let Some((peer_id, generation, data)) = pending.pop_any_with_generation() {
+                // Only invalidate the insertion-time stamp; never upgrade old bytes
+                // to a new session by looking up its generation after dequeue.
+                let generation = if self.current_connection_generation(&peer_id) == Some(generation)
+                {
+                    generation
+                } else {
+                    UNAUTHENTICATED_GENERATION
+                };
                 let data_len = data.len();
                 tracing::trace!(
                     "Received {} bytes from peer {:?} (from pending buffer)",
@@ -7936,7 +7965,7 @@ impl P2pEndpoint {
                     );
                 }
 
-                return Ok((peer_id, data));
+                return Ok((peer_id, generation, data));
             }
         }
 
@@ -7950,6 +7979,12 @@ impl P2pEndpoint {
             },
             _ = self.shutdown.cancelled() => Err(EndpointError::ShuttingDown),
         }
+    }
+
+    /// Generation of the currently live, open QUIC connection, if one is tracked.
+    /// This is a snapshot, not provenance for data returned by [`Self::recv`].
+    pub fn current_connection_generation(&self, peer: &PeerId) -> Option<u64> {
+        self.inner.current_connection_generation(peer)
     }
 
     // === Application byte-streams ============================================
@@ -9294,6 +9329,11 @@ impl P2pEndpoint {
         let generation = lifecycle_snapshot
             .map(|snapshot| snapshot.generation)
             .unwrap_or(conn_stable_id as u64);
+        // Keep receive provenance separate from the reader-management fallback
+        // stable_id: only a lifecycle allocation can identify authenticated data.
+        let recv_generation = lifecycle_snapshot
+            .map(|snapshot| snapshot.generation)
+            .unwrap_or(UNAUTHENTICATED_GENERATION);
         let cancel = CancellationToken::new();
         if let Some(snapshot) = lifecycle_snapshot {
             debug!(
@@ -9395,6 +9435,7 @@ impl P2pEndpoint {
                             &connection,
                             peer_id,
                             conn_stable_id,
+                            recv_generation,
                             send,
                             recv,
                             max_read_bytes,
@@ -9609,7 +9650,7 @@ impl P2pEndpoint {
             // counters even when the eventual `send().await` succeeds
             // after a brief block (X0X-0039).
             data_tx_diagnostics.observe_capacity(data_tx.capacity(), data_tx_capacity);
-            if data_tx.send((peer_id, payload)).await.is_err() {
+            if data_tx.send((peer_id, recv_generation, payload)).await.is_err() {
                 debug!(
                     "Reader task for peer {:?}: channel closed, exiting",
                     peer_id
@@ -9882,7 +9923,11 @@ impl P2pEndpoint {
                         // events on the constrained ingress path are visible
                         // alongside the QUIC reader-task path (X0X-0039).
                         data_tx_diagnostics.observe_capacity(data_tx.capacity(), data_tx_capacity);
-                        if data_tx.send((peer_id, data)).await.is_err() {
+                        if data_tx
+                            .send((peer_id, UNAUTHENTICATED_GENERATION, data))
+                            .await
+                            .is_err()
+                        {
                             debug!("Constrained poller: channel closed, exiting");
                             break;
                         }
@@ -10469,6 +10514,75 @@ mod tests {
     #[cfg(all(test, feature = "network-discovery"))]
     use crate::nat_traversal_api::tracked_connection_for_test;
 
+    #[cfg(feature = "network-discovery")]
+    #[tokio::test]
+    async fn recv_generation_pending_data_reconnect_invalidates_old_stamp() {
+        let (a, b, _connection) = loopback_quic_pair().await;
+        let peer = b.peer_id();
+        let old = a
+            .current_connection_generation(&peer)
+            .expect("live generation");
+        a.pending_data
+            .write()
+            .await
+            .push_with_generation(&peer, old, b"pre-auth".to_vec())
+            .expect("buffer");
+        a.disconnect(&peer).await.expect("disconnect");
+        // The first close may already have reached the remote reader.
+        assert!(matches!(
+            b.disconnect(&a.peer_id()).await,
+            Ok(()) | Err(EndpointError::PeerNotFound(_))
+        ));
+        assert_eq!(a.current_connection_generation(&peer), None);
+        tokio::time::timeout(Duration::from_secs(10), a.connect_addr(shim_addr(&b)))
+            .await
+            .expect("reconnect timeout")
+            .expect("reconnect");
+        let new = a
+            .current_connection_generation(&peer)
+            .expect("new live generation");
+        assert!(new > old);
+        let (sender, generation, data) = a.recv_with_generation().await.expect("drain");
+        assert_eq!(sender, peer);
+        assert_eq!(data, b"pre-auth");
+        assert_eq!(generation, UNAUTHENTICATED_GENERATION);
+        assert_ne!(
+            Some(generation),
+            a.current_connection_generation(&peer),
+            "stale pre-auth bytes cannot match a live session for legacy admission"
+        );
+        a.pending_data
+            .write()
+            .await
+            .push_with_generation(&peer, new, b"current".to_vec())
+            .expect("buffer current");
+        assert_eq!(
+            a.recv_with_generation().await.expect("current drain"),
+            (peer, new, b"current".to_vec())
+        );
+        a.pending_data
+            .write()
+            .await
+            .push(&peer, b"unproven".to_vec())
+            .expect("legacy insertion");
+        assert_eq!(
+            a.recv_with_generation().await.expect("unproven drain").1,
+            UNAUTHENTICATED_GENERATION
+        );
+        a.disconnect(&peer).await.expect("disconnect");
+        a.pending_data
+            .write()
+            .await
+            .push_with_generation(&peer, new, vec![1])
+            .expect("buffer closed");
+        assert_eq!(
+            a.recv_with_generation().await.expect("closed drain").1,
+            UNAUTHENTICATED_GENERATION
+        );
+        let _ = a.shutdown().await;
+        let _ = b.shutdown().await;
+    }
+
     fn collect_broadcast_events(
         events: &mut tokio::sync::broadcast::Receiver<P2pEvent>,
     ) -> Vec<P2pEvent> {
@@ -10506,14 +10620,22 @@ mod tests {
         // payload fills the queue; the second reserve cannot complete in
         // ACK_RECEIVE_ADMISSION_TIMEOUT and increments high_water_count.
         let capacity = 1usize;
-        let (tx, _rx) = mpsc::channel::<(PeerId, Vec<u8>)>(capacity);
+        let (tx, _rx) = mpsc::channel::<(PeerId, u64, Vec<u8>)>(capacity);
         let diags = DataChannelDiagnostics::default();
         let peer_id = PeerId([0x33; 32]);
         // Pre-fill so the next reserve must wait.
-        tx.send((peer_id, vec![0u8; 8])).await.expect("first send");
-        let admission =
-            P2pEndpoint::admit_ack_requested_payload(&tx, &diags, capacity, peer_id, vec![1u8; 8])
-                .await;
+        tx.send((peer_id, 1, vec![0u8; 8]))
+            .await
+            .expect("first send");
+        let admission = P2pEndpoint::admit_ack_requested_payload(
+            &tx,
+            &diags,
+            capacity,
+            peer_id,
+            1,
+            vec![1u8; 8],
+        )
+        .await;
         assert!(matches!(admission, Err(ReceiveRejectReason::Backpressured)));
         assert!(
             diags.high_water_count() >= 1,

--- a/tests/node_recv_generation.rs
+++ b/tests/node_recv_generation.rs
@@ -1,0 +1,123 @@
+//! Receive provenance must survive queueing and reconnects through the public Node API.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use ant_quic::{Node, NodeConfig, bootstrap_cache::BootstrapCacheConfig};
+use std::{net::SocketAddr, time::Duration};
+use tokio::time::timeout;
+
+const DEADLINE: Duration = Duration::from_secs(10);
+
+async fn node() -> Node {
+    Node::with_config(
+        NodeConfig::builder()
+            .bind_addr("127.0.0.1:0".parse::<SocketAddr>().expect("loopback"))
+            .mdns_enabled(false)
+            .bootstrap_cache(BootstrapCacheConfig::builder().persist(false).build())
+            .build(),
+    )
+    .await
+    .expect("node")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn recv_generation_survives_queued_reconnect_and_recv_stays_compatible() {
+    let sender = node().await;
+    let receiver = node().await;
+    let sender_id = sender.peer_id();
+    let receiver_id = receiver.peer_id();
+    // Dual-stack sockets can report [::] even when configured with IPv4 loopback.
+    let bound = receiver.local_addr().expect("receiver address");
+    let addr = SocketAddr::from(([127, 0, 0, 1], bound.port()));
+    let accept = {
+        let receiver = receiver.clone();
+        tokio::spawn(async move { while receiver.accept().await.is_some() {} })
+    };
+    assert_eq!(receiver.current_connection_generation(&sender_id), None);
+    timeout(DEADLINE, sender.connect_addr(addr))
+        .await
+        .expect("connect timeout")
+        .expect("connect");
+    sender
+        .send(&receiver_id, b"old uni")
+        .await
+        .expect("uni send");
+    timeout(DEADLINE, async {
+        while receiver.data_channel_diagnostics().data_tx_depth != 1 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("old frame queued before reconnect");
+    let old = receiver
+        .current_connection_generation(&sender_id)
+        .expect("old generation");
+    assert_ne!(old, u64::MAX);
+    // Endpoint instances allocate from the same process-wide namespace.
+    assert_ne!(
+        sender.current_connection_generation(&receiver_id),
+        Some(old)
+    );
+
+    let mut previous = old;
+    for cycle in 0..3 {
+        sender
+            .disconnect(&receiver_id)
+            .await
+            .expect("disconnect sender");
+        // The sender's close may have already removed the remote peer.
+        assert!(matches!(
+            receiver.disconnect(&sender_id).await,
+            Ok(())
+                | Err(ant_quic::NodeError::Endpoint(
+                    ant_quic::EndpointError::PeerNotFound(_)
+                ))
+        ));
+        assert_eq!(receiver.current_connection_generation(&sender_id), None);
+        timeout(DEADLINE, sender.connect_addr(addr))
+            .await
+            .expect("reconnect timeout")
+            .expect("reconnect");
+        sender
+            .send_with_receive_ack(&receiver_id, b"new ack", DEADLINE)
+            .await
+            .expect("ACK admission");
+        let current = receiver
+            .current_connection_generation(&sender_id)
+            .expect("current generation");
+        assert!(current > previous);
+        previous = current;
+        if cycle == 0 {
+            assert_eq!(
+                timeout(DEADLINE, receiver.recv_with_generation())
+                    .await
+                    .expect("old recv timeout")
+                    .expect("old recv"),
+                (sender_id, old, b"old uni".to_vec()),
+                "dequeue must not relabel the old reader's bytes"
+            );
+        }
+        assert_eq!(
+            timeout(DEADLINE, receiver.recv_with_generation())
+                .await
+                .expect("ack recv timeout")
+                .expect("ack recv"),
+            (sender_id, current, b"new ack".to_vec())
+        );
+    }
+    sender
+        .send(&receiver_id, b"compatible")
+        .await
+        .expect("send");
+    assert_eq!(
+        timeout(DEADLINE, receiver.recv())
+            .await
+            .expect("recv timeout")
+            .expect("recv"),
+        (sender_id, b"compatible".to_vec())
+    );
+    receiver.clone().shutdown().await;
+    assert_eq!(receiver.current_connection_generation(&sender_id), None);
+    assert!(receiver.recv_with_generation().await.is_err());
+    sender.shutdown().await;
+    accept.abort();
+}


### PR DESCRIPTION
Queued messages currently lose the connection generation before `Node::recv()` returns. A consumer that looks up the live session after a reconnect can therefore attribute old bytes to a new session. This implements the ant-quic portion of ADR-0063 §3.2 for saorsa-labs/x0x#517.

- Add `Node::recv_with_generation() -> Result<(PeerId, u64, Vec<u8>), NodeError>` and `current_connection_generation(&PeerId) -> Option<u64>`, with matching P2pEndpoint methods. Existing `recv()` signatures remain unchanged and discard the queued stamp.
- Capture the reader's lifecycle generation before receiving and retain it through uni-stream delivery, ACK-v2 admission, and the NAT relay ACK bridge. Use a shared process-wide monotonic allocator that never wraps or allocates `u64::MAX`; resolve reused stable IDs to the newest registration.
- Store pre-auth buffer provenance at insertion. Drains retain a current stamp or invalidate it to `u64::MAX`; they never substitute the live generation. This base has no production `pending_data` insertion sites. The existing buffer insertion API and constrained transports without proven QUIC lifecycle provenance use the reserved unauthenticated value.

Seven existing broken/private rustdoc links in the receive and diagnostics documentation are corrected so the warnings-denied documentation gate can pass.

Validation: formatting; all-feature/all-target Clippy with warnings denied; production panic/unwrap/expect denies; the repository's stricter all-target panic-safety Clippy command; workspace/all-target compilation; generation and bounded-buffer unit tests; public Node receive/reconnect integration test; rustdoc with warnings denied. The integration test preserves queued old uni-stream bytes across reconnect, checks ACK-v2 generation on three same-endpoint reconnects, and exercises unchanged `recv()` and shutdown. The pre-auth test proves stale provenance cannot equal a live session; downstream gossip admission remains the consumer integration gate.

G1 implementation only. Draft for review; the design's published-release exit criterion remains unmet. No dependency bumps, merge, release, tag, deployment, or x0x enablement. Independent of ant-quic PR #271's PATH_RESPONSE/PATH_CHALLENGE work.
