### PR TITLE
fix: honor explicit bind addresses without wildcard fallback

### DIFF
--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -11931,6 +11931,92 @@ mod tests {
         assert!(err.to_string().contains("not found"));
     }
 
+    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
+    fn explicit_bind_test_config(addr: SocketAddr, cache: &std::path::Path) -> P2pConfig {
+        P2pConfig::builder()
+            .bind_addr(addr)
+            .mdns_enabled(false)
+            .nat(crate::NatConfig {
+                enable_relay_fallback: false,
+                ..Default::default()
+            })
+            .port_mapping_enabled(false)
+            .bootstrap_cache(
+                BootstrapCacheConfig::builder()
+                    .cache_dir(cache)
+                    .persist(false)
+                    .build(),
+            )
+            .build()
+            .expect("isolated explicit-bind config")
+    }
+
+    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
+    #[tokio::test]
+    async fn explicit_bind_endpoint_reports_requested_ip_and_allocated_port() {
+        for ip in [
+            IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+        ] {
+            let cache = tempfile::tempdir().expect("private cache directory");
+            let requested = SocketAddr::new(ip, 0);
+            let endpoint = timeout(
+                Duration::from_secs(10),
+                P2pEndpoint::new(explicit_bind_test_config(requested, cache.path())),
+            )
+            .await
+            .expect("endpoint creation deadline")
+            .expect("loopback endpoint binds");
+            let actual = endpoint.local_addr().expect("bound socket address");
+            // An independent OS bind proves the reported nonzero port belongs
+            // to a live socket, rather than merely echoing the requested hint.
+            let conflict = std::net::UdpSocket::bind(actual).err().map(|e| e.kind());
+            endpoint.shutdown().await;
+            drop(endpoint);
+            assert_eq!(actual.ip(), requested.ip(), "explicit IP must be preserved");
+            assert_ne!(actual.port(), 0, "report the OS-allocated port");
+            assert_eq!(conflict, Some(std::io::ErrorKind::AddrInUse));
+        }
+    }
+
+    #[cfg(all(feature = "platform-verifier", feature = "network-discovery"))]
+    #[tokio::test]
+    async fn explicit_bind_endpoint_rejects_occupied_address_without_widening() {
+        for ip in [
+            IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+            IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
+        ] {
+            let cache = tempfile::tempdir().expect("private cache directory");
+            let sentinel = std::net::UdpSocket::bind(SocketAddr::new(ip, 0))
+                .expect("own the occupied loopback socket");
+            let requested = sentinel.local_addr().expect("sentinel address");
+            let result = timeout(
+                Duration::from_secs(10),
+                P2pEndpoint::new(explicit_bind_test_config(requested, cache.path())),
+            )
+            .await
+            .expect("occupied bind deadline");
+            let rejected_at_bind = match result {
+                Err(EndpointError::Config(message)) => {
+                    message.starts_with("Failed to bind UDP socket:")
+                }
+                Ok(endpoint) => {
+                    endpoint.shutdown().await;
+                    false
+                }
+                Err(_) => false,
+            };
+            assert!(
+                rejected_at_bind,
+                "occupied explicit address must fail at the socket bind"
+            );
+            assert_eq!(
+                sentinel.local_addr().expect("sentinel remains owned"),
+                requested
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_endpoint_creation() {
         // v0.13.0+: No role - all nodes are symmetric P2P nodes

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -49,6 +49,8 @@
 //! }
 //! ```
 
+mod socket_binding;
+
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
@@ -3080,27 +3082,27 @@ impl P2pEndpoint {
 
         use crate::high_level::runtime::AsyncUdpSocket;
 
-        // Socket strategy: try dual-socket (separate IPv4 + IPv6) first for maximum
-        // platform compatibility. Fall back to single-socket dual-stack, then IPv4 only.
-        let requested_port = config
+        // An explicit interface must be bound exactly. Wildcard and default
+        // configurations retain the dual-socket compatibility fallback ladder.
+        let requested_addr = config
             .bind_addr
             .as_ref()
-            .and_then(|addr| addr.as_socket_addr())
-            .map(|addr| addr.port())
-            .unwrap_or(0);
+            .and_then(|addr| addr.as_socket_addr());
 
         // Track DualStackSocket for local_addrs() API
         let mut _dual_stack_ref: Option<
             std::sync::Arc<crate::high_level::runtime::dual_stack::DualStackSocket>,
         > = None;
 
-        // Try dual-socket first (separate IPv4 + IPv6 sockets)
-        let mut inner = match crate::transport::UdpTransport::bind_dual_stack_for_endpoint(
-            requested_port,
+        let sockets = socket_binding::bind(
+            requested_addr,
+            crate::transport::UdpTransport::bind_dual_stack_for_endpoint,
+            crate::transport::UdpTransport::bind_for_quinn,
         )
         .await
-        {
-            Ok((_transport, dual_socket)) => {
+        .map_err(|e| EndpointError::Config(format!("Failed to bind UDP socket: {e}")))?;
+        let mut inner = match sockets {
+            socket_binding::BoundSocket::Dual((_transport, dual_socket)) => {
                 let (v4_addr, v6_addr) = dual_socket.local_addrs();
                 info!(
                     "Bound dual-socket: IPv4={}, IPv6={} (true dual-stack, separate sockets)",
@@ -3144,44 +3146,7 @@ impl P2pEndpoint {
                 .await
                 .map_err(|e| EndpointError::Config(e.to_string()))?
             }
-            Err(e) => {
-                // Fall back to single-socket approach
-                info!("Dual-socket failed ({e}), falling back to single-socket");
-
-                let dual_stack_default: std::net::SocketAddr = std::net::SocketAddr::new(
-                    std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED),
-                    requested_port,
-                );
-                let ipv4_fallback: std::net::SocketAddr = std::net::SocketAddr::new(
-                    std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
-                    requested_port,
-                );
-                let bind_addr = config
-                    .bind_addr
-                    .as_ref()
-                    .and_then(|addr| addr.as_socket_addr())
-                    .unwrap_or(dual_stack_default);
-
-                let (_transport, quinn_socket) =
-                    match crate::transport::UdpTransport::bind_for_quinn(bind_addr).await {
-                        Ok(result) => result,
-                        Err(e2) if bind_addr == dual_stack_default => {
-                            info!("Single-socket dual-stack failed ({e2}), falling back to IPv4");
-                            crate::transport::UdpTransport::bind_for_quinn(ipv4_fallback)
-                                .await
-                                .map_err(|e3| {
-                                    EndpointError::Config(format!(
-                                        "All socket binds failed (dual: {e}, v6: {e2}, v4: {e3})"
-                                    ))
-                                })?
-                        }
-                        Err(e2) => {
-                            return Err(EndpointError::Config(format!(
-                                "Failed to bind UDP socket: {e2}"
-                            )));
-                        }
-                    };
-
+            socket_binding::BoundSocket::Single((_transport, quinn_socket)) => {
                 let actual_bind_addr = quinn_socket.local_addr().map_err(|e2| {
                     EndpointError::Config(format!("Failed to get local address: {e2}"))
                 })?;

--- a/src/p2p_endpoint/socket_binding.rs
+++ b/src/p2p_endpoint/socket_binding.rs
@@ -1,0 +1,250 @@
+// Copyright 2024 Saorsa Labs Ltd.
+//
+// This Saorsa Network Software is licensed under the General Public License (GPL), version 3.
+// Please see the file LICENSE-GPL, or visit <http://www.gnu.org/licenses/> for the full text.
+//
+// Full details available at https://saorsalabs.com/licenses
+
+//! Endpoint bind strategy, separated from socket creation so address and fallback
+//! contracts can be tested without opening network sockets.
+
+use std::future::Future;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum BoundSocket<D, S> {
+    Dual(D),
+    Single(S),
+}
+
+pub(super) async fn bind<D, S, DF, SF>(
+    requested: Option<SocketAddr>,
+    mut dual: impl FnMut(u16) -> DF,
+    mut single: impl FnMut(SocketAddr) -> SF,
+) -> io::Result<BoundSocket<D, S>>
+where
+    DF: Future<Output = io::Result<D>>,
+    SF: Future<Output = io::Result<S>>,
+{
+    // Preserve the complete address (including IPv6 scope and flow info). An
+    // explicit bind failure must not silently widen to a wildcard interface.
+    if let Some(addr) = requested.filter(|addr| !addr.ip().is_unspecified()) {
+        return single(addr).await.map(BoundSocket::Single);
+    }
+
+    let port = requested.map_or(0, |addr| addr.port());
+    let dual_error = match dual(port).await {
+        Ok(socket) => return Ok(BoundSocket::Dual(socket)),
+        Err(error) => error,
+    };
+    let v6_default = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port);
+    let addr = requested.unwrap_or(v6_default);
+    match single(addr).await {
+        Ok(socket) => Ok(BoundSocket::Single(socket)),
+        Err(v6_error) if addr == v6_default => {
+            let v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
+            single(v4).await.map(BoundSocket::Single).map_err(|v4_error| {
+                io::Error::new(v4_error.kind(), format!(
+                    "All socket binds failed (dual: {dual_error}, v6: {v6_error}, v4: {v4_error})"
+                ))
+            })
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::future::ready;
+    use std::net::SocketAddrV6;
+    use std::task::{Context, Poll, Waker};
+
+    // Every injected binder returns Ready. No runtime, timers, I/O or sockets.
+    fn completed<T>(future: impl Future<Output = T>) -> T {
+        let mut future = std::pin::pin!(future);
+        match future
+            .as_mut()
+            .poll(&mut Context::from_waker(Waker::noop()))
+        {
+            Poll::Ready(result) => result,
+            Poll::Pending => panic!("pure binder unexpectedly pending"),
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Attempt {
+        Dual(u16),
+        Single(SocketAddr),
+    }
+
+    #[test]
+    fn explicit_address_preserves_family_scope_and_actual_port() {
+        for requested in [
+            "127.0.0.1:0".parse().unwrap(),
+            "192.0.2.7:43123".parse().unwrap(),
+            "[::1]:0".parse().unwrap(),
+            SocketAddr::V6(SocketAddrV6::new("fe80::1".parse().unwrap(), 0, 17, 9)),
+        ] {
+            let attempts = RefCell::new(Vec::new());
+            let mut actual = requested;
+            if actual.port() == 0 {
+                actual.set_port(43124);
+            }
+            let result = completed(bind(
+                Some(requested),
+                |port| {
+                    attempts.borrow_mut().push(Attempt::Dual(port));
+                    // Deliberately succeeds with an unrelated wildcard family/port.
+                    ready(Ok("[::]:49999".parse::<SocketAddr>().unwrap()))
+                },
+                |addr| {
+                    attempts.borrow_mut().push(Attempt::Single(addr));
+                    ready(Ok(actual))
+                },
+            ))
+            .unwrap();
+            assert_eq!(result, BoundSocket::Single(actual));
+            assert_eq!(*attempts.borrow(), vec![Attempt::Single(requested)]);
+        }
+    }
+
+    #[test]
+    fn explicit_failure_never_attempts_wildcard_fallback() {
+        for requested in ["127.0.0.1:43123", "[::1]:0"] {
+            let requested = requested.parse().unwrap();
+            let attempts = RefCell::new(Vec::new());
+            let error = completed(bind(
+                Some(requested),
+                |port| {
+                    attempts.borrow_mut().push(Attempt::Dual(port));
+                    ready(Ok(()))
+                },
+                |addr| {
+                    attempts.borrow_mut().push(Attempt::Single(addr));
+                    ready(Err::<(), _>(io::Error::from(io::ErrorKind::AddrInUse)))
+                },
+            ))
+            .unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+            assert_eq!(*attempts.borrow(), vec![Attempt::Single(requested)]);
+        }
+    }
+
+    #[test]
+    fn wildcard_and_default_prefer_dual_socket_without_rewriting_result() {
+        for requested in [
+            None,
+            Some("0.0.0.0:0".parse().unwrap()),
+            Some("[::]:43123".parse().unwrap()),
+        ] {
+            let attempts = RefCell::new(Vec::new());
+            // Dual port-zero sockets can have different actual ports.
+            let actual = (
+                "0.0.0.0:43124".parse::<SocketAddr>().unwrap(),
+                "[::]:43125".parse::<SocketAddr>().unwrap(),
+            );
+            let result = completed(bind(
+                requested,
+                |port| {
+                    attempts.borrow_mut().push(Attempt::Dual(port));
+                    ready(Ok(actual))
+                },
+                |addr| {
+                    attempts.borrow_mut().push(Attempt::Single(addr));
+                    ready(Ok(()))
+                },
+            ))
+            .unwrap();
+            assert_eq!(result, BoundSocket::Dual(actual));
+            assert_eq!(
+                *attempts.borrow(),
+                vec![Attempt::Dual(requested.map_or(0, |addr| addr.port()))]
+            );
+        }
+    }
+
+    #[test]
+    fn wildcard_fallbacks_preserve_order_address_and_port() {
+        for requested in [
+            None,
+            Some("[::]:43123".parse().unwrap()),
+            Some("0.0.0.0:43123".parse().unwrap()),
+        ] {
+            let port = requested.map_or(0, |addr: SocketAddr| addr.port());
+            let attempts = RefCell::new(Vec::new());
+            let v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port);
+            let v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
+            let result = completed(bind(
+                requested,
+                |port| {
+                    attempts.borrow_mut().push(Attempt::Dual(port));
+                    ready(Err::<(), _>(io::Error::from(
+                        io::ErrorKind::AddrNotAvailable,
+                    )))
+                },
+                |addr| {
+                    attempts.borrow_mut().push(Attempt::Single(addr));
+                    ready(if addr.is_ipv6() {
+                        Err(io::Error::from(io::ErrorKind::AddrNotAvailable))
+                    } else {
+                        Ok(addr)
+                    })
+                },
+            ))
+            .unwrap();
+            let expected = if requested.is_some_and(|addr| addr.is_ipv4()) {
+                vec![Attempt::Dual(port), Attempt::Single(v4)]
+            } else {
+                vec![
+                    Attempt::Dual(port),
+                    Attempt::Single(v6),
+                    Attempt::Single(v4),
+                ]
+            };
+            assert_eq!(result, BoundSocket::Single(v4));
+            assert_eq!(*attempts.borrow(), expected);
+        }
+    }
+
+    #[test]
+    fn wildcard_single_success_stops_and_total_failure_propagates() {
+        for succeed in [true, false] {
+            let attempts = RefCell::new(Vec::new());
+            let v6 = "[::]:43123".parse().unwrap();
+            let result = completed(bind(
+                Some(v6),
+                |port| {
+                    attempts.borrow_mut().push(Attempt::Dual(port));
+                    ready(Err::<(), _>(io::Error::from(
+                        io::ErrorKind::AddrNotAvailable,
+                    )))
+                },
+                |addr| {
+                    attempts.borrow_mut().push(Attempt::Single(addr));
+                    ready(if succeed {
+                        Ok(addr)
+                    } else {
+                        Err(io::Error::from(io::ErrorKind::PermissionDenied))
+                    })
+                },
+            ));
+            if succeed {
+                assert_eq!(result.unwrap(), BoundSocket::Single(v6));
+                assert_eq!(attempts.borrow().len(), 2);
+            } else {
+                assert_eq!(result.unwrap_err().kind(), io::ErrorKind::PermissionDenied);
+                assert_eq!(
+                    *attempts.borrow(),
+                    vec![
+                        Attempt::Dual(43123),
+                        Attempt::Single(v6),
+                        Attempt::Single("0.0.0.0:43123".parse().unwrap())
+                    ]
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Explicit non-wildcard `P2pConfig.bind_addr` requests currently lose their IP when the preferred dual-stack binder extracts only the port. For example, `127.0.0.1:0` can return a wildcard IPv6 socket and advertise an unusable address to x0x.

Pass the complete requested socket address to the existing single-address binder for explicit IPs. Return the actual bound family/address/port, including port-zero allocation, and propagate an explicit bind failure without widening. `None` and wildcard requests retain the existing dual-stack and fallback behavior. No protocol, authentication or public-discovery policy changes.

Validation on current head `1edc13c772cc856acf04f09dce8f0a9743526d03` (production behavior unchanged from reviewed `85a173a2`):

- Four ordered local gates passed: `cargo fmt --all`; all-feature/all-target clippy with `-D warnings`; production library/binary panic/unwrap/expect clippy; workspace/all-target check. Five pure binder controls passed, with original-strategy negative controls failing as intended. The current head also retains two endpoint-level regressions in the normal library suite: actual IPv4/IPv6 address and allocated-port ownership, and occupied-address rejection through `P2pEndpoint::new`. Both passed in one serial local run with all outbound traffic denied, discovery disabled and fresh private cache state (2 passed, 0 failed, 0 ignored; 2730 unselected).
- [Isolated Linux OS diagnostic](https://github.com/saorsa-labs/ant-quic/actions/runs/34061185656): original-source IPv4 and IPv6 controls each failed at the intended IP-mismatch assertion; all three fixed-source tests passed, covering actual socket/status address and port-zero allocation plus occupied IPv4/IPv6 rejection without widening. Baseline and fixed libraries/tests compiled fresh in distinct target directories; all five namespace processes were reaped cleanly.
- [Single isolated x0x consumer diagnostic](https://github.com/saorsa-labs/x0x/actions/runs/34061674309), using this exact Git dependency: the unchanged bootstrap restart/install/ACK-drain test passed in 37.058 seconds. This is one targeted consumer result, not full x0x CI or release acceptance.

The earlier [OS attempt](https://github.com/saorsa-labs/ant-quic/actions/runs/34059813596) remains a recorded build-custody failure: its shared target reused the baseline library for the alleged fixed test. It supplies no fixed-source acceptance. The corrected run above verifies separate targets and actual Cargo artifact custody.

Normal PR CI and an independent approving review are pending. This PR contains only the two production/helper source files and their pure plus endpoint-level unit tests; neither disposable diagnostic workflow nor consumer lock is included.
