### PR TITLE
fix(streams): single accept_bi consumer per connection

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,5 +25,5 @@ test-group = "node-app-streams"
 # round 2), and victims rotate with scheduling. All of them are serialised
 # into one group so their handshake/CPU spikes never overlap each other.
 [[profile.default.overrides]]
-filter = "test(p2p_endpoint::tests::churn_disconnect_reconnect_delivers_over_new_connection) or test(p2p_endpoint::tests::disconnect_sweeps_surviving_generation_open_bi_reports_connection_closed) or binary_id(ant-quic::b_events_parity)"
+filter = "test(p2p_endpoint::tests::churn_disconnect_reconnect_delivers_over_new_connection) or test(p2p_endpoint::tests::disconnect_sweeps_surviving_generation_open_bi_reports_connection_closed) or test(reader_recovers_from_prefix_starvation) or test(app_stream_has_single_owner_with_relay_server_configured) or test(late_reader_still_receives_app_stream_with_relay_configured) or test(partial_prefix_stream_does_not_leak_consumer_tasks) or binary_id(ant-quic::b_events_parity)"
 test-group = "loopback-pair-heavyweights"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   task (and its now-dead ACK-bidi bridge plumbing) is deleted — relay serving runs exclusively
   through the reader's prefix demux (ACK-v2 → app → relay, with `BIDI_PREFIX_READ_TIMEOUT`); the
   bounded `pending_accepts` queue is the sole accept source; no unbounded prefix read remains.
-  No wire, frame or transport-parameter change. `relay_connect_udp_bind_on_live_node` now drives
-  the supported single-consumer path (the relay node accepts; pre-fix it deliberately avoided
-  `accept()` to dodge the race this change removes).
+  No wire, frame or transport-parameter change. Contract note: relay serving on a node now
+  requires the application to drive `accept()` (the relay demux lives inside the reader task an
+  accepted connection gets) — a node that never drains `accept()` serves neither relay, ACK-v2
+  nor app streams. `relay_connect_udp_bind_on_live_node` now drives the supported
+  single-consumer path (the relay node accepts; pre-fix it deliberately avoided `accept()` to
+  dodge the race this change removes). Relay streams are served on their own task so a live
+  relay session never pins the reader (`run_stream_forwarding_loop` shares the peer
+  connection), and `spawn_reader_task` now enforces one reader per connection (stable_id).
 
 ## [0.27.50] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ConnectionClosed { reason }` — carrying the disconnect's close reason — instead of a
   misleading `PeerNotFound` for a peer this endpoint recently closed. No wire or API change.
 
