### PR TITLE
fix: validate complete benchmark results in CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,6 +11,9 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "benches/**"
+      - ".github/workflows/benchmarks.yml"
+      - "scripts/ci/criterion_report.py"
+      - "scripts/ci/test_criterion_report.py"
   pull_request:
     branches: [master, main]
     paths:
@@ -18,6 +21,9 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - "benches/**"
+      - ".github/workflows/benchmarks.yml"
+      - "scripts/ci/criterion_report.py"
+      - "scripts/ci/test_criterion_report.py"
   workflow_dispatch:
     inputs:
       baseline:
@@ -57,37 +63,23 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install cargo-criterion
-        run: cargo install cargo-criterion --locked || true
+      - name: Create fresh benchmark output
+        run: |
+          # Keep Criterion samples outside rust-cache's compiler target cleanup.
+          criterion_home=$(mktemp -d "$RUNNER_TEMP/ant-quic-criterion.XXXXXXXX")
+          echo "CRITERION_HOME=$criterion_home" >> "$GITHUB_ENV"
+
+      - name: Validate benchmark reporting helpers
+        run: python3 -m unittest discover -s scripts/ci -p 'test_criterion_report.py'
 
       - name: Run NAT traversal benchmarks
-        run: cargo bench --bench nat_traversal_performance -- --save-baseline current-nat || true
+        run: cargo bench --bench nat_traversal_performance -- --save-baseline current-nat
 
       - name: Run connection management benchmarks
-        run: cargo bench --bench connection_management -- --save-baseline current-conn || true
+        run: cargo bench --bench connection_management -- --save-baseline current-conn
 
       - name: Generate benchmark report
-        run: |
-          echo "# Benchmark Results" > benchmark-report.md
-          echo "## NAT Traversal" >> benchmark-report.md
-          cat target/criterion/nat_traversal_performance/*/base/estimates.json >> benchmark-report.md 2>/dev/null || echo "No results" >> benchmark-report.md
-
-          # Create benchmark results JSON
-          echo '{"timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "commit": "'${{ github.sha }}'", "results": []}' > benchmark-results.json
-          if [ -d "target/criterion/nat_traversal_performance" ]; then
-            find target/criterion/nat_traversal_performance -name "estimates.json" -exec cat {} \; | jq -s '.' > temp-results.json 2>/dev/null || echo "[]" > temp-results.json
-            jq --argjson results "$(cat temp-results.json)" '.results = $results' benchmark-results.json > benchmark-results-final.json
-            mv benchmark-results-final.json benchmark-results.json
-          fi
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v5
-        with:
-          name: benchmark-results-${{ github.sha }}
-          path: |
-            benchmark-results.json
-            benchmark-report.md
-            target/criterion/
+        run: python3 scripts/ci/criterion_report.py collect --root "$CRITERION_HOME"
 
       - name: Download baseline benchmarks
         if: github.event_name == 'pull_request'
@@ -104,31 +96,39 @@ jobs:
         if: github.event_name == 'pull_request' && success()
         id: compare
         run: |
-          if [ -d "baseline-benchmarks" ]; then
-            python3 .github/scripts/compare-benchmarks.py \
-              baseline-benchmarks/*/benchmark-results.json \
-              benchmark-results.json \
-              > comparison-report.md 2>/dev/null || echo "Comparison script not available" > comparison-report.md
-
-            if grep -q "REGRESSION" comparison-report.md; then
-              echo "regression_found=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "No baseline benchmarks found for comparison" > comparison-report.md
+          python3 scripts/ci/criterion_report.py compare \
+            --root "$CRITERION_HOME" --baseline-download baseline-benchmarks \
+            --comparator .github/scripts/compare-benchmarks.py
+          if grep -q "REGRESSION" "$CRITERION_HOME/comparison-report.md"; then
+            echo "regression_found=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Upload benchmark results
+        if: always() && env.CRITERION_HOME != ''
+        uses: actions/upload-artifact@v5
+        with:
+          name: benchmark-results-${{ github.sha }}
+          path: ${{ env.CRITERION_HOME }}/
+          if-no-files-found: error
+
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && env.CRITERION_HOME != ''
         uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
