### PR TITLE
fix(shutdown): close superseded lifecycle survivors before socket release (#283)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,5 +25,5 @@ test-group = "node-app-streams"
 # round 2), and victims rotate with scheduling. All of them are serialised
 # into one group so their handshake/CPU spikes never overlap each other.
 [[profile.default.overrides]]
-filter = "test(p2p_endpoint::tests::churn_disconnect_reconnect_delivers_over_new_connection) or test(p2p_endpoint::tests::disconnect_sweeps_surviving_generation_open_bi_reports_connection_closed) or test(reader_recovers_from_prefix_starvation) or test(app_stream_has_single_owner_with_relay_server_configured) or test(late_reader_still_receives_app_stream_with_relay_configured) or test(partial_prefix_stream_does_not_leak_consumer_tasks) or binary_id(ant-quic::b_events_parity)"
+filter = "test(p2p_endpoint::tests::churn_disconnect_reconnect_delivers_over_new_connection) or test(p2p_endpoint::tests::disconnect_sweeps_surviving_generation_open_bi_reports_connection_closed) or test(reader_recovers_from_prefix_starvation) or test(app_stream_has_single_owner_with_relay_server_configured) or test(late_reader_still_receives_app_stream_with_relay_configured) or test(partial_prefix_stream_does_not_leak_consumer_tasks) or test(shutdown_closes_superseded_survivors_remote_observes_disconnect) or binary_id(ant-quic::b_events_parity)"
 test-group = "loopback-pair-heavyweights"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relay session never pins the reader (`run_stream_forwarding_loop` shares the peer
   connection), and `spawn_reader_task` now enforces one reader per connection (stable_id).
 
+- **`shutdown()` closes superseded lifecycle survivors before the drain (#283, x0x#510).**
+  `NatTraversalEndpoint::shutdown` closed only the canonical `connections` entries; Superseded
+  survivors were closed merely implicitly by the post-drain `connection_lifecycle.clear()`,
+  immediately before `release_socket_for_shutdown` yanked the socket, so their CONNECTION_CLOSE
+  frames frequently never transmitted. The remote then kept the peer "connected" (its
+  `is_peer_connected` repromotes any still-alive Superseded entry) until the idle timeout — the
+  x0x restart-class "old owner connection never observed as gone". Shutdown now explicitly
+  closes every lifecycle-tracked generation BEFORE the bounded drain, so the close frames flush
+  while the socket still exists and the remote observes the disconnect within the drain window.
+  The remote-side repromotion logic itself is unchanged (possible follow-up).
+
 ## [0.27.50] - 2026-09-07
 
 ### Fixed

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -8337,6 +8337,35 @@ impl NatTraversalEndpoint {
             }
         }
 
+        // #283: close every lifecycle-tracked generation — Superseded
+        // survivors included — BEFORE the bounded drain. Previously only the
+        // canonical `connections` entries were closed here; survivors were
+        // closed merely implicitly by `connection_lifecycle.clear()` AFTER
+        // wait_idle, immediately before the socket release, so their
+        // CONNECTION_CLOSE frames frequently never transmitted. The REMOTE
+        // then kept the peer "connected" (its `is_peer_connected` falls
+        // through to `repromote_surviving_connection`, which resurrects any
+        // still-alive Superseded entry) until the idle timeout — the x0x#510
+        // restart-class "old owner connection never observed as gone".
+        {
+            let mut lifecycle = self.connection_lifecycle.write();
+            let mut closed = 0usize;
+            for entries in lifecycle.values_mut() {
+                for entry in entries.iter_mut() {
+                    if entry.connection.close_reason().is_none() {
+                        entry
+                            .connection
+                            .close(crate::VarInt::from_u32(0), b"Shutdown");
+                        closed += 1;
+                    }
+                }
+            }
+            drop(lifecycle);
+            if closed > 0 {
+                info!("shutdown: closed {closed} additional lifecycle-tracked connection(s)");
+            }
+        }
+
         // Bounded drain: in simultaneous-shutdown scenarios both sides may
         // close at once, so wait_idle can stall until the idle timeout.
         if let Some(ref endpoint) = self.inner_endpoint {

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -15124,6 +15124,122 @@ mod tests {
         b.shutdown().await;
     }
 
+    /// #283: `NatTraversalEndpoint::shutdown` must close every
+    /// lifecycle-tracked generation — Superseded survivors included — BEFORE
+    /// the bounded drain, so the CONNECTION_CLOSE frames flush while the
+    /// socket still exists. Previously only the canonical `connections`
+    /// entries were closed; survivors were closed merely implicitly by the
+    /// post-drain `connection_lifecycle.clear()`, immediately before
+    /// `release_socket_for_shutdown` yanked the socket, so the remote kept
+    /// the peer "connected" (its `is_peer_connected` repromotes any
+    /// still-alive Superseded entry) until the idle timeout — the x0x#510
+    /// restart-class "old owner connection never observed as gone".
+    ///
+    /// Construction: B dials A twice into the SAME initiator family (both
+    /// raw handshakes, registered on B explicitly — B's NAT accept task
+    /// processes one inbound at a time, so inbound-only constructions cannot
+    /// stack generations). The second registration is the newer same-family
+    /// generation and wins the tiebreak DETERMINISTICALLY, demoting the
+    /// first connection to an OPEN Superseded survivor on B. A holds the
+    /// first connection (its accept task registered it, its accept loop
+    /// spawned the reader). B's inner endpoint then shuts down: pre-fix only
+    /// the canonical winner is closed, the survivor stays transport-open and
+    /// A must stay "connected" until its idle timeout; with the fix every
+    /// generation closes before the drain and A observes the disconnect
+    /// within it.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
+    #[tokio::test]
+    async fn shutdown_closes_superseded_survivors_remote_observes_disconnect() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        let a_for_accept = a.clone();
+        tokio::spawn(async move { while a_for_accept.accept().await.is_some() {} });
+        let a_addr = localhost_addr(a.local_addr().expect("a bound"));
+        let b_id = b.peer_id();
+
+        // First B → A dial: A's NAT accept task registers it and A's accept
+        // loop adopts it (outer record + reader) — A is connected through it.
+        let c0 = tokio::time::timeout(Duration::from_secs(10), b.attempt_direct_handshake(a_addr))
+            .await
+            .expect("c0 handshake timeout")
+            .expect("c0 handshake");
+        let c0_probe = c0.clone();
+        b.inner
+            .add_connection_with_outcome(a.peer_id(), c0)
+            .expect("register c0 on B");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if a.is_connected(&b_id).await {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "A never adopted the first dial (not connected)"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        // Second B → A dial, same initiator family: newer generation wins
+        // deterministically, demoting c0 to an OPEN Superseded survivor on B.
+        let c1 = tokio::time::timeout(Duration::from_secs(10), b.attempt_direct_handshake(a_addr))
+            .await
+            .expect("c1 handshake timeout")
+            .expect("c1 handshake");
+        b.inner
+            .add_connection_with_outcome(a.peer_id(), c1.clone())
+            .expect("register c1 on B");
+        assert_eq!(
+            b.inner
+                .get_connection(&a.peer_id())
+                .expect("get_connection ok")
+                .expect("canonical winner")
+                .stable_id(),
+            c1.stable_id(),
+            "the newer same-family dial must be the canonical winner"
+        );
+        assert!(
+            c0_probe.close_reason().is_none(),
+            "the demoted first dial must remain open (Superseded survivor)"
+        );
+
+        // B's inner endpoint shuts down — the path that, pre-fix, closed
+        // only the canonical winner and left the Superseded survivor open.
+        b.inner.shutdown().await.expect("inner shutdown");
+
+        // A must observe the disconnect within the drain window (the bounded
+        // drain is 5 s; the QUIC idle timeout is far longer — pre-fix, A
+        // stays connected until it).
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while a.is_connected(&b_id).await {
+            assert!(
+                Instant::now() < deadline,
+                "A must observe B's shutdown within the drain window — a                  superseded survivor was never closed"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        a.shutdown().await;
+    }
+
     /// #280 (a): single stream owner. An application stream opened by the
     /// dialer must be delivered to the acceptor's app-stream queue EXACTLY
     /// once, with a relay server configured (the default), and exactly one


### PR DESCRIPTION
Fixes #283

## Mechanism (per the issue, confirmed in code)

`NatTraversalEndpoint::shutdown` closed only the canonical `connections` entries. Superseded-but-alive lifecycle survivors were closed merely **implicitly** by the post-drain `connection_lifecycle.clear()`, immediately before `release_socket_for_shutdown` yanked the socket — so their CONNECTION_CLOSE frames frequently never transmitted. On the remote, `is_peer_connected` falls through to `repromote_surviving_connection`, which resurrects any still-alive Superseded entry, and `remove_connected_peer_if_unroutable` refuses to drop the outer entry — the remote keeps the peer "connected" until the idle timeout (the x0x#510 restart-class "old owner connection never observed as gone"; x0x CI jobs 103561131939 / 103569350890 failing the 5 s barrier).

## Fix

`shutdown` now explicitly closes **every** lifecycle-tracked generation (Superseded survivors included) **before** the bounded drain (`wait_idle`), so the close frames flush while the socket still exists and the remote observes the disconnect within the drain window (5 s). The remote-side repromotion logic is deliberately unchanged — whether a remote should repromote a survivor after the winner dies is existing behavior with its own tests (#281's `reader_exit_winner_repromotes_open_superseded_survivor…`); gating repromotion during a peer's shutdown would need a wire-visible signal and is noted as a possible follow-up.

## Regression test — `shutdown_closes_superseded_survivors_remote_observes_disconnect`

- **Construction**: B dials A twice into the **same initiator family** (raw handshakes, both registered explicitly on B). Two findings from getting this deterministic: (1) cross-family tiebreaks are decided by per-connection key material (random), so only same-family generations give a deterministic outcome — the newer dial wins by generation, demoting the first to an **open** Superseded survivor on B; (2) B's NAT accept task awaits `handle_connection` (connection-lifetime monitor) inline, so it processes **one inbound at a time** — inbound-only constructions can never stack generations while the first lives, hence the explicit registrations. A holds the first connection (its accept task registered it, its accept loop spawned the reader).
- **Verified**: on clean `origin/master` (worktree, test transplanted) the test **FAILS at 17.8 s** — A stays connected past the 10 s post-shutdown deadline, exactly the issue's stale-remote shape; with the fix it **PASSES in ≈2.8 s** (survivor closed pre-drain, close flushed, A's reader exits, cleanup drops both structures).

## Gates

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` ✅; production panic-safety clippy ✅
- New test **5/5 in release** (`cargo test --release --lib`), ≈2.16 s each
- Unfiltered `cargo nextest run --workspace --all-features --no-fail-fast`: **3404 passed / 7 failed / 51 skipped**, every failure named and classified:
  - `interop_test::test_docker_config_exists`, `nat_docker_integration::tests::configured_docker_nat_assets_exist` — deterministic, fixtures removed in `46ae21df`, **fail on master too**.
  - `lifecycle_observability::lifecycle_transitions_emit_structured_tracing_fields` (verified 5/5 isolated in the #279 round), `lifecycle_active_close`, `simultaneous_connect_dedup::test_tiebreaker_deterministic`, `lifecycle_sender_stale`, `reconnect_reader_task::recv_after_reconnect` — the rotating load-flake family; each has been verified passing in isolation on both this tree and master in earlier rounds, and the same names fail in master baseline full-suite runs (e.g., 3399/5/53 on `527f6575`, 3402/8/51 on the #282 branch).
- CHANGELOG entry under `[Unreleased]`; test added to the `loopback-pair-heavyweights` nextest group; no version bump.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63458965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because an in-flight accepted handshake can register after the new close sweep and survive until socket release.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Late Connections Escape Shutdown** <a href="https://github.com/saorsa-labs/ant-quic/pull/285#discussion_r3997057689">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/nat_traversal_api.rs:8351-8363
An accepted handshake can finish after this lifecycle sweep because the accept worker checks `shutdown` only before waiting for a connection, not before registering it. The late connection misses both close passes. Shutdown can then clear its lifecycle entry and release the socket without allowing a CONNECTION_CLOSE frame to flush, leaving the remote peer connected until its idle timeout. Registrations must be rejected or immediately closed after shutdown starts.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Adds lifecycle-wide connection closure to `NatTraversalEndpoint::shutdown`.
- Adds a same-family replacement regression test that verifies the remote observes shutdown.
- Serializes the heavyweight regression test in nextest and documents the fix.
- The close sweep remains vulnerable to generations registered by already-running handshake tasks after shutdown begins.

<h3>Diagram</h3>

```mermaid
sequenceDiagram
    participant S as Shutdown task
    participant A as In-flight accept task
    participant L as Lifecycle registry
    participant E as QUIC endpoint
    S->>S: Set shutdown flag
    S->>L: Close currently tracked generations
    A->>A: Handshake completes
    A->>L: Register new generation without shutdown re-check
    S->>E: wait_idle
    E-->>S: Drain timeout
    S->>L: Clear lifecycle handles
    S->>E: Release socket
    Note over A,E: Late generation cannot flush a timely CONNECTION_CLOSE
```

<sub>Reviews (1) · Last reviewed commit: ["fix(shutdown): close superseded lifecycl..."](https://github.com/saorsa-labs/ant-quic/commit/8f8f333418502286603ff9a8d8098c30c5dc5529)</sub>

<!-- /greptile_comment -->