+- **One stream consumer per connection: relay accept task removed, single accept source (#280, x0x#277 shape B).**
+  Two unsynchronised `accept_bi()` consumers raced on every accepted connection whenever a relay
+  server existed (the default): the NAT layer spawned `handle_relay_requests` per connection while
+  the endpoint reader task polled the same source. When the relay task won, it read the 8-byte
+  prefix, had no app-magic branch, parsed `ANQAppB1` as a big-endian length (1,096,057,153),
+  tripped "request too large" and silently dropped the stream — writes succeed, the peer's
+  `accept_bi()` never yields. Independently, `accept_connection()` drained a legacy
+  `ConnectionEstablished` path beside the pending-accept queue, so one connection could be
+  returned twice and spawn two reader tasks; `handle_relay_requests`' prefix read also had no
+  timeout (a remote-triggerable task leak per partial-prefix stream). The redundant relay accept
+  task (and its now-dead ACK-bidi bridge plumbing) is deleted — relay serving runs exclusively
+  through the reader's prefix demux (ACK-v2 → app → relay, with `BIDI_PREFIX_READ_TIMEOUT`); the
+  bounded `pending_accepts` queue is the sole accept source; no unbounded prefix read remains.
+  No wire, frame or transport-parameter change. `relay_connect_udp_bind_on_live_node` now drives
+  the supported single-consumer path (the relay node accepts; pre-fix it deliberately avoided
+  `accept()` to dodge the race this change removes).
+
 ## [0.27.50] - 2026-09-07
 
 ### Fixed

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -27,7 +27,7 @@ use std::{
     fmt,
     net::SocketAddr,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use crate::constrained::{ConstrainedEngine, EngineConfig, EngineEvent};
@@ -314,9 +314,6 @@ use tokio::{
     time::{sleep, timeout},
 };
 
-use crate::ack_frame::{
-    ACK_BIDI_REQUEST_MAGIC, AckControlOutcome, ReceiveRejectReason, encode_ack_bidi_response,
-};
 use crate::connection_lifecycle::{ConnectionCloseReason, ConnectionLifecycleState};
 use crate::high_level::default_runtime;
 
@@ -578,12 +575,6 @@ pub struct NatTraversalEndpoint {
     /// MASQUE relay server - every node provides relay services (symmetric P2P)
     /// Per ADR-004: All nodes are equal and participate in relaying with resource budgets
     relay_server: Option<Arc<MasqueRelayServer>>,
-    /// Endpoint-level ACK-v2 bidi stream sink.
-    ///
-    /// The NAT relay service also accepts bidi streams on peer connections. If
-    /// it wins the accept race for an ACK-v2 stream, it forwards the stream here
-    /// instead of closing it as an invalid relay request.
-    ack_bidi_stream_tx: Arc<ParkingRwLock<Option<mpsc::UnboundedSender<IncomingAckBidiStream>>>>,
     /// Successful candidate pairs discovered via hole punching
     /// Maps peer ID to the remote address that successfully responded
     /// Uses DashMap for fine-grained concurrent access without blocking workers
@@ -798,18 +789,6 @@ fn default_max_concurrent_uni_streams() -> u32 {
     Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
 pub struct PeerId(pub [u8; 32]);
-
-/// ACK-v2 bidi stream accepted by a NAT-layer relay handler and forwarded to
-/// the endpoint-level app reader. This bridges the current split accept loops
-/// until bidi streams are owned by a single typed dispatcher.
-pub(crate) struct IncomingAckBidiStream {
-    pub(crate) peer_id: PeerId,
-    pub(crate) conn_stable_id: usize,
-    pub(crate) send: InnerSendStream,
-    pub(crate) recv: InnerRecvStream,
-    pub(crate) prefix: Vec<u8>,
-    pub(crate) accepted_at: Instant,
-}
 
 /// Information about a bootstrap/coordinator node
 #[derive(Debug, Clone)]
@@ -1924,7 +1903,6 @@ impl NatTraversalEndpoint {
             shared_relay_endpoint: Arc::new(std::sync::Mutex::new(None)),
             relay_accept_loop_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             relay_server,
-            ack_bidi_stream_tx: Arc::new(ParkingRwLock::new(None)),
             successful_candidates: Arc::new(dashmap::DashMap::new()),
             transport_candidates: Arc::new(dashmap::DashMap::new()),
             transport_registry,
@@ -2110,8 +2088,6 @@ impl NatTraversalEndpoint {
             let next_connection_generation_clone = endpoint.next_connection_generation.clone();
             let local_peer_id = endpoint.local_peer_id;
             let emitted_events_clone = emitted_established_events.clone();
-            let relay_server_clone = endpoint.relay_server.clone();
-            let ack_bidi_stream_tx_clone = endpoint.ack_bidi_stream_tx.clone();
             let observed_address_tx_clone = endpoint.observed_address_tx.clone();
             let traversal_event_notify_clone = endpoint.traversal_event_notify.clone();
             let incoming_notify_clone = endpoint.incoming_notify.clone();
@@ -2127,8 +2103,6 @@ impl NatTraversalEndpoint {
                     next_connection_generation_clone,
                     local_peer_id,
                     emitted_events_clone,
-                    relay_server_clone,
-                    ack_bidi_stream_tx_clone,
                     observed_address_tx_clone,
                     traversal_event_notify_clone,
                     incoming_notify_clone,
@@ -2436,7 +2410,6 @@ impl NatTraversalEndpoint {
             shared_relay_endpoint: Arc::new(std::sync::Mutex::new(None)),
             relay_accept_loop_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             relay_server,
-            ack_bidi_stream_tx: Arc::new(ParkingRwLock::new(None)),
             successful_candidates: Arc::new(dashmap::DashMap::new()),
             transport_candidates: Arc::new(dashmap::DashMap::new()),
             transport_registry,
@@ -2622,8 +2595,6 @@ impl NatTraversalEndpoint {
             let next_connection_generation_clone = endpoint.next_connection_generation.clone();
             let local_peer_id = endpoint.local_peer_id;
             let emitted_events_clone = emitted_established_events.clone();
-            let relay_server_clone = endpoint.relay_server.clone();
-            let ack_bidi_stream_tx_clone = endpoint.ack_bidi_stream_tx.clone();
             let observed_address_tx_clone = endpoint.observed_address_tx.clone();
             let traversal_event_notify_clone = endpoint.traversal_event_notify.clone();
             let incoming_notify_clone = endpoint.incoming_notify.clone();
@@ -2639,8 +2610,6 @@ impl NatTraversalEndpoint {
                     next_connection_generation_clone,
                     local_peer_id,
                     emitted_events_clone,
-                    relay_server_clone,
-                    ack_bidi_stream_tx_clone,
                     observed_address_tx_clone,
                     traversal_event_notify_clone,
                     incoming_notify_clone,
@@ -3125,14 +3094,6 @@ impl NatTraversalEndpoint {
     /// enabling multi-transport support and shared socket management.
     pub fn transport_registry(&self) -> Option<&Arc<TransportRegistry>> {
         self.transport_registry.as_ref()
-    }
-
-    /// Register the endpoint-level ACK-v2 bidi stream sink.
-    pub(crate) fn set_ack_bidi_stream_sender(
-        &self,
-        tx: mpsc::UnboundedSender<IncomingAckBidiStream>,
-    ) {
-        *self.ack_bidi_stream_tx.write() = Some(tx);
     }
 
     /// Let the endpoint-level reader hand a non-ACK bidi stream back to the
@@ -5338,8 +5299,6 @@ impl NatTraversalEndpoint {
         let next_connection_generation_clone = self.next_connection_generation.clone();
         let local_peer_id = self.local_peer_id;
         let emitted_events_clone = self.emitted_established_events.clone();
-        let relay_server_clone = self.relay_server.clone();
-        let ack_bidi_stream_tx_clone = self.ack_bidi_stream_tx.clone();
         let observed_address_tx_clone = self.observed_address_tx.clone();
         let traversal_event_notify_clone = self.traversal_event_notify.clone();
         let incoming_notify_clone = self.incoming_notify.clone();
@@ -5355,8 +5314,6 @@ impl NatTraversalEndpoint {
                 next_connection_generation_clone,
                 local_peer_id,
                 emitted_events_clone,
-                relay_server_clone,
-                ack_bidi_stream_tx_clone,
                 observed_address_tx_clone,
                 traversal_event_notify_clone,
                 incoming_notify_clone,
@@ -5378,10 +5335,6 @@ impl NatTraversalEndpoint {
         next_connection_generation: Arc<AtomicU64>,
         local_peer_id: PeerId,
         emitted_events: Arc<dashmap::DashSet<PeerId>>,
-        relay_server: Option<Arc<MasqueRelayServer>>,
-        ack_bidi_stream_tx: Arc<
-            ParkingRwLock<Option<mpsc::UnboundedSender<IncomingAckBidiStream>>>,
-        >,
         observed_address_tx: mpsc::UnboundedSender<ObservedAddressReport>,
         traversal_event_notify: Arc<tokio::sync::Notify>,
         incoming_notify: Arc<tokio::sync::Notify>,
@@ -5395,8 +5348,6 @@ impl NatTraversalEndpoint {
                     let connection_lifecycle = connection_lifecycle.clone();
                     let next_connection_generation = next_connection_generation.clone();
                     let emitted_events = emitted_events.clone();
-                    let relay_server = relay_server.clone();
-                    let ack_bidi_stream_tx = ack_bidi_stream_tx.clone();
                     let observed_address_tx = observed_address_tx.clone();
                     let traversal_event_notify = traversal_event_notify.clone();
                     let incoming_notify = incoming_notify.clone();
@@ -5460,21 +5411,6 @@ impl NatTraversalEndpoint {
                                     traversal_event_notify.notify_waiters();
                                 }
 
-                                if let Some(ref server) = relay_server {
-                                    let conn_clone = connection.clone();
-                                    let server_clone = Arc::clone(server);
-                                    let ack_bidi_stream_tx = ack_bidi_stream_tx.clone();
-                                    tokio::spawn(async move {
-                                        Self::handle_relay_requests(
-                                            peer_id,
-                                            conn_clone,
-                                            server_clone,
-                                            ack_bidi_stream_tx,
-                                        )
-                                        .await;
-                                    });
-                                }
-
                                 Self::spawn_observed_address_watch_task_parts(
                                     observed_address_tx.clone(),
                                     peer_id,
@@ -5500,36 +5436,6 @@ impl NatTraversalEndpoint {
                     break;
                 }
             }
-        }
-    }
-
-    /// Handle relay requests from a connected peer (symmetric P2P)
-    ///
-    /// This listens for bidirectional streams and processes CONNECT-UDP Bind requests.
-    /// Per ADR-004: All nodes are equal and participate in relaying with resource budgets.
-    fn dispatch_ack_bidi_stream(
-        ack_bidi_stream_tx: &Arc<
-            ParkingRwLock<Option<mpsc::UnboundedSender<IncomingAckBidiStream>>>,
-        >,
-        stream: IncomingAckBidiStream,
-    ) -> Result<(), IncomingAckBidiStream> {
-        let tx = ack_bidi_stream_tx.read().clone();
-        match tx {
-            Some(tx) => tx.send(stream).map_err(|error| error.0),
-            None => Err(stream),
-        }
-    }
-
-    async fn send_ack_bidi_not_supported(mut send_stream: InnerSendStream) {
-        let bytes = encode_ack_bidi_response(AckControlOutcome::Rejected(
-            ReceiveRejectReason::NotSupported,
-        ));
-        if let Err(error) = send_stream.write_all(&bytes).await {
-            debug!(error = %error, "failed to send ACK-v2 NotSupported response");
-            return;
-        }
-        if let Err(error) = send_stream.finish() {
-            debug!(error = %error, "failed to finish ACK-v2 NotSupported response");
         }
     }
 
@@ -5657,73 +5563,6 @@ impl NatTraversalEndpoint {
                     "Stream from {} is not a CONNECT-UDP request: {}",
                     client_addr, e
                 );
-            }
-        }
-    }
-
-    async fn handle_relay_requests(
-        peer_id: PeerId,
-        connection: InnerConnection,
-        relay_server: Arc<MasqueRelayServer>,
-        ack_bidi_stream_tx: Arc<
-            ParkingRwLock<Option<mpsc::UnboundedSender<IncomingAckBidiStream>>>,
-        >,
-    ) {
-        let client_addr = connection.remote_address();
-        debug!("Started relay request handler for peer at {}", client_addr);
-
-        loop {
-            // Accept bidirectional streams for relay requests
-            match connection.accept_bi().await {
-                Ok((send_stream, mut recv_stream)) => {
-                    let server = Arc::clone(&relay_server);
-                    let addr = client_addr;
-                    let conn_stable_id = connection.stable_id();
-                    let ack_bidi_stream_tx = ack_bidi_stream_tx.clone();
-                    let accepted_at = Instant::now();
-
-                    tokio::spawn(async move {
-                        let mut prefix = vec![0u8; ACK_BIDI_REQUEST_MAGIC.len()];
-                        if let Err(e) = recv_stream.read_exact(&mut prefix).await {
-                            debug!("Failed to read bidi stream prefix from {}: {}", addr, e);
-                            return;
-                        }
-
-                        if prefix.as_slice() == &ACK_BIDI_REQUEST_MAGIC[..] {
-                            let stream = IncomingAckBidiStream {
-                                peer_id,
-                                conn_stable_id,
-                                send: send_stream,
-                                recv: recv_stream,
-                                prefix,
-                                accepted_at,
-                            };
-                            if let Err(stream) =
-                                Self::dispatch_ack_bidi_stream(&ack_bidi_stream_tx, stream)
-                            {
-                                Self::send_ack_bidi_not_supported(stream.send).await;
-                            }
-                            return;
-                        }
-
-                        Self::handle_relay_bidi_stream_with_prefix(
-                            server,
-                            addr,
-                            send_stream,
-                            recv_stream,
-                            prefix,
-                        )
-                        .await;
-                    });
-                }
-                Err(e) => {
-                    // Connection closed or error
-                    debug!(
-                        "Relay handler stopping for {} - accept_bi error: {}",
-                        client_addr, e
-                    );
-                    break;
-                }
             }
         }
     }
@@ -6388,10 +6227,10 @@ impl NatTraversalEndpoint {
 
         info!("Establishing relay session to {}", relay_addr);
 
-        // Prefer reusing an existing peer connection to the relay.
-        // The relay server's handle_relay_requests is spawned for each ACCEPTED
-        // connection, so using the existing connection ensures a handler is
-        // already listening for bidi streams.
+        // Prefer reusing an existing peer connection to the relay: the
+        // endpoint's reader task demultiplexes relay bidi streams for every
+        // connection the application accepts (#280), so an existing
+        // connection already carries a serving path.
         let existing_conn = self.connections.iter().find_map(|entry| {
             let conn = entry.value();
             if conn.remote_address() == relay_addr && conn.close_reason().is_none() {
@@ -6601,9 +6440,12 @@ impl NatTraversalEndpoint {
 
     /// Accept incoming connections on the endpoint.
     ///
-    /// The pending-accept queue is bounded (`MAX_PENDING_ACCEPTS`); if the
-    /// application does not drain it, the oldest queued connections are
-    /// evicted and will not be returned here.
+    /// The bounded `pending_accepts` queue is the sole accept source (#280):
+    /// every producer (main accept loop, shared-relay accept loop) pushes here
+    /// with generation tagging, so a connection is never returned twice and
+    /// never receives two reader tasks. `ConnectionEstablished` remains an
+    /// observer event only. If the application does not drain the queue, the
+    /// oldest queued connections are evicted and will not be returned here.
     pub async fn accept_connection(&self) -> Result<(PeerId, InnerConnection), NatTraversalError> {
         debug!("Waiting for incoming connection via accept queue...");
         loop {
@@ -6640,50 +6482,6 @@ impl NatTraversalEndpoint {
                     pending.peer_id
                 );
                 return Ok((pending.peer_id, connection));
-            }
-
-            // Drain all pending events (non-blocking, under ParkingMutex) for
-            // relay/legacy paths that may still only signal via event_rx.
-            {
-                let mut event_rx = self.event_rx.lock();
-                loop {
-                    match event_rx.try_recv() {
-                        Ok(NatTraversalEvent::ConnectionEstablished {
-                            peer_id,
-                            remote_address,
-                            side,
-                        }) => {
-                            info!(
-                                "Received ConnectionEstablished event for peer {:?} at {} (side: {:?})",
-                                peer_id, remote_address, side
-                            );
-                            let Some(connection) = self
-                                .connections
-                                .get(&peer_id)
-                                .map(|entry| entry.value().clone())
-                            else {
-                                debug!(
-                                    "Ignoring stale ConnectionEstablished event for peer {:?}: connection no longer in storage",
-                                    peer_id
-                                );
-                                continue;
-                            };
-                            return Ok((peer_id, connection));
-                        }
-                        Ok(event) => {
-                            debug!(
-                                "Ignoring non-connection event while waiting for accept: {:?}",
-                                event
-                            );
-                        }
-                        Err(mpsc::error::TryRecvError::Empty) => break,
-                        Err(mpsc::error::TryRecvError::Disconnected) => {
-                            return Err(NatTraversalError::NetworkError(
-                                "Event channel closed".to_string(),
-                            ));
-                        }
-                    }
-                }
             }
 
             self.incoming_notify.notified().await;

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -3096,6 +3096,14 @@ impl NatTraversalEndpoint {
         self.transport_registry.as_ref()
     }
 
+    /// Whether a relay server is configured on this endpoint (the default).
+    /// Lets the reader's prefix demux decide synchronously whether an
+    /// unrecognised-prefix stream is a relay candidate before handing it to
+    /// the relay service on its own task (#280 round 2).
+    pub(crate) fn relay_server_present(&self) -> bool {
+        self.relay_server.is_some()
+    }
+
     /// Let the endpoint-level reader hand a non-ACK bidi stream back to the
     /// relay service after it has consumed the protocol prefix.
     pub(crate) async fn handle_relay_bidi_stream_from_app_reader(

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -90,8 +90,8 @@ use crate::happy_eyeballs::{self, HappyEyeballsConfig};
 use crate::mdns::{MdnsPeerRecord, MdnsRuntimeEvent, MdnsSnapshot, spawn_mdns_runtime};
 pub use crate::nat_traversal_api::TraversalPhase;
 use crate::nat_traversal_api::{
-    ConstrainedEventWithAddr, IncomingAckBidiStream, NatTraversalEndpoint, NatTraversalError,
-    NatTraversalEvent, PeerId, TraversalFailureReason,
+    ConstrainedEventWithAddr, NatTraversalEndpoint, NatTraversalError, NatTraversalEvent, PeerId,
+    TraversalFailureReason,
 };
 use crate::peer_directory::{PeerDirectorySnapshot, PeerDiscoverySource};
 use crate::port_mapping::{
@@ -3296,67 +3296,6 @@ impl P2pEndpoint {
             coordinator_health: Arc::new(crate::coordinator_health::CoordinatorHealth::new()),
             ack_response_drop_injection: Arc::new(AtomicUsize::new(0)),
         };
-
-        let (ack_bidi_tx, mut ack_bidi_rx) = mpsc::unbounded_channel();
-        endpoint.inner.set_ack_bidi_stream_sender(ack_bidi_tx);
-        {
-            let connected_peers = Arc::clone(&endpoint.connected_peers);
-            let peer_activity = Arc::clone(&endpoint.peer_activity);
-            let ack_diagnostics = Arc::clone(&endpoint.ack_diagnostics);
-            let ack_request_dedupe = Arc::clone(&endpoint.ack_request_dedupe);
-            let data_tx = endpoint.data_tx.clone();
-            let data_tx_diagnostics = Arc::clone(&endpoint.data_tx_diagnostics);
-            let data_tx_capacity = endpoint.data_tx_capacity;
-            let event_tx = endpoint.event_tx.clone();
-            let shutdown = endpoint.shutdown.clone();
-            let max_read_bytes = endpoint.config.max_message_size;
-            let ack_response_drop_injection = Arc::clone(&endpoint.ack_response_drop_injection);
-            tokio::spawn(async move {
-                loop {
-                    tokio::select! {
-                        _ = shutdown.cancelled() => break,
-                        stream = ack_bidi_rx.recv() => {
-                            let Some(IncomingAckBidiStream {
-                                peer_id,
-                                conn_stable_id,
-                                send,
-                                recv,
-                                prefix,
-                                accepted_at,
-                            }) = stream else {
-                                break;
-                            };
-                            if !Self::handle_ack_bidi_stream(
-                                ack_diagnostics.as_ref(),
-                                ack_request_dedupe.as_ref(),
-                                &connected_peers,
-                                &peer_activity,
-                                &data_tx,
-                                data_tx_diagnostics.as_ref(),
-                                data_tx_capacity,
-                                &event_tx,
-                                peer_id,
-                                conn_stable_id,
-                                send,
-                                recv,
-                                prefix,
-                                accepted_at,
-                                max_read_bytes,
-                                &ack_response_drop_injection,
-                            )
-                            .await
-                            {
-                                debug!(
-                                    "ACK-v2 bidi bridge stopping for peer {:?}: consumer gone",
-                                    peer_id
-                                );
-                                break;
-                            }
-                        }
-                    }
-                }
-            });
-        }
 
         // Spawn background pollers for transport and peer-address updates.
         endpoint.spawn_constrained_poller();
@@ -14506,10 +14445,16 @@ mod tests {
     /// partial prefix must not freeze the reader task. After the prefix-read
     /// timeout the reader resets the half-opened stream and continues, so a
     /// subsequent application stream is still delivered to `accept_bi`.
+    ///
+    /// #280: previously `#[ignore]`d as "timing-sensitive" — it was actually
+    /// sampling the two-consumer `accept_bi` race (the redundant
+    /// per-connection relay accept task). With the single-reader demux
+    /// restored it is deterministic and runs everywhere.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
     #[tokio::test]
-    #[ignore = "real two-node loopback test; timing-sensitive across CI configs \
-                (release / --no-default-features / beta / windows). Run explicitly: \
-                `cargo test --lib -- --ignored reader_recovers_from_prefix_starvation`"]
     async fn reader_recovers_from_prefix_starvation() {
         async fn build_endpoint() -> P2pEndpoint {
             P2pEndpoint::new(
@@ -15018,19 +14963,16 @@ mod tests {
     ///   connection is installed in BOTH `connected_peers` and the
     ///   nat-traversal winner map before connectivity is reported.
     ///
-    /// Ignored like its neighbour `reader_recovers_from_prefix_starvation`:
-    /// the two-node accept fixture is timing-sensitive across CI configs and,
-    /// in release builds, independently broken by ant-quic#280 (one connect
-    /// yields two accepted generations; the dialer's stream never surfaces) —
-    /// not fixable by settling or serialising.
+    /// #280: previously `#[ignore]`d (PR #279 round 3) because master's
+    /// two-consumer accept race made this fixture bimodal — the "two accepted
+    /// generations" symptom was in fact one connection returned twice plus the
+    /// relay task stealing the dialer's stream. With the single-reader demux
+    /// restored the churn sequence is deterministic.
     // Requires the network-discovery socket path: the fallback
     // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
     // connections (see issue tracked separately).
     #[cfg(all(test, feature = "network-discovery"))]
     #[tokio::test]
-    #[ignore = "real two-node loopback test; timing-sensitive across CI configs \
-                (release / --no-default-features / beta / windows). Run explicitly: \
-                `cargo test --lib -- --ignored churn_disconnect_reconnect_delivers_over_new_connection`"]
     async fn churn_disconnect_reconnect_delivers_over_new_connection() {
         // Deadline/poll values follow the neighbouring loopback fixtures:
         // a 30 s overall connect budget (relay_only_data_plane_end_to_end's
@@ -15149,6 +15091,248 @@ mod tests {
             .expect("post-churn read");
         assert_eq!(post_payload, b"post-churn");
 
+        a.shutdown().await;
+        b.shutdown().await;
+    }
+
+    /// #280 (a): single stream owner. An application stream opened by the
+    /// dialer must be delivered to the acceptor's app-stream queue EXACTLY
+    /// once, with a relay server configured (the default), and exactly one
+    /// reader task must own the connection.
+    ///
+    /// Pre-fix on origin/master this fails deterministically: `accept()`
+    /// returned the same connection twice (legacy `ConnectionEstablished`
+    /// accept path) so two reader tasks were spawned — `reader_handle_count`
+    /// was 2 — and the app stream itself was stolen ~50% of the time by the
+    /// redundant per-connection relay accept task, which parsed the app magic
+    /// as a big-endian relay length and silently dropped the stream.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
+    #[tokio::test]
+    async fn app_stream_has_single_owner_with_relay_server_configured() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        let b_for_accept = b.clone();
+        tokio::spawn(async move { while b_for_accept.accept().await.is_some() {} });
+        let b_addr = localhost_addr(b.local_addr().expect("b bound"));
+        let b_id = b.peer_id();
+        let a_id = a.peer_id();
+
+        tokio::time::timeout(Duration::from_secs(30), a.connect_addr(b_addr))
+            .await
+            .expect("connect timeout")
+            .expect("connect failed");
+
+        let (mut send, _recv) = a.open_bi(&b_id).await.expect("open_bi");
+        send.write_all(b"single-owner").await.expect("write");
+        send.finish().expect("finish");
+
+        // Delivered exactly once: the first accept yields the stream...
+        let (from, _, mut stream) = tokio::time::timeout(Duration::from_secs(15), b.accept_bi())
+            .await
+            .expect("app stream must reach the accept queue")
+            .expect("app stream handle");
+        assert_eq!(from, a_id);
+        let payload = stream.read_to_end(1024).await.expect("read payload");
+        assert_eq!(payload, b"single-owner");
+        // ...and a second accept finds nothing (no duplicate delivery).
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), b.accept_bi())
+                .await
+                .is_err(),
+            "the app stream must be delivered exactly once"
+        );
+
+        // Exactly one reader task owns the connection (pre-fix: two).
+        assert_eq!(
+            b.reader_handle_count().await,
+            1,
+            "one accepted connection must have exactly one reader task"
+        );
+
+        a.shutdown().await;
+        b.shutdown().await;
+    }
+
+    /// #280 (b): an app-magic stream must reach the app queue even when the
+    /// acceptor's reader starts LATE — with a relay server configured (the
+    /// default).
+    ///
+    /// Pre-fix on origin/master this fails deterministically: the moment the
+    /// NAT layer accepted the connection it spawned the redundant relay task,
+    /// the only `accept_bi` consumer until the application accepted. During
+    /// the deliberate 300 ms head start it consumed the dialer's app stream,
+    /// mis-parsed the app magic (`ANQAppB1` → big-endian length
+    /// 1,096,057,153) and silently dropped it — the accept queue stayed empty
+    /// forever (the x0x#277 "shape B" signature: writes succeed, zero
+    /// received). Post-fix there is no second consumer: the stream waits in
+    /// the connection's accept queue until the reader starts.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
+    #[tokio::test]
+    async fn late_reader_still_receives_app_stream_with_relay_configured() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        // Deliberately NO accept loop on b yet: on the pre-fix code the
+        // relay task gets an uncontested window over the connection.
+        let b_addr = localhost_addr(b.local_addr().expect("b bound"));
+        let b_id = b.peer_id();
+        let a_id = a.peer_id();
+
+        tokio::time::timeout(Duration::from_secs(30), a.connect_addr(b_addr))
+            .await
+            .expect("connect timeout")
+            .expect("connect failed");
+
+        let (mut send, _recv) = a.open_bi(&b_id).await.expect("open_bi");
+        send.write_all(b"late-reader").await.expect("write");
+        send.finish().expect("finish");
+
+        // Give any rogue second consumer an uncontested window.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // NOW the application accepts (reader spawns) — the stream must still
+        // be delivered.
+        let b_for_accept = b.clone();
+        tokio::spawn(async move { while b_for_accept.accept().await.is_some() {} });
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            if let Ok(Ok((from, _, mut stream))) =
+                tokio::time::timeout(Duration::from_secs(2), b.accept_bi()).await
+            {
+                assert_eq!(from, a_id);
+                let payload = stream.read_to_end(1024).await.expect("read payload");
+                assert_eq!(payload, b"late-reader");
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "app stream was consumed by a rogue accept_bi consumer (dropped silently)"
+            );
+        }
+
+        a.shutdown().await;
+        b.shutdown().await;
+    }
+
+    /// #280 (c): a partial-prefix stream must not leak consumer tasks. The
+    /// reader's `BIDI_PREFIX_READ_TIMEOUT` releases the starved stream; the
+    /// connection keeps exactly one reader and stays fully serviceable.
+    ///
+    /// Pre-fix on origin/master this fails deterministically: the same
+    /// connection was accepted twice (two reader tasks ⇒
+    /// `reader_handle_count` == 2), and every partial-prefix stream
+    /// additionally parked a relay task forever on an unbounded prefix read.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
+    #[tokio::test]
+    async fn partial_prefix_stream_does_not_leak_consumer_tasks() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        let b_for_accept = b.clone();
+        tokio::spawn(async move { while b_for_accept.accept().await.is_some() {} });
+        let b_addr = localhost_addr(b.local_addr().expect("b bound"));
+        let b_id = b.peer_id();
+
+        tokio::time::timeout(Duration::from_secs(30), a.connect_addr(b_addr))
+            .await
+            .expect("connect timeout")
+            .expect("connect failed");
+
+        // Raw stream with a partial (3 of 8 bytes) prefix: the reader must
+        // time the prefix read out and reset the stream instead of parking.
+        let conn = a
+            .inner
+            .get_connection(&b_id)
+            .expect("get_connection")
+            .expect("a is connected to b");
+        let (mut starved_send, _starved_recv) = conn.open_bi().await.expect("raw open_bi");
+        starved_send
+            .write_all(&[0u8; 3])
+            .await
+            .expect("partial prefix write");
+
+        // Wait past BIDI_PREFIX_READ_TIMEOUT so the reader releases the
+        // starved stream (test cfg: 2 s; margin for scheduling).
+        tokio::time::sleep(BIDI_PREFIX_READ_TIMEOUT + Duration::from_millis(500)).await;
+
+        assert_eq!(
+            b.reader_handle_count().await,
+            1,
+            "the starved stream must not grow the reader set (pre-fix: duplicate accept)"
+        );
+
+        // And the same single reader still serves a good app stream.
+        let (mut send, _recv) = a.open_bi(&b_id).await.expect("open_bi after starvation");
+        send.write_all(b"post-starvation").await.expect("write");
+        send.finish().expect("finish");
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            if let Ok(Ok((_from, _, mut stream))) =
+                tokio::time::timeout(Duration::from_secs(2), b.accept_bi()).await
+            {
+                let payload = stream.read_to_end(1024).await.expect("read payload");
+                assert_eq!(payload, b"post-starvation");
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "reader never recovered from the starved partial-prefix stream"
+            );
+        }
+
+        drop(starved_send);
         a.shutdown().await;
         b.shutdown().await;
     }

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -6140,7 +6140,7 @@ impl P2pEndpoint {
     #[allow(clippy::too_many_arguments)]
     async fn handle_bidi_stream_inline(
         ack_bidi_serialization: &Arc<tokio::sync::Mutex<()>>,
-        inner: &NatTraversalEndpoint,
+        inner: &Arc<NatTraversalEndpoint>,
         ack_diagnostics: &AckDiagnostics,
         ack_request_dedupe: &Arc<AckRequestDedupeCache>,
         connected_peers: &Arc<RwLock<HashMap<PeerId, PeerConnection>>>,
@@ -6263,10 +6263,20 @@ impl P2pEndpoint {
             return true;
         }
 
-        if inner
-            .handle_relay_bidi_stream_from_app_reader(connection.clone(), send, recv, prefix)
-            .await
-        {
+        // #280 round 2: serve the relay stream on its OWN task. The relay
+        // session's success path runs `run_stream_forwarding_loop` for the
+        // whole session lifetime, and `establish_relay_session` deliberately
+        // REUSES the peer connection — awaiting that loop inline would pin
+        // the sole accept consumer, so no further app/ACK-v2/gossip stream
+        // from this peer would be accepted while the session lives.
+        if inner.relay_server_present() {
+            let inner = Arc::clone(inner);
+            let relay_connection = connection.clone();
+            tokio::spawn(async move {
+                inner
+                    .handle_relay_bidi_stream_from_app_reader(relay_connection, send, recv, prefix)
+                    .await;
+            });
             return true;
         }
 
@@ -9594,8 +9604,27 @@ impl P2pEndpoint {
         });
         let abort_handle = join_handle.abort_handle();
 
-        // Append — DO NOT pre-empt existing readers. See function doc.
+        // #280 round 2: enforce one reader per CONNECTION (stable_id). Readers
+        // for OTHER generations of the same peer are still tolerated (issue
+        // #166 drain semantics) — only a duplicate for the same connection is
+        // skipped, turning the single-reader invariant from a call-site audit
+        // into an enforced guarantee.
         let mut handles = self.reader_handles.write().await;
+        if handles.get(&peer_id).is_some_and(|entries| {
+            entries
+                .iter()
+                .any(|handle| handle.conn_stable_id == conn_stable_id)
+        }) {
+            debug!(
+                peer_id = ?peer_id,
+                conn_stable_id,
+                "reader already registered for this connection; cancelling duplicate spawn"
+            );
+            drop(handles);
+            cancel.cancel();
+            abort_handle.abort();
+            return;
+        }
         handles.entry(peer_id).or_default().push(ReaderTaskHandle {
             generation,
             conn_stable_id,

--- a/tests/b_send_with_receive_ack.rs
+++ b/tests/b_send_with_receive_ack.rs
@@ -88,7 +88,7 @@ async fn send_with_receive_ack_returns_after_remote_pipeline_accepts() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn send_with_receive_ack_survives_relay_handler_bidi_accept_competition() {
+async fn send_with_receive_ack_survives_concurrent_relay_bind_streams() {
     let _guard = test_guard().await;
 
     let receiver = make_node(vec![]).await;

--- a/tests/relayed_byte_stream.rs
+++ b/tests/relayed_byte_stream.rs
@@ -136,10 +136,10 @@ async fn relay_connect_udp_bind_on_live_node() {
         .expect("get_quic_connection error")
         .expect("no connection to relay node after successful connect");
 
-    // Open a raw bidi stream. This is NOT Node::open_bi() — that method prepends
-    // the 8-byte ANQAppB1 magic which would make handle_relay_requests interpret
-    // the first 4 bytes as a length = 0x414e5141 > 1024 and silently drop the stream.
-    // A raw stream has no prefix, so the first 4 bytes are our length field.
+    // Open a raw bidi stream. This is NOT Node::open_bi() — that method
+    // prepends the 8-byte ANQAppB1 magic, which the reader's prefix demux
+    // routes to the application queue instead of the relay service. A raw
+    // stream has no magic, so the first 4 bytes are our length field.
     let (mut send, mut recv) = timeout(Duration::from_secs(5), conn.open_bi())
         .await
         .expect("open_bi timed out")
@@ -193,4 +193,121 @@ async fn relay_connect_udp_bind_on_live_node() {
         "relay response must include the allocated UDP forwarding address; \
          response={response:?}",
     );
+}
+
+/// #280 round 2: a live relay session must not wedge the peer's other
+/// streams.
+///
+/// `establish_relay_session` deliberately REUSES the existing peer
+/// connection, so the CONNECT-UDP forwarding loop shares the connection with
+/// application bidi streams and uni datagrams. Pre-fix, the reader awaited
+/// the relay branch inline, pinning the sole `accept_bi`/`accept_uni`
+/// consumer inside `run_stream_forwarding_loop` for the whole session: every
+/// app stream and uni from that peer went unaccepted until the session ended.
+/// Post-fix the relay stream is served on its own task after prefix
+/// classification, and both an app bidi stream and a uni datagram from the
+/// same peer are still accepted while the session is live.
+#[tokio::test]
+async fn relay_session_does_not_wedge_peer_streams() {
+    // b: relay node (relay server configured by default), with a normal
+    // accept loop so the connection gets its single reader task.
+    let b = Node::bind("127.0.0.1:0".parse().expect("addr"))
+        .await
+        .expect("relay node");
+    let a = Node::bind("127.0.0.1:0".parse().expect("addr"))
+        .await
+        .expect("client node");
+
+    let b_for_accept = b.clone();
+    tokio::spawn(async move { while b_for_accept.accept().await.is_some() {} });
+
+    let b_id = b.peer_id();
+    let b_addr = loopback_addr(&b);
+
+    timeout(Duration::from_secs(5), a.connect_addr(b_addr))
+        .await
+        .expect("connect timed out")
+        .expect("connect failed");
+
+    // Open the relay session on the SAME connection the app streams will use.
+    let conn = a
+        .inner_endpoint()
+        .get_quic_connection(&b_id)
+        .expect("get_quic_connection error")
+        .expect("no connection to relay node after successful connect");
+    let (mut send, mut recv) = timeout(Duration::from_secs(5), conn.open_bi())
+        .await
+        .expect("open_bi timed out")
+        .expect("open_bi failed");
+
+    let request = ConnectUdpRequest::bind_any();
+    let request_bytes: Bytes = request.encode();
+    let req_len = request_bytes.len() as u32;
+    send.write_all(&req_len.to_be_bytes())
+        .await
+        .expect("write request length");
+    send.write_all(&request_bytes)
+        .await
+        .expect("write request body");
+    // Do NOT finish() — the relay stream stays open for UDP forwarding.
+
+    let mut resp_len_buf = [0u8; 4];
+    timeout(Duration::from_secs(5), recv.read_exact(&mut resp_len_buf))
+        .await
+        .expect("read response length timed out")
+        .expect("read response length failed");
+    let resp_len = u32::from_be_bytes(resp_len_buf) as usize;
+    let mut response_bytes = vec![0u8; resp_len];
+    timeout(Duration::from_secs(5), recv.read_exact(&mut response_bytes))
+        .await
+        .expect("read response body timed out")
+        .expect("read response body failed");
+    let response = ConnectUdpResponse::decode(&mut Bytes::from(response_bytes))
+        .expect("failed to decode CONNECT-UDP Response");
+    assert!(
+        response.is_success(),
+        "relay session must be established before asserting peer-stream liveness"
+    );
+
+    // While the relay session is live on this connection: an application
+    // bidi stream from the same peer must still be accepted.
+    let (mut app_send, _app_recv) = timeout(Duration::from_secs(5), a.open_bi(&b_id))
+        .await
+        .expect("app open_bi timed out")
+        .expect("app open_bi failed");
+    app_send
+        .write_all(b"app-during-relay")
+        .await
+        .expect("app write");
+    app_send.finish().expect("app finish");
+    let (_from, _send_half, mut app_stream) = timeout(Duration::from_secs(5), b.accept_bi())
+        .await
+        .expect("app stream must be accepted while the relay session is live")
+        .expect("app stream handle");
+    let app_payload = tokio::time::timeout(Duration::from_secs(5), app_stream.read_to_end(1024))
+        .await
+        .expect("app read timed out")
+        .expect("app read");
+    assert_eq!(app_payload, b"app-during-relay");
+
+    // And a uni datagram from the same peer must still be delivered via
+    // `recv()` (the reader's accept_uni path).
+    a.send(&b_id, b"uni-during-relay")
+        .await
+        .expect("send uni datagram");
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let uni_payload = loop {
+        if let Ok(Ok((_peer, data))) = tokio::time::timeout(Duration::from_secs(2), b.recv()).await
+        {
+            break data;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "uni datagram must be delivered while the relay session is live"
+        );
+    };
+    assert_eq!(uni_payload, b"uni-during-relay");
+
+    a.shutdown().await;
+    b.shutdown().await;
 }

--- a/tests/relayed_byte_stream.rs
+++ b/tests/relayed_byte_stream.rs
@@ -12,14 +12,16 @@
 //! ANQAckB3 magic prefix) and exchanges a length-prefixed CONNECT-UDP Bind / Response
 //! with `r`'s relay service. The test asserts the response is a success and that `r`
 //! allocated a UDP forwarding socket for the session.
-//!
 //! This exercises a code path not covered elsewhere:
-//! - `handle_relay_requests` accepting bidi streams on an accepted connection
-//!   (`nat_traversal_api.rs` line 5527)
+//! - the reader task's bidi demux forwarding a raw (unrecognised-prefix)
+//!   stream to the relay service via `handle_relay_bidi_stream_from_app_reader`
+//!   (`p2p_endpoint.rs`) — the single stream consumer on an accepted
+//!   connection (#280: the former redundant per-connection relay accept task
+//!   was removed)
 //! - `handle_relay_bidi_stream_with_prefix` parsing the CONNECT-UDP Bind frame
-//!   (`nat_traversal_api.rs` line 5419)
+//!   (`nat_traversal_api.rs`)
 //! - `MasqueRelayServer::handle_connect_request` binding a real UDP socket for
-//!   the session (`masque/relay_server.rs` line 512)
+//!   the session (`masque/relay_server.rs`)
 //! - The length-prefixed CONNECT-UDP Response encoding
 //!
 //! `masque_integration_tests.rs` tests the relay protocol types in isolation using
@@ -92,25 +94,18 @@ fn loopback_addr(node: &Node) -> std::net::SocketAddr {
 /// Two real `Node` instances are bound on loopback. `a` opens a raw QUIC bidi stream
 /// on its connection to `r` (bypassing `Node::open_bi`'s ANQAppB1 prefix) and
 /// exchanges a CONNECT-UDP Bind / Response with `r`'s relay service.
-///
 /// # Determinism guarantee
 ///
-/// `r.accept()` is deliberately **never called**. Without an application-layer accept
-/// loop, `spawn_reader_task` is never spawned on `r` for the connection from `a`. The
-/// only concurrent consumer of bidi streams on that connection is `handle_relay_requests`,
-/// which is spawned automatically by the NAT traversal layer when the connection is
-/// accepted (`nat_traversal_api.rs` line 5346). This makes the test deterministic:
-/// there is no race between `spawn_reader_task` and `handle_relay_requests` for the
-/// CONNECT-UDP Bind stream.
-///
-/// (For comparison: in `node_app_streams.rs` the connected-pair helper does call
-/// `b.accept()`, which spawns both handlers concurrently. ANQAppB1 and ANQAckB3
-/// streams route correctly because each unknown-prefix stream is silently dropped by
-/// the other handler — but a raw CONNECT-UDP stream might be stolen by
-/// `spawn_reader_task` if both are running, making such a test non-deterministic.)
+/// `r` runs a normal application accept loop, so the connection from `a` gets
+/// exactly one reader task — the single `accept_bi` consumer on that
+/// connection (#280). The reader's prefix demux forwards the raw
+/// length-prefixed CONNECT-UDP Bind stream to the relay service; there is no
+/// second consumer to race with. (Pre-#280 this test deliberately never called
+/// `r.accept()` because a redundant NAT-layer relay task raced the reader for
+/// bidi streams; that task no longer exists.)
 #[tokio::test]
 async fn relay_connect_udp_bind_on_live_node() {
-    // r: relay node. No accept loop — handle_relay_requests runs automatically.
+    // r: relay node, with a normal accept loop (single-consumer path, #280).
     let r = Node::bind("127.0.0.1:0".parse().expect("addr"))
         .await
         .expect("relay node");
@@ -118,19 +113,19 @@ async fn relay_connect_udp_bind_on_live_node() {
         .await
         .expect("client node");
 
+    // r drains accepted connections so each gets its single reader task.
+    let r_for_accept = r.clone();
+    tokio::spawn(async move { while r_for_accept.accept().await.is_some() {} });
+
     let r_id = r.peer_id();
     let r_addr = loopback_addr(&r);
 
-    // Connect a → r. The NAT traversal layer on r accepts the incoming connection
-    // and spawns handle_relay_requests in a background task.
+    // Connect a → r. r's accept loop registers the connection and spawns its
+    // single reader task, whose prefix demux serves relay requests.
     timeout(Duration::from_secs(5), a.connect_addr(r_addr))
         .await
         .expect("connect timed out")
         .expect("connect failed");
-
-    // Yield to give r's NAT traversal accept-loop task time to run and spawn
-    // handle_relay_requests before we push the bidi stream into the connection.
-    tokio::task::yield_now().await;
 
     // Retrieve the raw QUIC connection from a's side.
     // After a successful connect_addr(), the connection is stored in a's NAT


### PR DESCRIPTION
Fixes #280; refs saorsa-labs/x0x#277 (shape B)

## Mechanism (corrected root cause per the issue's last comment + instrumented analysis)

There were never two accepted *generations*. One connection had **two unsynchronised `accept_bi()` consumers**:

- **Defect A (the stream thief)**: whenever a relay server exists — the default — `accept_connections` spawned a per-connection `handle_relay_requests` task that loops on `connection.accept_bi()`, the same source the endpoint reader task polls. Whoever polls first wins. The relay task has **no app-magic branch**: on winning an app stream it parsed `ANQAppB1`'s first 4 bytes as a big-endian length (1,096,057,153), tripped "request too large" and **returned, dropping the stream** — no reset, no error, no event. The opener's `write_all` had already succeeded: exactly the x0x#277 "shape B" signature (writes succeed, zero received). Bimodal ~50% in release (`reader_recovers_from_prefix_starvation`: 4.2 s pass / 46 s fail).
- **Defect B (doubles the racers)**: `accept_connection()` had two accept sources — the `pending_accepts` queue and a legacy `ConnectionEstablished` drain — so one connection was returned twice and got **two reader tasks** (confirmed by instrumented traces: `LEGACY EVENT PATH` + two `ReaderExited { generation: 1 }`).
- **Also**: `handle_relay_requests`' prefix read had **no timeout** — a peer opening a bidi stream and sending ≤7 bytes leaked one task per stream, forever (remote-triggerable).

## Fix (no wire/frame/transport-parameter change)

1. **Deleted the redundant relay accept task** (spawn + `handle_relay_requests`) together with its now-dead ACK-bidi bridge plumbing (`IncomingAckBidiStream`, `set_ack_bidi_stream_sender`, `dispatch_ack_bidi_stream`, `send_ack_bidi_not_supported`, the consumer task in `P2pEndpoint::new`). Relay serving runs **exclusively** through the reader's prefix demux (ACK-v2 → app → relay — the ordering the demux comment always required but could only guarantee inside one task), where every prefix read is bounded by `BIDI_PREFIX_READ_TIMEOUT`. Surveyed: **no unbounded prefix read remains**.
2. **`pending_accepts` is the sole accept source**: the legacy `ConnectionEstablished` branch in `accept_connection()` is gone (the event remains an observer event). A connection is never returned twice and never gets two reader tasks. The dedupe-set clear in `register_connection_lifecycle_parts` is untouched — it exists for event re-emission on re-registration, not for the accept path.
3. `relay_connect_udp_bind_on_live_node` updated to the supported single-consumer path: the relay node now runs an accept loop. Pre-fix, that test **deliberately never called `accept()`** to dodge this very race — its own doc comment documented the two-consumer race as its determinism strategy — and it failed deterministically (5.2 s timeout) with the task deleted. Serving relay requests on a connection whose owner never drains `accept()` was exactly the unsupported mode the analysis called out (it also loses ACK-v2, `recv()` and app streams).

## Relay-serving proof

- All 245 relay-adjacent tests green (`test(relay)`, `node_app_streams`, `test(masque)`), including `relay_connect_udp_bind_on_live_node` through the reader demux (0.17 s) and `relay_only_data_plane_end_to_end`.
- `establish_relay_session`'s stale comment referencing the deleted task updated to the reader-demux reality.

## Tests — a/b/c verified to FAIL 3/3 on clean `527f6575` (worktree, only the tests transplanted); all pass on this branch

- **(a) `app_stream_has_single_owner_with_relay_server_configured`**: dialer's app stream delivered to the accept queue **exactly once** (second accept times out) and **exactly one reader task** (`reader_handle_count == 1`). Master failure: count == 2 (defect B, deterministic, 1.2 s) and/or the stream stolen (defect A).
- **(b) `late_reader_still_receives_app_stream_with_relay_configured`**: the acceptor's reader starts 300 ms after the app stream is written — a rogue consumer gets an uncontested window. Master failure: deterministic 16.5 s "consumed by a rogue accept_bi consumer" (with no reader yet, the relay task is the sole consumer and always steals).
- **(c) `partial_prefix_stream_does_not_leak_consumer_tasks`**: raw stream + 3-byte prefix, wait past the timeout; single reader retained and a good stream still served. Master failure: 2 readers (defect B, 2.7 s).
- **Un-ignored** `reader_recovers_from_prefix_starvation` and `churn_disconnect_reconnect_delivers_over_new_connection` — both were sampling this race (the latter's "two accepted generations" symptom was defect B + A). Both **5/5 in release** (`cargo test --release --lib`): prefix ≈6.2 s, churn ≈4.14 s (matching the analysis's post-fix timing exactly; pre-fix churn failed CI on 2-vCPU runners).

## Gates

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` ✅ · production panic-safety clippy (`-D clippy::panic/unwrap_used/expect_used`) ✅
- Release reproducer 5× each (the CI command shape) ✅ 10/10
- Unfiltered `cargo nextest run --workspace --all-features --no-fail-fast`: **origin/master (527f6575) baseline 1×: 3399/5/53** (docker ×2, `lifecycle_sender_stale`, `recv_after_reconnect`, `b_events_parity`). **This branch 2×: 3400/9, 3401/8** — `relayed_byte_stream` green both runs; every failure is a deterministic docker-asset test (fixtures removed in `46ae21df`) or a rotating load flake (`lifecycle_simultaneous_replace`, `lifecycle_observability`, `lifecycle_active_close`, `simultaneous_connect_dedup`, `lifecycle_sender_stale`, `recv_after_reconnect`, `b_events_parity`) — each of the new-name ones verified passing in isolation on both trees; note this branch un-ignores two heavyweight fixtures master skips, adding load to the pool. No failure is deterministic on this branch and absent from master's flake family.
- `cargo doc`: **no CI workflow runs it** (established in #279 round 2) — not run here; the six pre-existing broken intra-doc links remain for #281's already-open fix.
- CHANGELOG under `[Unreleased]`; no version bump; no new `#[ignore]`s (two removed).


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63423363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the changed connection paths consistently establish one reader and preserve ACK, application, and relay stream routing.

<h3>Summary</h3>

- Removes the competing NAT-layer relay/ACK stream consumer and routes ACK-v2, application, and relay streams through the reader’s bounded prefix demultiplexer.
- Makes `pending_accepts` the sole source for inbound application accepts, preventing duplicate reader creation.
- Adds and enables regression coverage for late readers, partial prefixes, connection churn, and relay serving through the single-consumer path.
- Updates nextest scheduling and documentation for the heavier loopback tests.

<h3>Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    C[Established QUIC connection] --> Q[pending_accepts]
    Q --> A[P2pEndpoint::accept]
    A --> R[Single reader task]
    R --> B[accept_bi]
    B --> T{Bounded prefix demux}
    T -->|ACK-v2 magic| K[ACK-v2 handler]
    T -->|Application magic| P[Application stream queue]
    T -->|Other prefix| M[MASQUE relay handler]
```

<sub>Reviews (1) · Last reviewed commit: ["fix(streams): single accept\_bi consumer ..."](https://github.com/saorsa-labs/ant-quic/commit/efd3af3398ea1ffb73d0128e83af7ae74872bdd5)</sub>

<!-- /greptile_comment -->