+            const path = require('path');
+            const reportPath = path.join(process.env.CRITERION_HOME, 'comparison-report.md');
+            const resultsPath = path.join(process.env.CRITERION_HOME, 'benchmark-report.md');
             let comment = '## Benchmark Results\n\n';
 
-            if (fs.existsSync('comparison-report.md')) {
-              comment += fs.readFileSync('comparison-report.md', 'utf8');
+            if (fs.existsSync(reportPath)) {
+              comment += fs.readFileSync(reportPath, 'utf8');
+            } else if (fs.existsSync(resultsPath)) {
+              comment += fs.readFileSync(resultsPath, 'utf8');
+              comment += '\nComparison unavailable; inspect the failed workflow step.\n';
             } else {
-              comment += fs.readFileSync('benchmark-report.md', 'utf8');
+              comment += 'Benchmark run incomplete; comparison unavailable.\n';
             }
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -162,7 +162,7 @@ jobs:
         if: steps.compare.outputs.regression_found == 'true'
         run: |
           echo "Performance regression detected!"
-          cat comparison-report.md
+          cat "$CRITERION_HOME/comparison-report.md"
           exit 1
 
   profile:

--- a/scripts/ci/criterion_report.py
+++ b/scripts/ci/criterion_report.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Validate selected Criterion samples and adapt them to the existing comparator."""
+
+import argparse
+import json
+import math
+from pathlib import Path
+import subprocess
+import sys
+
+
+GROUPS = {
+    "current-nat": {
+        "candidate_discovery", "hole_punching", "candidate_prioritization",
+        "nat_type_detection", "relay_fallback", "address_mapping",
+    },
+    "current-conn": {
+        "connection_tracking", "event_processing", "resource_cleanup",
+        "concurrent_access",
+    },
+}
+
+# Full selected workload at the pinned benchmark definitions. Keep this contract
+# in sync when those definitions intentionally change; group presence is insufficient.
+# nat_traversal_performance.rs:16,54,95,135,168,209 (23 IDs).
+# connection_management.rs:123,270,375,467 (31 IDs).
+EXPECTED_IDS = {
+    "current-nat": (
+        {f"candidate_discovery/{n}" for n in (1, 5, 10, 20)}
+        | {f"hole_punching/{n}" for n in (1, 5, 10, 25)}
+        | {f"candidate_prioritization/{n}" for n in (10, 50, 100, 500)}
+        | {"nat_type_detection/detect_nat_type"}
+        | {f"relay_fallback/{n}" for n in (1, 3, 5, 10)}
+        | {f"address_mapping/{operation}/{n}"
+           for operation in ("insert", "lookup") for n in (100, 1000, 10000)}
+    ),
+    "current-conn": (
+        {f"connection_tracking/{operation}/{n}"
+         for operation in ("add_connections", "lookup_connections", "remove_connections", "update_connections")
+         for n in (10, 100, 1000, 5000)}
+        | {f"event_processing/{operation}/{n}"
+           for operation in ("queue_events", "process_events") for n in (10, 100, 1000, 10000)}
+        | {f"resource_cleanup/cleanup_inactive/{n}" for n in (100, 1000, 5000)}
+        | {f"concurrent_access/{operation}/{n}"
+           for operation in ("read_heavy_workload", "write_heavy_workload") for n in (100, 1000)}
+    ),
+}
+
+
+def load_json(path):
+    return json.loads(path.read_text())
+
+
+def positive_number(value):
+    return type(value) in (int, float) and math.isfinite(value) and value > 0
+
+
+def convert(root):
+    """Read named snapshots only; never use cached base/new/report estimates."""
+    records = {}
+    for label, required_groups in GROUPS.items():
+        observed_groups = set()
+        observed_ids = set()
+        for snapshot in sorted(root.glob(f"**/{label}")):
+            if not snapshot.is_dir():
+                raise ValueError(f"not a snapshot directory: {snapshot}")
+            benchmark = load_json(snapshot / "benchmark.json")
+            estimates = load_json(snapshot / "estimates.json")
+            sample = load_json(snapshot / "sample.json")
+            group = benchmark["group_id"]
+            identity = benchmark["full_id"]
+            if group not in required_groups or not isinstance(identity, str):
+                raise ValueError("unexpected benchmark group or identity")
+            relative = snapshot.parent.relative_to(root).as_posix()
+            if benchmark["directory_name"] != relative:
+                raise ValueError("benchmark directory does not match its metadata")
+            if identity in records:
+                raise ValueError("duplicate benchmark identity")
+            for statistic in ("mean", "median"):
+                if not positive_number(estimates[statistic]["point_estimate"]):
+                    raise ValueError("invalid timing estimate")
+            iterations, times = sample["iters"], sample["times"]
+            if (not isinstance(iterations, list) or not isinstance(times, list)
+                    or not iterations or len(iterations) != len(times)
+                    or not all(positive_number(x) for x in iterations + times)):
+                raise ValueError("missing or invalid measurement samples")
+            records[identity] = {
+                "type": "benchmark-complete", "id": identity,
+                "mean": estimates["mean"], "median": estimates["median"],
+            }
+            observed_groups.add(group)
+            observed_ids.add(identity)
+        if observed_groups != required_groups:
+            raise ValueError(f"missing groups for {label}: {sorted(required_groups - observed_groups)}")
+        if observed_ids != EXPECTED_IDS[label]:
+            raise ValueError(
+                f"incomplete benchmark identities for {label}: "
+                f"missing={sorted(EXPECTED_IDS[label] - observed_ids)}, "
+                f"unexpected={sorted(observed_ids - EXPECTED_IDS[label])}"
+            )
+    return [records[key] for key in sorted(records)]
+
+
+def write_records(path, records):
+    path.write_text("".join(json.dumps(record, allow_nan=False) + "\n" for record in records))
+
+
+def baseline_root(download):
+    artifacts = list(download.glob("*/benchmark-results.json"))
+    if len(artifacts) != 1:
+        raise ValueError("expected exactly one downloaded baseline artifact")
+    artifact = artifacts[0].parent
+    # Older workflows archived the real samples even though their summary was empty.
+    legacy = artifact / "target" / "criterion"
+    return legacy if legacy.is_dir() else artifact
+
+
+def compare(args):
+    try:
+        baseline = convert(baseline_root(args.baseline_download))
+        current = convert(args.root)
+        # Refuse partial or unrelated data instead of silently calling it a comparison.
+        if {row["id"] for row in baseline} != {row["id"] for row in current}:
+            raise ValueError("baseline and current benchmark identities differ")
+        baseline_file = args.root / "baseline-results.json"
+        current_file = args.root / "benchmark-results.json"
+        write_records(baseline_file, baseline)
+        write_records(current_file, current)
+        result = subprocess.run(
+            [sys.executable, str(args.comparator), str(baseline_file), str(current_file)],
+            capture_output=True, text=True, check=True,
+        )
+        args.report.write_text(result.stdout)
+    except (OSError, ValueError, KeyError, TypeError, subprocess.CalledProcessError) as error:
+        args.report.write_text(f"### Comparison unavailable\n\n{error}\n")
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("collect", "compare"))
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--baseline-download", type=Path)
+    parser.add_argument("--comparator", type=Path)
+    args = parser.parse_args()
+    args.report = args.root / "comparison-report.md"
+    try:
+        if args.command == "collect":
+            records = convert(args.root)
+            write_records(args.root / "benchmark-results.json", records)
+            (args.root / "benchmark-report.md").write_text(
+                f"# Benchmark Results\n\nValidated {len(records)} measured benchmarks.\n"
+            )
+        else:
+            if args.baseline_download is None or args.comparator is None:
+                parser.error("compare requires --baseline-download and --comparator")
+            compare(args)
+    except (OSError, ValueError, KeyError, TypeError, subprocess.CalledProcessError) as error:
+        print(f"benchmark report failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_criterion_report.py
+++ b/scripts/ci/test_criterion_report.py
@@ -1,0 +1,196 @@
+"""Pure fixtures exercise the adapter and the actual existing comparison script."""
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+from types import SimpleNamespace
+
+import criterion_report as report
+
+
+REPO = Path(__file__).resolve().parents[2]
+HELPER = Path(__file__).with_name("criterion_report.py")
+COMPARATOR = REPO / ".github/scripts/compare-benchmarks.py"
+
+
+def fixture(root, mean=100):
+    for label, identities in report.EXPECTED_IDS.items():
+        for identity in identities:
+            group = identity.split("/", 1)[0]
+            snapshot = root / identity / label
+            snapshot.mkdir(parents=True)
+            (snapshot / "benchmark.json").write_text(json.dumps({
+                "group_id": group, "full_id": identity,
+                "directory_name": identity,
+            }))
+            (snapshot / "estimates.json").write_text(json.dumps({
+                "mean": {"point_estimate": mean}, "median": {"point_estimate": mean},
+            }))
+            (snapshot / "sample.json").write_text(json.dumps({
+                "iters": [1, 2], "times": [mean, mean * 2],
+            }))
+
+
+class CriterionReportTests(unittest.TestCase):
+    def setUp(self):
+        self.scratch = tempfile.TemporaryDirectory()
+        self.addCleanup(self.scratch.cleanup)
+        self.root = Path(self.scratch.name)
+        self.current = self.root / "current"
+        self.download = self.root / "download"
+        self.artifact = self.download / "benchmark-results-baseline"
+        self.artifact.mkdir(parents=True)
+        (self.artifact / "benchmark-results.json").write_text('{"results": []}\n')
+
+    def compare(self):
+        return subprocess.run([
+            sys.executable, str(HELPER), "compare", "--root", str(self.current),
+            "--baseline-download", str(self.download), "--comparator", str(COMPARATOR),
+        ], capture_output=True, text=True)
+
+    def test_actual_comparator_stable_and_regression(self):
+        fixture(self.artifact)
+        for mean, regression in ((100, False), (120, True)):
+            with self.subTest(mean=mean):
+                if self.current.exists():
+                    shutil.rmtree(self.current)
+                fixture(self.current, mean)
+                result = self.compare()
+                self.assertEqual(result.returncode, 0, result.stderr)
+                output = (self.current / "comparison-report.md").read_text()
+                self.assertEqual("REGRESSION" in output, regression)
+                self.assertIn("| candidate_discovery/1 |", output)
+
+    def test_legacy_raw_artifact_migrates_empty_aggregate(self):
+        fixture(self.artifact / "target/criterion")
+        fixture(self.current, 120)
+        result = self.compare()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("REGRESSION", (self.current / "comparison-report.md").read_text())
+
+    def test_empty_legacy_aggregate_is_not_comparison(self):
+        fixture(self.current)
+        result = self.compare()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Comparison unavailable", (self.current / "comparison-report.md").read_text())
+
+    def test_missing_or_multiple_baseline_artifacts_fail(self):
+        fixture(self.current)
+        (self.artifact / "benchmark-results.json").unlink()
+        self.assertNotEqual(self.compare().returncode, 0)
+        (self.artifact / "benchmark-results.json").write_text("{}")
+        other = self.download / "other"
+        other.mkdir()
+        (other / "benchmark-results.json").write_text("{}")
+        self.assertNotEqual(self.compare().returncode, 0)
+
+    def test_partial_identity_set_fails(self):
+        fixture(self.artifact)
+        fixture(self.current)
+        original = self.current / "candidate_discovery/1/current-nat"
+        extra = self.current / "candidate_discovery/extra/current-nat"
+        shutil.copytree(original, extra)
+        data = json.loads((extra / "benchmark.json").read_text())
+        data.update(full_id="candidate_discovery/extra", directory_name="candidate_discovery/extra")
+        (extra / "benchmark.json").write_text(json.dumps(data))
+        self.assertNotEqual(self.compare().returncode, 0)
+
+    def test_same_missing_case_on_both_sides_fails_before_comparator(self):
+        fixture(self.artifact)
+        fixture(self.current)
+        for root in (self.artifact, self.current):
+            shutil.rmtree(root / "candidate_discovery/1/current-nat")
+            self.assertTrue((root / "candidate_discovery/5/current-nat").is_dir())
+        args = SimpleNamespace(
+            baseline_download=self.download, root=self.current, comparator=COMPARATOR,
+            report=self.current / "comparison-report.md",
+        )
+        with mock.patch.object(report.subprocess, "run") as comparator:
+            with self.assertRaisesRegex(ValueError, "incomplete benchmark identities"):
+                report.compare(args)
+            comparator.assert_not_called()
+        self.assertIn("Comparison unavailable", args.report.read_text())
+
+    def test_substituted_identity_with_same_count_is_rejected(self):
+        fixture(self.current)
+        metadata = self.current / "candidate_discovery/1/current-nat/benchmark.json"
+        data = json.loads(metadata.read_text())
+        data["full_id"] = "candidate_discovery/substituted"
+        metadata.write_text(json.dumps(data))
+        self.assertEqual(len(list(self.current.glob("**/benchmark.json"))), 54)
+        with self.assertRaisesRegex(ValueError, "unexpected=.*substituted"):
+            report.convert(self.current)
+
+    def test_missing_group_and_sample_rejected(self):
+        fixture(self.current)
+        sample = self.current / "candidate_discovery/1/current-nat/sample.json"
+        sample.unlink()
+        with self.assertRaises(FileNotFoundError):
+            report.convert(self.current)
+        shutil.rmtree(self.current / "candidate_discovery")
+        with self.assertRaisesRegex(ValueError, "missing groups"):
+            report.convert(self.current)
+
+    def test_duplicate_id_rejected(self):
+        fixture(self.current)
+        original = self.current / "candidate_discovery/1/current-nat"
+        extra = self.current / "candidate_discovery/extra/current-nat"
+        shutil.copytree(original, extra)
+        data = json.loads((extra / "benchmark.json").read_text())
+        data["directory_name"] = "candidate_discovery/extra"
+        (extra / "benchmark.json").write_text(json.dumps(data))
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            report.convert(self.current)
+
+    def test_invalid_estimates_rejected(self):
+        fixture(self.current)
+        estimates = self.current / "candidate_discovery/1/current-nat/estimates.json"
+        for value in (0, -1, True, "100", float("nan"), float("inf")):
+            with self.subTest(value=value):
+                estimates.write_text(json.dumps({"mean": {"point_estimate": value}}))
+                with self.assertRaisesRegex(ValueError, "invalid timing"):
+                    report.convert(self.current)
+
+    def test_invalid_samples_rejected(self):
+        fixture(self.current)
+        sample = self.current / "candidate_discovery/1/current-nat/sample.json"
+        for iterations, times in (([], []), ([1], [1, 2]), ([1], [0]), ([True], [2])):
+            with self.subTest(iterations=iterations, times=times):
+                sample.write_text(json.dumps({"iters": iterations, "times": times}))
+                with self.assertRaisesRegex(ValueError, "measurement samples"):
+                    report.convert(self.current)
+
+    def test_cached_output_is_excluded_from_fresh_root(self):
+        stale = self.root / "target/criterion/candidate_discovery/1/current-nat"
+        stale.mkdir(parents=True)
+        fixture(self.current)
+        self.assertEqual(len(report.convert(self.current)), 54)
+        self.assertEqual(list(stale.iterdir()), [])
+
+    def test_comparator_failure_is_not_masked(self):
+        fixture(self.artifact)
+        fixture(self.current)
+        result = subprocess.run([
+            sys.executable, str(HELPER), "compare", "--root", str(self.current),
+            "--baseline-download", str(self.download), "--comparator", str(self.root / "missing.py"),
+        ], capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Comparison unavailable", (self.current / "comparison-report.md").read_text())
+
+    def test_collect_outputs_actual_comparator_schema(self):
+        fixture(self.current)
+        result = subprocess.run([sys.executable, str(HELPER), "collect", "--root", str(self.current)],
+                                capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        records = [json.loads(line) for line in (self.current / "benchmark-results.json").read_text().splitlines()]
+        self.assertEqual(len(records), 54)
+        self.assertTrue(all(row["type"] == "benchmark-complete" for row in records))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The benchmark workflow restores empty Criterion baseline directories from the compiler cache, searches an output directory that the selected benchmarks never create, and feeds aggregate JSON to a comparator that expects NDJSON. This produced 54 missing-sample messages and a green empty comparison table in PR274.

Create a fresh Criterion output directory outside the compiler cache and propagate benchmark command failures. A dedicated adapter validates all 54 expected benchmark IDs, samples and estimates, then emits the existing comparator format. It also converts the raw measurements retained in older baseline artifacts. Missing, ambiguous, malformed or incomplete inputs fail with an explicit comparison-unavailable report. The two benchmark suites, sampling configuration and >10% regression threshold are unchanged.

Validation:14 pure helper tests pass, including actual stable/regression comparator cases, missing identical measurements on both sides, substituted IDs preserving count, and malformed samples. The verified master baseline artifact converts all54 measurements. Python compilation, YAML/bash/Node syntax, diff checks and source-connected shell controls pass; the old masked shell exits0 for an inert failing cargo witness while the new command returns17. No local Rust benchmarks ran. Normal GitHub-hosted runtime evidence remains pending.

This standalone change contains only the workflow and its two Python helper/test files; it does not include the bind fix from PR274.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes benchmark comparison fail closed instead of accepting empty or incomplete Criterion output.
- Moves Criterion output into a fresh directory outside the compiler cache.
- Propagates benchmark command failures and validates all 54 expected measurements.
- Converts current and legacy artifacts into the comparator’s NDJSON format.
- Preserves comparison-unavailable diagnostics through artifact upload and PR comments.
- Adds focused helper tests covering stable, regressed, malformed, missing, duplicate, and legacy results.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

The output-directory behavior, complete identity contract, artifact layouts, comparator schema, regression gate, and failure-reporting lifecycle align with the repository’s benchmark definitions and existing comparator.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/benchmarks.yml | Routes Criterion output through a fresh directory, propagates failures, and preserves artifacts and PR diagnostics. |
| scripts/ci/criterion_report.py | Validates complete Criterion snapshots, supports legacy artifacts, emits comparator-compatible NDJSON, and fails closed. |
| scripts/ci/test_criterion_report.py | Exercises the adapter and real comparator across successful, regressed, incomplete, malformed, duplicate, and legacy inputs. |

</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Create fresh CRITERION_HOME] --> B[Run two Criterion suites]
  B --> C[Collect and validate 54 snapshots]
  C --> D[Upload validated results and raw samples]
  E[Download base-branch artifact] --> F[Resolve legacy or current layout]
  F --> G[Validate baseline snapshots]
  C --> H[Write current NDJSON]
  G --> I[Write baseline NDJSON]
  H --> J[Existing benchmark comparator]
  I --> J
  J --> K[Comparison report]
  K --> L{Regression over 10%?}
  L -->|Yes| M[Comment and fail job]
  L -->|No| N[Comment and pass]
  B -. failure .-> O[Upload diagnostics and report comparison unavailable]
  C -. failure .-> O
  G -. failure .-> O
  J -. failure .-> O
```

<sub>Reviews (1): Last reviewed commit: ["fix: validate complete benchmark results..."](https://github.com/saorsa-labs/ant-quic/commit/e67ab23c98ae76840f1e155ae569463683db4a78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61057287)</sub>

<!-- /greptile_comment -->