### PR TITLE
fix(shutdown): join accept workers, refuse late handshake registrations (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`shutdown()` now aborts and joins the accept workers and refuses late handshake registrations (#286, x0x#692).**
+  The connection accept workers were spawned with their join handles dropped, so `shutdown()` never waited
+  for them, and the registration path had no shutdown check: an inbound handshake completing after the #285
+  lifecycle sweep landed in both `connections` (drained only once, before the sweep) and
+  `connection_lifecycle`, was closed by nobody, and the remote — which registers its own side of the dial —
+  kept the peer "connected" until its idle timeout. Observed downstream as a stale `is_connected` roughly
+  1 run in 20 after `shutdown()` (x0x#692). `shutdown()` now keeps the workers' join handles, aborts and
+  joins them inside the bounded drain before the socket release, and the registration path refuses (and
+  closes) any late registration while the endpoint is shutting down. No wire change.
+
 ## [0.27.51] - 2026-09-12
 
 ### Fixed
@@ -180,10 +192,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a check-then-act that per-stream concurrency could race into double delivery.
   Cross-stream ordering was never guaranteed (each stream is one self-contained
   message); per-stream `data_tx` ordering is unchanged.
-
-## [Unreleased]
-
-### Fixed
 
 - **Stream-scoped read errors no longer kill the connection reader (#255 fix A).** A peer
   resetting one stream mid-message (the fork's Drop⇒RESET abandonment class, `0xA17C0244` —

--- a/src/nat_traversal_api.rs
+++ b/src/nat_traversal_api.rs
@@ -475,6 +475,10 @@ pub(crate) enum ConnectionRegistrationOutcome {
     Rejected {
         winner_generation: u64,
     },
+    /// #286: the endpoint is shutting down — the registration was refused
+    /// and the connection has been closed by the registrar. Nothing was
+    /// entered into either map.
+    Refused,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -621,6 +625,11 @@ pub struct NatTraversalEndpoint {
     shared_relay_endpoint: Arc<std::sync::Mutex<Option<InnerEndpoint>>>,
     /// Whether the shared relay endpoint already has an accept loop attached.
     relay_accept_loop_started: Arc<std::sync::atomic::AtomicBool>,
+    /// #286: join handles of the background accept workers (the connection
+    /// accept loops and the shared-relay accept loop). `shutdown` aborts and
+    /// joins them inside the bounded drain so no worker can register a
+    /// late-completing handshake after the lifecycle sweep.
+    accept_worker_handles: Arc<ParkingMutex<Vec<tokio::task::JoinHandle<()>>>>,
     /// MASQUE relay server - every node provides relay services (symmetric P2P)
     /// Per ADR-004: All nodes are equal and participate in relaying with resource budgets
     relay_server: Option<Arc<MasqueRelayServer>>,
@@ -1952,6 +1961,7 @@ impl NatTraversalEndpoint {
             relay_sessions: Arc::new(dashmap::DashMap::new()),
             shared_relay_endpoint: Arc::new(std::sync::Mutex::new(None)),
             relay_accept_loop_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            accept_worker_handles: Arc::new(ParkingMutex::new(Vec::new())),
             relay_server,
             successful_candidates: Arc::new(dashmap::DashMap::new()),
             transport_candidates: Arc::new(dashmap::DashMap::new()),
@@ -2143,7 +2153,7 @@ impl NatTraversalEndpoint {
             let incoming_notify_clone = endpoint.incoming_notify.clone();
             let pending_accepts_clone = endpoint.pending_accepts.clone();
 
-            tokio::spawn(async move {
+            let accept_worker_handle = tokio::spawn(async move {
                 Self::accept_connections(
                     endpoint_clone,
                     shutdown_clone,
@@ -2160,6 +2170,12 @@ impl NatTraversalEndpoint {
                 )
                 .await;
             });
+            // #286: keep the accept worker's handle so shutdown can abort and
+            // join it inside the bounded drain.
+            endpoint
+                .accept_worker_handles
+                .lock()
+                .push(accept_worker_handle);
 
             info!("Started accepting connections (symmetric P2P node)");
         }
@@ -2460,6 +2476,7 @@ impl NatTraversalEndpoint {
             relay_sessions: Arc::new(dashmap::DashMap::new()),
             shared_relay_endpoint: Arc::new(std::sync::Mutex::new(None)),
             relay_accept_loop_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            accept_worker_handles: Arc::new(ParkingMutex::new(Vec::new())),
             relay_server,
             successful_candidates: Arc::new(dashmap::DashMap::new()),
             transport_candidates: Arc::new(dashmap::DashMap::new()),
@@ -2651,7 +2668,7 @@ impl NatTraversalEndpoint {
             let incoming_notify_clone = endpoint.incoming_notify.clone();
             let pending_accepts_clone = endpoint.pending_accepts.clone();
 
-            tokio::spawn(async move {
+            let accept_worker_handle = tokio::spawn(async move {
                 Self::accept_connections(
                     endpoint_clone,
                     shutdown_clone,
@@ -2668,6 +2685,12 @@ impl NatTraversalEndpoint {
                 )
                 .await;
             });
+            // #286: keep the accept worker's handle so shutdown can abort and
+            // join it inside the bounded drain.
+            endpoint
+                .accept_worker_handles
+                .lock()
+                .push(accept_worker_handle);
 
             info!("Started accepting connections (symmetric P2P node)");
         }
@@ -2827,7 +2850,8 @@ impl NatTraversalEndpoint {
             let incoming_notify = self.incoming_notify.clone();
             let pending_accepts = self.pending_accepts.clone();
             let relay_event_tx = self.event_tx.clone();
-            tokio::spawn(async move {
+            let relay_shutdown = self.shutdown.clone();
+            let relay_worker_handle = tokio::spawn(async move {
                 loop {
                     match relay_endpoint.accept().await {
                         Some(incoming) => match incoming.await {
@@ -2858,6 +2882,7 @@ impl NatTraversalEndpoint {
                                     connection_lifecycle.as_ref(),
                                     next_connection_generation.as_ref(),
                                     emitted_events.as_ref(),
+                                    relay_shutdown.load(Ordering::Relaxed),
                                     peer_id,
                                     conn.clone(),
                                 );
@@ -2872,6 +2897,11 @@ impl NatTraversalEndpoint {
                                             "Rejected relayed connection for peer {:?}; live generation {} kept",
                                             peer_id, winner_generation
                                         );
+                                        continue;
+                                    }
+                                    ConnectionRegistrationOutcome::Refused => {
+                                        // Late registration during shutdown;
+                                        // the connection is already closed.
                                         continue;
                                     }
                                 };
@@ -2920,6 +2950,10 @@ impl NatTraversalEndpoint {
                     }
                 }
             });
+
+            // #286: keep the relay accept worker's handle so shutdown can
+            // abort and join it inside the bounded drain.
+            self.accept_worker_handles.lock().push(relay_worker_handle);
         }
 
         // Step 4: Store relay public address for re-advertisement to future peers
@@ -4545,6 +4579,7 @@ impl NatTraversalEndpoint {
         connection_lifecycle: &ParkingRwLock<HashMap<PeerId, Vec<TrackedConnection>>>,
         next_connection_generation: &AtomicU64,
         emitted_established_events: &dashmap::DashSet<PeerId>,
+        shutting_down: bool,
         connection: InnerConnection,
     ) -> Result<(PeerId, InnerConnection), NatTraversalError> {
         let peer_id = Self::derive_peer_id_from_connection(&connection).ok_or_else(|| {
@@ -4559,12 +4594,16 @@ impl NatTraversalEndpoint {
             connection_lifecycle,
             next_connection_generation,
             emitted_established_events,
+            shutting_down,
             peer_id,
             connection.clone(),
         );
 
         match outcome {
             ConnectionRegistrationOutcome::Live { .. } => Ok((peer_id, connection)),
+            ConnectionRegistrationOutcome::Refused => Err(NatTraversalError::NetworkError(
+                "endpoint is shutting down".to_string(),
+            )),
             ConnectionRegistrationOutcome::Rejected { .. } => {
                 let existing = connections
                     .get(&peer_id)
@@ -4701,6 +4740,7 @@ impl NatTraversalEndpoint {
                     let low_level_endpoint = endpoint.clone();
                     let envelope = envelope.clone();
                     let traversal_event_notify = self.traversal_event_notify.clone();
+                    let dial_shutdown = self.shutdown.clone();
                     let connect_timeout = Self::coordination_connect_timeout(&self.config);
 
                     tokio::spawn(async move {
@@ -4713,6 +4753,7 @@ impl NatTraversalEndpoint {
                                         connection_lifecycle.as_ref(),
                                         next_connection_generation.as_ref(),
                                         emitted_established_events.as_ref(),
+                                        dial_shutdown.load(Ordering::Relaxed),
                                         connection,
                                     ) {
                                         Ok(result) => result,
@@ -5363,7 +5404,7 @@ impl NatTraversalEndpoint {
         let incoming_notify_clone = self.incoming_notify.clone();
         let pending_accepts_clone = self.pending_accepts.clone();
 
-        tokio::spawn(async move {
+        let accept_worker_handle = tokio::spawn(async move {
             Self::accept_connections(
                 endpoint_clone,
                 shutdown_clone,
@@ -5380,6 +5421,9 @@ impl NatTraversalEndpoint {
             )
             .await;
         });
+        // #286: keep the accept worker's handle so shutdown can abort and
+        // join it inside the bounded drain.
+        self.accept_worker_handles.lock().push(accept_worker_handle);
 
         Ok(())
     }
@@ -5411,6 +5455,7 @@ impl NatTraversalEndpoint {
                     let traversal_event_notify = traversal_event_notify.clone();
                     let incoming_notify = incoming_notify.clone();
                     let pending_accepts = pending_accepts.clone();
+                    let shutdown = shutdown.clone();
                     tokio::spawn(async move {
                         match connecting.await {
                             Ok(connection) => {
@@ -5430,6 +5475,7 @@ impl NatTraversalEndpoint {
                                     connection_lifecycle.as_ref(),
                                     next_connection_generation.as_ref(),
                                     emitted_events.as_ref(),
+                                    shutdown.load(Ordering::Relaxed),
                                     peer_id,
                                     connection.clone(),
                                 );
@@ -5445,6 +5491,11 @@ impl NatTraversalEndpoint {
                                             "Rejected inbound connection for peer {:?}; live generation {} kept",
                                             peer_id, winner_generation
                                         );
+                                        return;
+                                    }
+                                    ConnectionRegistrationOutcome::Refused => {
+                                        // Late registration during shutdown;
+                                        // the connection is already closed.
                                         return;
                                     }
                                 };
@@ -6812,9 +6863,25 @@ impl NatTraversalEndpoint {
         connection_lifecycle: &ParkingRwLock<HashMap<PeerId, Vec<TrackedConnection>>>,
         next_connection_generation: &AtomicU64,
         emitted_established_events: &dashmap::DashSet<PeerId>,
+        shutting_down: bool,
         peer_id: PeerId,
         connection: InnerConnection,
     ) -> ConnectionRegistrationOutcome {
+        // #286: a handshake completing after the shutdown lifecycle sweep
+        // would land in both maps and never be closed (the canonical
+        // `connections` map is drained only once, before the sweep), leaving
+        // exactly one stale survivor the remote repromotes until its idle
+        // timeout. Refuse the late registration and close the connection.
+        if shutting_down {
+            debug!(
+                peer_id = ?peer_id,
+                "refusing late connection registration: endpoint is shutting down"
+            );
+            if connection.close_reason().is_none() {
+                connection.close(crate::VarInt::from_u32(0), b"Shutdown");
+            }
+            return ConnectionRegistrationOutcome::Refused;
+        }
         let generation = next_connection_generation.fetch_add(1, Ordering::Relaxed);
         let tracked = TrackedConnection {
             connection: connection.clone(),
@@ -7039,6 +7106,7 @@ impl NatTraversalEndpoint {
             self.connection_lifecycle.as_ref(),
             self.next_connection_generation.as_ref(),
             self.emitted_established_events.as_ref(),
+            self.shutdown.load(Ordering::Relaxed),
             peer_id,
             connection,
         ))
@@ -8494,6 +8562,34 @@ impl NatTraversalEndpoint {
             drop(lifecycle);
             if closed > 0 {
                 info!("shutdown: closed {closed} additional lifecycle-tracked connection(s)");
+            }
+        }
+
+        // #286: abort and join the accept workers BEFORE the bounded drain,
+        // so no worker can register a handshake that completes after the
+        // lifecycle sweep above (the flag is checked at registration, but the
+        // join also guarantees the worker is gone before the socket is
+        // released). Aborted mid-handshake dials are dropped by the endpoint
+        // driver, which closes them. The join is bounded by the same drain
+        // budget — no unbounded await.
+        {
+            let handles = {
+                let mut workers = self.accept_worker_handles.lock();
+                std::mem::take(&mut *workers)
+            };
+            if !handles.is_empty() {
+                debug!(
+                    "shutdown: aborting and joining {} accept worker(s)",
+                    handles.len()
+                );
+                for handle in &handles {
+                    handle.abort();
+                }
+                let _ = tokio::time::timeout(
+                    SHUTDOWN_DRAIN_TIMEOUT,
+                    futures_util::future::join_all(handles),
+                )
+                .await;
             }
         }
 
@@ -10139,6 +10235,7 @@ impl NatTraversalEndpoint {
                     let low_level_endpoint = endpoint.clone();
                     let target_peer_id = peer_id;
                     let external_addr = our_external_address;
+                    let dial_shutdown = self.shutdown.clone();
                     let connect_timeout = Self::coordination_connect_timeout(&self.config);
 
                     tokio::spawn(async move {
@@ -10154,6 +10251,7 @@ impl NatTraversalEndpoint {
                                         connection_lifecycle.as_ref(),
                                         next_connection_generation.as_ref(),
                                         emitted_established_events.as_ref(),
+                                        dial_shutdown.load(Ordering::Relaxed),
                                         connection,
                                     ) {
                                         Ok(result) => result,

--- a/src/p2p_endpoint.rs
+++ b/src/p2p_endpoint.rs
@@ -16079,6 +16079,141 @@ mod tests {
         a.shutdown().await;
     }
 
+    /// #286: an inbound handshake completing DURING `shutdown()` — after the
+    /// #285 lifecycle sweep — must not leave an entry in either map. The
+    /// accept worker is spawned with its join handle dropped, so `shutdown()`
+    /// never waited for it and the registration path had no shutdown check:
+    /// the late entry landed in `connections` (drained only once, before the
+    /// sweep) and `connection_lifecycle`, was closed by nobody, and the
+    /// remote — which registers its own side of the dial, as the real dialer
+    /// flow does — kept the peer "connected" until its idle timeout: the x0x
+    /// 1-in-20 stale `is_connected` after `shutdown()` (x0x#692).
+    ///
+    /// Modelled on the #285 test's harness. The late dial is started first
+    /// (its ClientHello is on the wire), then shutdown begins, so the
+    /// handshake completes squarely after the flag is set and the lifecycle
+    /// sweep has run. Asserts (a) no entry survives in either map after
+    /// shutdown completes, and (b) the remote observes the disconnect within
+    /// the drain window rather than at the idle timeout.
+    // Requires the network-discovery socket path: the fallback
+    // `create_dual_stack_sockets` (no-default-features) cannot accept loopback
+    // connections (see issue tracked separately).
+    #[cfg(all(test, feature = "network-discovery"))]
+    #[tokio::test]
+    async fn shutdown_during_inbound_handshake_leaves_no_stale_entry() {
+        async fn build_endpoint() -> P2pEndpoint {
+            P2pEndpoint::new(
+                crate::unified_config::P2pConfig::builder()
+                    .bind_addr(SocketAddr::new(
+                        IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                        0,
+                    ))
+                    .port_mapping_enabled(false)
+                    .build()
+                    .expect("test config"),
+            )
+            .await
+            .expect("endpoint binds")
+        }
+
+        let a = build_endpoint().await;
+        let b = build_endpoint().await;
+        let a_for_accept = a.clone();
+        tokio::spawn(async move { while a_for_accept.accept().await.is_some() {} });
+        let b_addr = localhost_addr(b.local_addr().expect("b bound"));
+        let a_addr = localhost_addr(a.local_addr().expect("a bound"));
+        let b_id = b.peer_id();
+        let a_id = a.peer_id();
+
+        // Family 1 (B → A dial, registered on B; A adopts it through its
+        // accept path): A holds a live connection to B whose fate the test
+        // observes, and B's accept worker is running.
+        let c0 = tokio::time::timeout(Duration::from_secs(10), b.attempt_direct_handshake(a_addr))
+            .await
+            .expect("c0 handshake timeout")
+            .expect("c0 handshake");
+        b.inner
+            .add_connection_with_outcome(a_id, c0)
+            .expect("register c0 on B");
+
+        // Precondition: A is connected to B through family 1.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !a.is_connected(&b_id).await {
+            assert!(
+                Instant::now() < deadline,
+                "precondition: A must be connected to B"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        // Start the late A → B dial FIRST (ClientHello in flight), then begin
+        // B's shutdown: the handshake completes after the flag is set and the
+        // lifecycle sweep has run — the #286 window.
+        let late_dial = {
+            let a = a.clone();
+            tokio::spawn(async move { a.attempt_direct_handshake(b_addr).await })
+        };
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let b_shutdown = {
+            let b = b.clone();
+            tokio::spawn(async move { b.inner.shutdown().await })
+        };
+
+        // The dial's fate depends on where the fix cuts it: refused (the
+        // handshake completes and the registration is refused — B closes the
+        // connection) or aborted (the worker dies mid-handshake — the
+        // endpoint abandons the dial). Both close the transport. Register
+        // A's side only when the handshake completed, mirroring the real
+        // dialer flow that registers its own side.
+        let late = tokio::time::timeout(Duration::from_secs(10), late_dial)
+            .await
+            .expect("late dial task")
+            .expect("late dial join");
+        if let Ok(late_conn) = late {
+            a.inner
+                .add_connection_with_outcome(b_id, late_conn)
+                .expect("register A's side of the late dial");
+        }
+
+        // (b) A must observe the disconnect within the drain window (the
+        // bounded drain is 5 s; the QUIC idle timeout is far longer — on the
+        // unfixed code the never-closed late survivor keeps A connected
+        // until it).
+        let observe_deadline = Instant::now() + Duration::from_secs(15);
+        while a.is_connected(&b_id).await {
+            assert!(
+                Instant::now() < observe_deadline,
+                "A must observe B's shutdown within the drain window — a                  late-registered handshake survived the shutdown"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        // Shutdown has completed (A already observed the disconnects).
+        b_shutdown
+            .await
+            .expect("shutdown task")
+            .expect("inner shutdown");
+
+        // (a) No entry survives in either map: the connections map is empty,
+        // and no lifecycle generation remains promotable.
+        assert!(
+            b.inner
+                .list_connections()
+                .expect("list_connections")
+                .is_empty(),
+            "no connection may remain in the winner map after shutdown"
+        );
+        assert!(
+            b.inner
+                .get_connection(&a_id)
+                .expect("get_connection")
+                .is_none(),
+            "no lifecycle generation may remain promotable after shutdown"
+        );
+
+        a.shutdown().await;
+    }
+
     /// #280 (a): single stream owner. An application stream opened by the
     /// dialer must be delivered to the acceptor's app-stream queue EXACTLY
     /// once, with a relay server configured (the default), and exactly one


### PR DESCRIPTION
Closes #286 · unblocks x0x#692

## Mechanism (observed downstream: x0x sees a stale `is_connected` ~1 run in 20 after `shutdown()`, with its #283-workaround retirement blocked)

The accept workers were spawned with their `JoinHandle` dropped (`nat_traversal_api.rs` constructor accept loops, `start_listening`'s loop, and the shared-relay accept loop), so `shutdown()` never waited for them, and the registration path (`register_connection_lifecycle_parts`) had no shutdown check. An inbound handshake completing *after* the #285 lifecycle sweep landed in both `connections` — drained only once, **before** the sweep — and `connection_lifecycle`, was closed by nobody, and the remote (which registers its own side of the dial, as the real dialer flow does) kept the peer "connected" until its idle timeout.

## Fix — part → file:line (post-change numbering)

1. **Keep the worker handles** → `src/nat_traversal_api.rs:632` field `accept_worker_handles`; pushes at the four spawn sites (`~2176`, `~2691` constructor loops, `~5419` `start_listening`, `~2956` shared-relay loop).
2. **Flag before the sweep** → the existing `self.shutdown` flag is stored first in `shutdown()` (`~8469`), i.e. already before the #285 lifecycle sweep (`~8497`) — no new flag needed; what was missing was (3) and (4) making it authoritative.
3. **Refuse late registrations** → `register_connection_lifecycle_parts` (`~6835`): when the flag is set, refuse (new `ConnectionRegistrationOutcome::Refused`), **close the connection** rather than leaking it, and enter neither map. Threaded through: the main accept loop (`~5510`, `Refused` arm `~5543`), the shared-relay loop (`~2959`, arm `~2893`), `materialize_authenticated_connection` (`~4608`, coordinator dials, both callers `~4755`/`~10251`), and `register_connection_lifecycle` (`~7140`, covers the p2p `add_connection_with_outcome` path).
4. **Abort + join before socket release, inside the bounded drain** → `shutdown()` (`~8547`): aborts every accept worker and joins them under the existing `SHUTDOWN_DRAIN_TIMEOUT` — no unbounded await — before `release_socket_for_shutdown`. Aborted mid-handshake dials are abandoned and closed by the endpoint driver; dials that complete are refused by (3) and closed explicitly.

## Regression test — `shutdown_during_inbound_handshake_leaves_no_stale_entry` (modelled on the #285 harness)

The late A→B dial is started **first** (its ClientHello on the wire), then B's `inner.shutdown()` begins — the handshake completes squarely after the flag is set and the lifecycle sweep has run — and A registers its side of the dial, mirroring the real dialer flow. Asserts (a) no entry survives in either map after shutdown (`list_connections().is_empty()` + `get_connection(...).is_none()`), and (b) the remote observes the disconnect within the drain window rather than at the idle timeout. Both outcomes of the fixed race (refused handshake / aborted worker) close the transport, so the test accepts either.

**Evidence, both directions:**
- **Reverted fix ⇒ FAIL** (`7.4 s`): `"no connection may remain in the winner map after shutdown"` — the late registration survives in `connections`, exactly the filed mechanism (refusal and abort+join both disabled; the shutdown's `wait_idle` also burned its 5 s timeout waiting on the never-closed survivor).
- **Fix in place ⇒ PASS** (`0.89 s` debug).
- **20× in release: 20 PASS / 0 FAIL** (`cargo test --release --lib -- shutdown_during_inbound_handshake_leaves_no_stale_entry`, ≈0.4 s each) — the downstream rate is ~1/20, so 20 clean runs is meaningful coverage.

## Gates (commands + results)

- `cargo fmt --all -- --check` → exit 0 ✅
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` → exit 0 ✅
- `cargo clippy --workspace --all-features --lib --bins -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used` → exit 0 ✅ (no unwrap/expect/panic in the production diff)
- `cargo nextest run --workspace --all-features --no-fail-fast` → **3420 run: 3410 passed / 10 failed / 51 skipped**. Every failure, and whether it also fails on origin/master:
  - `interop_test::test_docker_config_exists`, `nat_docker_integration::tests::configured_docker_nat_assets_exist` — deterministic; fixtures removed in `46ae21df`; **fail on master**.
  - `lifecycle_observability::lifecycle_transitions_emit_structured_tracing_fields`, `lifecycle_active_close::superseded_connection_surfaces_close_reason_quickly`, `regression_166_mesh_churn::mesh_churn_preserves_every_acked_stream`, `simultaneous_connect_dedup::test_tiebreaker_deterministic`, `lifecycle_sender_stale::stale_sender_connection_fails_after_supersede`, `reconnect_reader_task::recv_after_reconnect`, `b_events_parity::peer_lifecycle_subscriptions_track_establish_replace_and_close` — the known rotating load-class lifecycle family; the same names fail across master baseline full-suite runs on this machine (documented in the #279/#281/#282/#283 rounds; `test_tiebreaker_deterministic` is additionally flaky **in isolation** on both trees — branch 2/5, master 0/5).
  - `cli_connect_smoke::cli_connect_peer_id_smoke` — failed **only while heavy gate builds ran concurrently** (its 5 s startup deadline for the `local_identity` event was exceeded); passes **2/2 in isolation on this branch** and 1/1 on a clean master worktree; the binary itself starts and emits the event normally. Load-sensitive, not a regression.
- CHANGELOG entry under `[Unreleased]`; no version bump; test added to the `loopback-pair-heavyweights` nextest group.

Unblocks x0x#692 (its #283 workaround can retire once this ships in a release).


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63584825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

This PR is not yet safe to merge because an in-flight detached handshake or bypassing dial-completion path can still insert a connection after the shutdown sweep.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Shutdown Still Allows Insertions** <a href="https://github.com/saorsa-labs/ant-quic/pull/288/files#diff-671566e7485f5fbab736e65da8109a530349c1716e2d279004f94c1606748bb2R6875">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/nat_traversal_api.rs:6875
An accepted handshake runs in a detached child task, but shutdown only joins the parent accept worker. The child checks a caller-provided shutdown value before taking the lifecycle lock, so it can read `false`, wait while shutdown performs its one-time sweep, and then add a live connection to both maps after the sweep. The hole-punch and validated-candidate completion paths also insert directly into `connections` without checking shutdown. These in-flight operations can therefore leave a live entry after `shutdown()` returns, preserving the stale-connected behavior this change is intended to fix.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Tracks, aborts, and joins main and shared-relay accept workers before socket release.
- Adds a refused registration outcome that closes late connections.
- Threads shutdown state through primary lifecycle registration paths.
- Adds coverage for an inbound handshake racing with shutdown.
- The remaining unsynchronized and bypassing insertion paths mean the shutdown invariant is not yet fully enforced.

<h3>Diagram</h3>

```mermaid
sequenceDiagram
    participant H as Detached handshake task
    participant S as shutdown()
    participant L as Lifecycle lock/maps
    H->>H: "load shutdown = false"
    S->>S: "store shutdown = true"
    S->>L: acquire lock and sweep connections
    S->>L: release lock
    H->>L: acquire lock and register Live entry
    S->>S: join parent accept worker
    Note over H,S: Child handshake task is not joined
    S-->>S: return with late entry possible
```

<sub>Reviews (1) · Last reviewed commit: ["fix(shutdown): join accept workers, refu..."](https://github.com/saorsa-labs/ant-quic/commit/ecd1985a501955940fd6ce6923071152dcf128ee)</sub>

<!-- /greptile_comment -->