### PR TITLE
chore(release): prepare ant-quic 0.27.49 (post-#271 RFC 9000 §14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.49] - 2026-09-06
+
 ### Fixed
 
 - **RFC 9000 §14 compliance: PQC handshakes no longer rely on IP fragmentation (#270, x0x#505).**
@@ -23,9 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path MTU. PQ handshake volume continues to flow as multiple ≤MTU datagrams of split CRYPTO
   frames; the server's first flight was ~95% padding, not key material. Regression tests drive
   a full PQC handshake through the low-level state machines and assert every transmit fits
-  1200 bytes (fails on the pre-fix code with three 4096-byte datagrams).
-
-
+  1200 bytes (fails on the pre-fix code with three 4096-byte datagrams). Merged as #271
+  (`c3ca46adef666e83750ec4bae160deb8c5b61094`), including PATH_RESPONSE token echo and
+  PATH_CHALLENGE finalize/encrypt repairs before merge.
 
 ## [0.27.48] - 2026-09-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.48"
+version = "0.27.49"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.48"
+version = "0.27.49"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump `0.27.48` → `0.27.49` on tip containing merge `c3ca46ad` (#271).
- Changelog promotes Unreleased RFC 9000 §14 / x0x#505 fix notes.
- David auth 2026-09-06: real crates.io publish OK once CI green.
- **Does not** auto-bump x0x #515/#517; consume is a separate draft after crates.io.

## Test plan
- [ ] Four ordered gates exit 0 (fmt apply, clippy-all, clippy-production, check)
- [ ] `cargo publish --dry-run` exit 0
- [ ] Required CI green on this PR
- [ ] Real `cargo publish` only after CI green (Developer seat)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This release-preparation PR consistently advances ant-quic from 0.27.48 to 0.27.49 and promotes the RFC 9000 §14 fix notes into a dated changelog section.
- Keeps Cargo.toml and Cargo.lock package versions aligned.
- Records the PQC handshake datagram-sizing fix and associated path-validation repairs.
- Introduces no source-code, dependency-version, feature, or runtime-behavior changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because its release metadata is internally consistent and introduces no behavioral or dependency changes.

No actionable failures remain: the manifest, lockfile, and changelog agree on version 0.27.49, and the flagged unmaintained dependencies predate this PR unchanged.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the published ant-quic package version to 0.27.49 with no dependency or feature changes. |
| Cargo.lock | Synchronizes the root ant-quic lockfile entry with the manifest version; all dependency entries remain unchanged. |
| CHANGELOG.md | Adds the dated 0.27.49 release section and records the RFC 9000 §14 compliance fix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): prepare 0.27.49 publish ..."](https://github.com/saorsa-labs/ant-quic/commit/afaec336f54c77b67b4cda85e4b358455efaacc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60948052)</sub>

<!-- /greptile_comment -->