### PR TITLE
chore(release): cut 0.27.50 to publish the #274 bind fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.50] - 2026-09-07
+
+### Fixed
+
+- **Honor explicit `P2pConfig.bind_addr` without collapsing to a wildcard (#274).** The preferred
+  dual-stack binder previously extracted only the port from non-wildcard bind requests, so
+  `127.0.0.1:0` (and other explicit IPs) could return a wildcard IPv6 socket and advertise an
+  unusable address to consumers. Explicit IPs now go through the single-address binder with the
+  complete requested socket address; the actual bound family/address/port (including port-zero
+  allocation) is returned, and an explicit bind failure is propagated without widening.
+  `None` and wildcard requests keep the existing dual-stack and fallback behavior. Merged as
+  #274 (`d78b78f5ce6d3a8d060a7a1f6644d2d87753c463`); crates.io 0.27.49 still has the old bind
+  behavior and cannot be republished.
+
 ## [0.27.49] - 2026-09-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.49"
+version = "0.27.50"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.49"
+version = "0.27.50"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

crates.io already has **0.27.49** (`39618d742aeca6048da3b5f04a584882bd1503ac37348603c66d9f6e1346d9dc`) with the **old** bind behavior. That version cannot be republished.

The explicit-bind fix from **#274** is already on `master` at merge `d78b78f5ce6d3a8d060a7a1f6644d2d87753c463` (head `1edc13c772cc856acf04f09dce8f0a9743526d03`), but `Cargo.toml` was still `0.27.49`. This PR is the release bump so tag/CI can publish **0.27.50** with that fix.

## What

Release-bump only:

- `Cargo.toml` / `Cargo.lock`: `0.27.49` → `0.27.50`
- `CHANGELOG.md`: add `[0.27.50] - 2026-09-07` covering #274 (explicit `P2pConfig.bind_addr` no longer collapses to a wildcard)

No bind-code changes. No refactor.

## Publish policy

Tag/CI publishes crates. Do **not** run `cargo publish` from this PR. Do **not** tag from this PR unless that is the repo’s normal post-merge release path.

## Base

Branched from current `master` (`d78b78f5`), which already includes `src/p2p_endpoint/socket_binding.rs`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a29bb84-b18a-4cc0-8afa-4dee0aa5f2f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a29bb84-b18a-4cc0-8afa-4dee0aa5f2f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the 0.27.50 release containing the previously merged explicit-bind fix.
- Updates the crate version from 0.27.49 to 0.27.50 in the manifest and lockfile.
- Adds release notes describing the corrected handling of explicit bind addresses.
- Keeps release metadata consistent with the repository’s release checks.

<h3>Confidence Score: 5/5</h3>

The release-only changes appear safe to merge, with consistent version metadata and accurate release notes.

No actionable failures remain; the manifest, lockfile, changelog, and release-validation expectations are aligned, while identified dependency advisories are unchanged from the base.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Cargo.toml | Bumps the authoritative ant-quic package version to 0.27.50. |
| Cargo.lock | Synchronizes the root ant-quic lockfile entry with the manifest version. |
| CHANGELOG.md | Adds a correctly ordered 0.27.50 release entry accurately documenting the merged bind fix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): prepare 0.27.50 publish ..."](https://github.com/saorsa-labs/ant-quic/commit/f34420c4a6ac7f8bf2b5ce072cc084c05f31dff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61150941)</sub>

<!-- /greptile_comment -->