### PR TITLE
chore(release): 0.27.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.51] - 2026-09-12
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "ant-quic"
-version = "0.27.50"
+version = "0.27.51"
 dependencies = [
  "ant-quic-workspace-hack",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ant-quic"
-version = "0.27.50"
+version = "0.27.51"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Patch release: #279 (#278), #282 (#280), #285 (#283), #281 (tiebreaker liveness). Version bumped via scripts/bump-version.sh; CHANGELOG [Unreleased] cut to [0.27.51] - 2026-09-12. Tag v0.27.51 on the merge commit after CI is green; release.yml publishes to crates.io. Downstream: x0x pin bump for x0x#277 / x0x#510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012unbWRGbx4WqpWwGyobxx9

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63497498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The release metadata changes appear safe to merge.

<h3>Summary</h3>

- Bumps the crate version from 0.27.50 to 0.27.51 in the manifest and lockfile.
- Cuts the accumulated Fixed entries into a dated 0.27.51 changelog section.
- Keeps all release-consumed version references consistent.

<sub>Reviews (1) · Last reviewed commit: ["chore(release): 0.27.51"](https://github.com/saorsa-labs/ant-quic/commit/95525e1d954d76295533bb31299b3634eafaf284)</sub>

<!-- /greptile_comment -->